### PR TITLE
registry: add delete button to repository list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+bun dev          # start dev server
+bun build        # production build
+bun preview      # preview production build
+bun check        # type-check via svelte-check + jsconfig.json
+bun check:watch  # type-check in watch mode
+bun lint         # ESLint
+bun test         # Playwright e2e tests
+```
+
+For deployment:
+```bash
+make build   # build Docker image and push to registry.deploys.app
+make deploy  # build and deploy to deploys-app project
+```
+
+## Architecture
+
+This is a **SvelteKit 2** console for deploys.app, a deployment platform. It uses **Svelte 5** runes (`$state`, `$derived`, `$props`) and is deployed on Cloudflare (default) or Node.js via env-controlled adapter selection.
+
+### Route layout
+
+```
+src/routes/
+  auth/                        # sign-in / callback / sign-out (unauthenticated)
+  (auth)/                      # layout group — redirects to /auth/signin if no token
+    (project)/                 # layout group — requires ?project= param
+      deployment/ disk/ domain/ dropbox/ email/
+      pull-secret/ registry/ role/ route/
+      service-account/ workload-identity/
+    billing/
+    project/                   # project selection & creation
+  api/[fn]/+server.js          # server-side API proxy (adds auth header, forwards to API_ENDPOINT)
+```
+
+The `(auth)` and `(project)` parentheses are SvelteKit route groups — they share layouts without affecting the URL.
+
+### API layer
+
+All API calls go through a single proxy: `POST /api/{fnName}`.
+
+- **Client side**: `src/lib/api/index.js` — `api.invoke(fnName, args, fetch)` posts to the local proxy.
+- **Server side**: `src/routes/api/[fn]/+server.js` — reads token from cookies, forwards to `env.API_ENDPOINT` (https://api.deploys.app) with `Authorization: bearer {token}`.
+- **Cache invalidation**: `api.invalidate(fn)` / `api.intervalInvalidate(cb, interval)` for polling.
+- **Error handling**: `api: unauthorized` → reloads page; `api: forbidden` → `error.forbidden`; `api: validate error` → `error.validate[]`; `api: * not found` → `error.notFound`.
+
+All API types are defined in `src/types/api.d.ts` using TypeScript namespaces (`Api.Profile`, `Api.Response<T>`, `Api.Deployment`, etc.).
+
+### State management
+
+No global store. Data flows via SvelteKit's `load()` functions:
+- `+layout.server.js` for server-loaded data (auth token, user profile)
+- `+page.js` / `+layout.js` for client-side data fetching
+- Svelte 5 runes (`$state`, `$derived`) for component-local state
+
+### Auth
+
+OAuth2 against `auth.deploys.app`. Token stored in httpOnly cookies. `src/hooks.server.js` injects the token into every `/api/*` request and persists the selected project + theme in cookies.
+
+### Styling
+
+Uses the **nomimono-css** design system (classes like `nm-panel`, `nm-button`, `nm-field`). SCSS files live in `src/style/`, imported via the `$style` alias. Theme (dark/light) is stored in a cookie and applied via `data-theme` attribute.
+
+### Modals
+
+Centralized in `src/lib/modal/index.js` — wraps SweetAlert2. Use this for confirmations and form dialogs rather than inline alert/confirm.
+
+### Language note
+
+The codebase uses **JavaScript with JSDoc** type annotations (not TypeScript `.ts` files), checked via `svelte-check` against `jsconfig.json`. Keep new files in `.js`/`.svelte` with JSDoc types.

--- a/src/routes/(auth)/(project)/registry/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/+page.svelte
@@ -31,11 +31,11 @@
 <div class="nm-panel is-level-300">
 	<p>registry.deploys.app/{project}/{'{repository}'}:{'{tag}'}</p>
 	<div class="nm-table-container _mgt-6">
-		<table class="nm-table">
+		<table class="nm-table is-variant-compact">
 			<thead>
 				<tr>
 					<th>Repository</th>
-					<th></th>
+					<th class="is-collapse is-align-right"></th>
 				</tr>
 			</thead>
 			<tbody>
@@ -47,10 +47,9 @@
 								{repo.name}
 							</a>
 						</td>
-						<td class="_ta-r">
-							<button class="nm-button is-variant-negative is-size-sm" type="button"
-								onclick={() => deleteRepository(repo.name)}>
-								Delete
+						<td>
+							<button class="icon-button" aria-label="Remove" onclick={() => deleteRepository(repo.name)}>
+								<i class="fa-solid fa-trash-alt"></i>
 							</button>
 						</td>
 					</tr>

--- a/src/routes/(auth)/(project)/registry/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/+page.svelte
@@ -1,12 +1,29 @@
 <script>
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
 
 	const { data } = $props()
 
 	const project = $derived(data.project)
 	const repositories = $derived(data.repositories)
 	const error = $derived(data.error)
+
+	function deleteRepository (name) {
+		modal.confirm({
+			title: `Delete "${name}" ?`,
+			yes: 'Delete',
+			callback: async () => {
+				const resp = await api.invoke('registry/delete', { project, repository: name }, fetch)
+				if (!resp.ok) {
+					modal.error({ error: resp.error })
+					return
+				}
+				await api.invalidate('registry/list')
+			}
+		})
+	}
 </script>
 
 <h6>Registry (Alpha)</h6>
@@ -18,6 +35,7 @@
 			<thead>
 				<tr>
 					<th>Repository</th>
+					<th></th>
 				</tr>
 			</thead>
 			<tbody>
@@ -29,10 +47,16 @@
 								{repo.name}
 							</a>
 						</td>
+						<td class="_ta-r">
+							<button class="nm-button is-variant-negative is-size-sm" type="button"
+								onclick={() => deleteRepository(repo.name)}>
+								Delete
+							</button>
+						</td>
 					</tr>
 				{/each}
-				<NoDataRow span={1} list={repositories} />
-				<ErrorRow span={1} {error} />
+				<NoDataRow span={2} list={repositories} />
+				<ErrorRow span={2} {error} />
 			</tbody>
 		</table>
 	</div>


### PR DESCRIPTION
## Summary

- Adds a **Delete** button to each row in the registry repository list page
- Clicking the button shows a confirmation modal before deleting
- On confirmation, calls `registry/delete` API and invalidates the list to refresh the UI
- Error from the API is shown via the error modal

## Changes

- `src/routes/(auth)/(project)/registry/+page.svelte` — added delete button, confirmation modal logic, and updated `NoDataRow`/`ErrorRow` span from 1→2 for the new column

## Reviewer notes

The delete API (`POST /api/registry/delete`) accepts `{ project, repository }` and removes all GCS objects and DB records for that repository. The confirmation modal uses the existing `modal.confirm` pattern consistent with other pages (e.g. pull-secret detail).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)