### PR TITLE
registry: promote to production, add storage usage and untag

### DIFF
--- a/src/routes/(auth)/(project)/registry/+page.js
+++ b/src/routes/(auth)/(project)/registry/+page.js
@@ -3,10 +3,15 @@ import api from '$lib/api'
 export async function load ({ parent, fetch }) {
 	const { project } = await parent()
 
-	/** @type {Api.Response<Api.List<Api.Repository>>} */
-	const res = await api.invoke('registry/list', { project }, fetch)
+	const [res, storageRes] = await Promise.all([
+		/** @type {Promise<Api.Response<Api.List<Api.Repository>>>} */
+		api.invoke('registry/list', { project }, fetch),
+		/** @type {Promise<Api.Response<Api.ProjectStorage>>} */
+		api.invoke('registry/getProjectStorage', { project }, fetch)
+	])
 	return {
 		repositories: res.result?.items ?? [],
-		error: res.error
+		error: res.error,
+		storage: storageRes.result ?? null
 	}
 }

--- a/src/routes/(auth)/(project)/registry/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/+page.svelte
@@ -1,6 +1,7 @@
 <script>
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import * as format from '$lib/format'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 
@@ -9,6 +10,7 @@
 	const project = $derived(data.project)
 	const repositories = $derived(data.repositories)
 	const error = $derived(data.error)
+	const storage = $derived(data.storage)
 
 	function deleteRepository (name) {
 		modal.confirm({
@@ -26,10 +28,13 @@
 	}
 </script>
 
-<h6>Registry (Alpha)</h6>
+<h6>Registry</h6>
 <br>
 <div class="nm-panel is-level-300">
 	<p>registry.deploys.app/{project}/{'{repository}'}:{'{tag}'}</p>
+	{#if storage !== null}
+		<p class="_mgt-4">Total Storage: <strong>{format.storage(storage.size)}</strong></p>
+	{/if}
 	<div class="nm-table-container _mgt-6">
 		<table class="nm-table is-variant-compact">
 			<thead>

--- a/src/routes/(auth)/(project)/registry/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/detail/+page.svelte
@@ -4,6 +4,8 @@
 	import ClipboardJS from 'clipboard'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
 
 	const { data } = $props()
 
@@ -18,6 +20,21 @@
 			copyList.destroy()
 		}
 	})
+
+	function untagTag (tag) {
+		modal.confirm({
+			title: `Untag "${tag}" ?`,
+			yes: 'Untag',
+			callback: async () => {
+				const resp = await api.invoke('registry/untag', { project, repository: data.id, tag }, fetch)
+				if (!resp.ok) {
+					modal.error({ error: resp.error })
+					return
+				}
+				await api.invalidate('registry/getTags')
+			}
+		})
+	}
 </script>
 
 <div class="nm-breadcrumb">
@@ -47,6 +64,7 @@
 				<th>Tag</th>
 				<th>Digest</th>
 				<th>Created At</th>
+				<th class="is-collapse"></th>
 			</tr>
 			</thead>
 			<tbody>
@@ -65,10 +83,15 @@
 							</span>
 						</td>
 						<td>{format.datetime(tag.createdAt)}</td>
+						<td>
+							<button class="icon-button" aria-label="Untag" onclick={() => untagTag(tag.tag)}>
+								<i class="fa-solid fa-tag-slash"></i>
+							</button>
+						</td>
 					</tr>
 				{/each}
-				<NoDataRow span={3} list={tags} />
-				<ErrorRow span={3} {error} />
+				<NoDataRow span={4} list={tags} />
+				<ErrorRow span={4} {error} />
 			</tbody>
 		</table>
 	</div>

--- a/src/routes/(auth)/(project)/registry/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/detail/+page.svelte
@@ -85,7 +85,7 @@
 						<td>{format.datetime(tag.createdAt)}</td>
 						<td>
 							<button class="icon-button" aria-label="Untag" onclick={() => untagTag(tag.tag)}>
-								<i class="fa-solid fa-tag-slash"></i>
+								<i class="fa-solid fa-trash-alt"></i>
 							</button>
 						</td>
 					</tr>

--- a/src/routes/(auth)/Sidebar.svelte
+++ b/src/routes/(auth)/Sidebar.svelte
@@ -89,7 +89,7 @@
 		},
 		{
 			id: 'registry',
-			title: 'Registry (Alpha)',
+			title: 'Registry',
 			icon: 'fa-warehouse-full',
 			link: '/registry'
 		}

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -316,7 +316,13 @@ declare namespace Api {
 
     export type Repository = {
         name: string
+        size: number
         createdAt: string
+    }
+
+    export type ProjectStorage = {
+        size: number
+        updatedAt?: string
     }
 
     export type RepositoryTag = {


### PR DESCRIPTION
## Changes

- **Remove Alpha label** — Registry is no longer marked as Alpha in the sidebar
- **Project storage usage** — Registry list page now fetches `registry/getProjectStorage` and displays total storage above the repository table
- **Untag button** — Repository detail page has a new untag button (rightmost column) for each tag row, calling `registry/untag` with a confirmation modal
- **Type fixes** — `Repository` type now includes the `size` field; new `ProjectStorage` type added to `api.d.ts`