### PR TITLE
feat: surface deployment TTL in console

### DIFF
--- a/src/lib/format/index.js
+++ b/src/lib/format/index.js
@@ -94,3 +94,34 @@ export function deploymentType (t) {
 export function shortDigest (s) {
 	return s.replace(/^sha256:/, '').slice(0, 12)
 }
+
+/**
+ * @param {number} seconds
+ * @returns {string}
+ */
+export function duration (seconds) {
+	if (!seconds || seconds <= 0) {
+		return ''
+	}
+	const d = Math.floor(seconds / 86400)
+	const h = Math.floor((seconds % 86400) / 3600)
+	const m = Math.floor((seconds % 3600) / 60)
+	const s = Math.floor(seconds % 60)
+	const parts = []
+	if (d) parts.push(`${d}d`)
+	if (h) parts.push(`${h}h`)
+	if (m) parts.push(`${m}m`)
+	if (s && !d && !h) parts.push(`${s}s`)
+	return parts.join(' ') || '0s'
+}
+
+/**
+ * @param {number} ttlSeconds
+ * @returns {string}
+ */
+export function ttlExpireAt (ttlSeconds) {
+	if (!ttlSeconds || ttlSeconds <= 0) {
+		return ''
+	}
+	return dayjs().add(ttlSeconds, 'second').format('YYYY-MM-DD HH:mm:ss')
+}

--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -195,6 +195,16 @@
 				<td>Sidecars</td>
 				<td>{deployment.sidecars?.length || 0}</td>
 			</tr>
+			{#if deployment.ttl > 0}
+				<tr>
+					<td>Auto-delete</td>
+					<td>
+						<i class="fa-regular fa-clock _mgr-5 _cl-warning"></i>
+						{format.ttlExpireAt(deployment.ttl)}
+						<span class="_cl-light _mgl-3">(in {format.duration(deployment.ttl)})</span>
+					</td>
+				</tr>
+			{/if}
 			<tr>
 				<td>Deployed At</td>
 				<td>{format.datetime(deployment.createdAt)}</td>

--- a/src/routes/(auth)/(project)/deployment/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/+page.svelte
@@ -41,6 +41,10 @@
 					<tr>
 						<td>
 							<DeploymentStatusIcon action={it.action} status={it.status} url={it.statusUrl} type={it.type} />
+							{#if it.ttl > 0}
+								<i class="fa-regular fa-clock _mgr-5 _cl-warning"
+									title={`Auto-delete at ${format.ttlExpireAt(it.ttl)} (in ${format.duration(it.ttl)})`}></i>
+							{/if}
 							<a class="nm-link" href={`/deployment/metrics?project=${project}&location=${it.location}&name=${it.name}`}>
 								{it.name}
 							</a>

--- a/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
@@ -73,7 +73,10 @@
 				port: null,
 				credentials: ''
 			}
-		}
+		},
+		ttlValue: 0,
+		// unit in seconds; '0' means no auto-delete
+		ttlUnit: '0'
 	})
 	if (deployment) {
 		form.location = deployment.location
@@ -115,6 +118,18 @@
 					credentials: ''
 				}
 			}
+		if (deployment.ttl > 0) {
+			if (deployment.ttl % 86400 === 0) {
+				form.ttlUnit = '86400'
+				form.ttlValue = deployment.ttl / 86400
+			} else if (deployment.ttl % 3600 === 0) {
+				form.ttlUnit = '3600'
+				form.ttlValue = deployment.ttl / 3600
+			} else {
+				form.ttlUnit = '60'
+				form.ttlValue = Math.max(1, Math.round(deployment.ttl / 60))
+			}
+		}
 	}
 
 	const selectedLocation = $derived(locations.find((x) => x.id === form.location))
@@ -232,13 +247,16 @@
 
 		saving = true
 		try {
+			const unit = parseInt(form.ttlUnit) || 0
+			const ttlSeconds = unit > 0 ? Math.max(0, Math.floor(Number(form.ttlValue) || 0)) * unit : 0
 			const resp = await api.invoke('deployment.deploy', {
 				project,
 				...form,
 				protocol: form.type === 'WebService' ? form.protocol : '',
 				env: form.env.reduce((p, x) => { p[x.k] = x.v; return p }, {}),
 				mountData: form.mountData.reduce((p, x) => { p[x.k] = x.v; return p }, {}),
-				sidecars: convertSidecar()
+				sidecars: convertSidecar(),
+				ttl: ttlSeconds
 			}, fetch)
 			if (!resp.ok) {
 				modal.error({ error: resp.error })
@@ -518,6 +536,37 @@
 				{/if}
 			</div>
 		{/if}
+
+		<br>
+		<hr>
+		<br>
+
+		<h6><strong>Auto-delete (TTL)</strong></h6>
+		<div class="lo-6 _g-6">
+			<div class="nm-field">
+				<label for="input-ttl_unit">Unit</label>
+				<div class="nm-select">
+					<select id="input-ttl_unit" bind:value={form.ttlUnit}>
+						<option value="0">No auto-delete</option>
+						<option value="60">Minutes</option>
+						<option value="3600">Hours</option>
+						<option value="86400">Days</option>
+					</select>
+				</div>
+			</div>
+
+			{#if form.ttlUnit !== '0'}
+				<div class="nm-field">
+					<label for="input-ttl_value">Duration</label>
+					<div class="nm-input">
+						<input id="input-ttl_value" type="number" min="1" bind:value={form.ttlValue}>
+					</div>
+				</div>
+			{/if}
+		</div>
+		<small class="helper">
+			Deployment will be automatically deleted after this duration. Routes cannot be set on auto-delete deployments.
+		</small>
 
 		{#if ['WebService', 'Worker', 'InternalTCPService'].includes(form.type)}
 			<div>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -298,6 +298,7 @@ declare namespace Api {
         createdAt: string
         createdBy: string
         successAt: string
+        ttl: number
     }
 
     export type ServiceAccount = {


### PR DESCRIPTION
## Summary
- Adds an **Auto-delete (TTL)** section to the deploy form with a unit selector (minutes / hours / days) and a duration input. When redeploying a TTL deployment, the form auto-picks the cleanest unit from the deployment's remaining TTL.
- Adds a clock icon before the deployment name on the list page when the deployment has a TTL set; the icon's `title` tooltip shows the expire date and remaining duration.
- Adds an **Auto-delete** row to the deployment detail page showing both the expire date and the remaining time.
- Adds the `ttl` field to `Api.Deployment` and two format helpers: `duration(seconds)` (e.g. `2d 3h`) and `ttlExpireAt(ttlSeconds)` (formats `now + ttl` as a datetime).

## Notes for reviewer
- The API returns `ttl` as **remaining seconds**, not the originally-set duration. When redeploying without touching the TTL field, the new TTL is set to whatever remained at form-load time. If you want "remember original duration" semantics, that requires an API-side change to return both remaining and original.
- Checked `dayjs/plugin/duration`: `humanize()` is too coarse (`"2 days"` for 2d3h) and `format()` always renders zero tokens, so a custom `duration()` was kept.

## Test plan
- [ ] Create a deployment with no TTL — verify no clock icon shows on the list and no Auto-delete row on the detail page.
- [ ] Create a deployment with a TTL (e.g. 1 day) — verify the icon appears on the list with a tooltip, the detail page shows the Auto-delete row, and the deploy form repopulates with `1 / Days` when reopened.
- [ ] Set the TTL field back to `No auto-delete` and redeploy — verify the TTL is cleared.
- [ ] `bun check` and `bun lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)