### PR TITLE
docs/style: improve copy quality across the console and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,36 @@
-# Console
+# deploys.app Console
 
-Web console for manage resources on deploys.app.
+Web console for managing resources on deploys.app.
 
 ## Developing
 
 Install dependencies with `bun install`.
 
-Start development server:
+Start the development server:
 
 ```bash
-bun -b run dev
+bun dev
 
 # or start the server and open the app in a new browser tab
-bun -b run dev --open
+bun dev --open
 ```
 
 ## Building
 
-To create a production version:
+To create a production build:
 
 ```bash
-bun -b run build
+bun build
+```
+
+Preview the production build:
+
+```bash
+bun preview
 ```
 
 ## License
 
 MIT
 
-This project uses font-awesome pro, you need font-awesome pro license to editing source code.
+This project uses Font Awesome Pro. A Font Awesome Pro license is required to edit the source code.

--- a/src/lib/modal/index.js
+++ b/src/lib/modal/index.js
@@ -15,7 +15,7 @@ import 'sweetalert2/dist/sweetalert2.min.css'
  */
 export async function confirm ({ title, html, yes, callback }) {
 	const result = await Swal.fire({
-		title: 'Are you sure?' ,
+		title: 'Are you sure?',
 		text: title,
 		html,
 		icon: 'warning',

--- a/src/lib/modal/index.js
+++ b/src/lib/modal/index.js
@@ -15,7 +15,7 @@ import 'sweetalert2/dist/sweetalert2.min.css'
  */
 export async function confirm ({ title, html, yes, callback }) {
 	const result = await Swal.fire({
-		title: 'Are you sure ?',
+		title: 'Are you sure?' ,
 		text: title,
 		html,
 		icon: 'warning',

--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -25,7 +25,7 @@
 
 	function deleteItem () {
 		modal.confirm({
-			title: `Delete "${deployment.name}" ?`,
+			title: `Delete "${deployment.name}"?`,
 			yes: 'Delete',
 			callback: async () => {
 				const resp = await api.invoke('deployment.delete', {
@@ -43,7 +43,7 @@
 	}
 </script>
 
-<h6><strong>Deployment details</strong></h6>
+<h6><strong>Deployment Details</strong></h6>
 <div class="nm-table-container">
 	<table class="nm-table is-variant-compact" style="--table-data-border-color: none">
 		<tbody>
@@ -227,7 +227,7 @@
 	</div>
 </div>
 
-<h6><strong>Environment variables</strong></h6>
+<h6><strong>Environment Variables</strong></h6>
 <div class="nm-table-container">
 	<table class="nm-table is-variant-compact" style="--table-data-border-color: none">
 		<thead>

--- a/src/routes/(auth)/(project)/deployment/_components/Header.svelte
+++ b/src/routes/(auth)/(project)/deployment/_components/Header.svelte
@@ -20,7 +20,7 @@
 
 	function pause () {
 		modal.confirm({
-			title: `Pause ${deployment.name} in ${deployment.location} ?`,
+			title: `Pause ${deployment.name} in ${deployment.location}?`,
 			yes: 'Pause',
 			callback: async () => {
 				const resp = await api.invoke('deployment.pause', {
@@ -39,7 +39,7 @@
 
 	function resume () {
 		modal.confirm({
-			title: `Resume ${deployment.name} in ${deployment.location} ?`,
+			title: `Resume ${deployment.name} in ${deployment.location}?`,
 			yes: 'Resume',
 			callback: async () => {
 				const resp = await api.invoke('deployment.resume', {

--- a/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
@@ -295,9 +295,9 @@
 <div class="nm-panel is-level-300 _dp-g _g-7">
 	<div class="lo-12 _jtfit-st _g-5">
 		{#if deployment}
-			<h5><strong>Deploy new revision</strong></h5>
+			<h5><strong>Deploy New Revision</strong></h5>
 		{:else}
-			<h5><strong>Deploy new deployment</strong></h5>
+			<h5><strong>Deploy New Deployment</strong></h5>
 		{/if}
 	</div>
 	<hr>
@@ -632,7 +632,7 @@
                 </select>
             </div>
             <small class="helper">
-                Number of vCPUs limit to each container instance. Autoscale trigger when CPU hit 80% of the limit.
+                Number of vCPUs limited to each container instance. Autoscaling triggers when CPU usage reaches 80% of the limit.
             </small>
         </div>
 

--- a/src/routes/(auth)/(project)/disk/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/disk/(detail)/detail/+page.svelte
@@ -13,7 +13,7 @@
 
 	function deleteItem () {
 		modal.confirm({
-			title: `Delete "${name}" ?`,
+			title: `Delete "${name}"?`,
 			yes: 'Delete',
 			callback: async () => {
 				const resp = await api.invoke('disk.delete', { project, location, name }, fetch)

--- a/src/routes/(auth)/(project)/domain/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/+page.svelte
@@ -13,7 +13,7 @@
 
 	function deleteDomain (domain) {
 		modal.confirm({
-			title: `Delete domain "${domain.domain}" ?`,
+			title: `Delete domain "${domain.domain}"?`,
 			yes: 'Delete',
 			callback: async () => {
 				const resp = await api.invoke('domain.delete', {

--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -53,7 +53,7 @@
 		}
 
 		await modal.confirm({
-			title: `Purge cache on domain "${domain.domain}" ?`,
+			title: `Purge cache on domain "${domain.domain}"?`,
 			yes: 'Purge',
 			callback: async () => {
 				purging = true
@@ -160,7 +160,7 @@
 
 	function deleteItem () {
 		modal.confirm({
-			title: `Delete domain "${domain.domain}" ?`,
+			title: `Delete domain "${domain.domain}"?`,
 			yes: 'Delete',
 			callback: async () => {
 				const resp = await api.invoke('domain.delete', {
@@ -178,7 +178,7 @@
 
 	function upgradeCdn () {
 		modal.confirm({
-			html: `Add CDN to "${domain.domain}" ?`,
+			html: `Add CDN to "${domain.domain}"?`,
 			yes: 'Upgrade',
 			callback: async () => {
 				const resp = await api.invoke('domain.create', {

--- a/src/routes/(auth)/(project)/pull-secret/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/pull-secret/detail/+page.svelte
@@ -21,7 +21,7 @@
 
 	function deleteItem () {
 		modal.confirm({
-			title: `Delete "${pullSecret.name}" ?`,
+			title: `Delete "${pullSecret.name}"?`,
 			yes: 'Delete',
 			callback: async () => {
 				const resp = await api.invoke('pullSecret.delete', { project, location, name }, fetch)

--- a/src/routes/(auth)/(project)/registry/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/+page.svelte
@@ -14,7 +14,7 @@
 
 	function deleteRepository (name) {
 		modal.confirm({
-			title: `Delete "${name}" ?`,
+			title: `Delete "${name}"?`,
 			yes: 'Delete',
 			callback: async () => {
 				const resp = await api.invoke('registry/delete', { project, repository: name }, fetch)

--- a/src/routes/(auth)/(project)/registry/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/detail/+page.svelte
@@ -23,7 +23,7 @@
 
 	function untagTag (tag) {
 		modal.confirm({
-			title: `Untag "${tag}" ?`,
+			title: `Untag "${tag}"?`,
 			yes: 'Untag',
 			callback: async () => {
 				const resp = await api.invoke('registry/untag', { project, repository: data.id, tag }, fetch)

--- a/src/routes/(auth)/(project)/role/bind/+page.svelte
+++ b/src/routes/(auth)/(project)/role/bind/+page.svelte
@@ -92,7 +92,7 @@
 		<div class="nm-field">
 			<div class="nm-select">
 				<select onchange={selectRoleChanged}>
-					<option value="" disabled selected>---Select Role---</option>
+					<option value="" disabled selected>Select Role</option>
 					{#each roles as it (it.role)}
 						{#if !form.roles.includes(it.role)}
 							<option value={it.role}>{it.name} ({it.role})</option>

--- a/src/routes/(auth)/(project)/role/create/+page.svelte
+++ b/src/routes/(auth)/(project)/role/create/+page.svelte
@@ -21,7 +21,7 @@
 		if (!role) return
 
 		modal.confirm({
-			title: `Delete ${role.role} and its users ?`,
+			title: `Delete ${role.role} and its users?`,
 			yes: 'Delete',
 			callback: async () => {
 				const resp = await api.invoke('role.delete', { project, role: role.role }, fetch)
@@ -143,7 +143,7 @@
 			<div class="nm-field _dp-f _mgbt-5">
 				<div class="nm-select">
 					<select onchange={selectPermissionChanged}>
-						<option value="" disabled selected>---Select Permission---</option>
+						<option value="" disabled selected>Select Permission</option>
 						{#each permissions.filter((x) => !form.permissions.includes(x)) as it (it)}
 							<option value={it}>{it}</option>
 						{/each}

--- a/src/routes/(auth)/(project)/role/users/+page.svelte
+++ b/src/routes/(auth)/(project)/role/users/+page.svelte
@@ -15,7 +15,7 @@
 	 */
 	function deleteUser (email) {
 		modal.confirm({
-			title: `Delete user ${email} from project ${project} ?`,
+			title: `Delete user ${email} from project ${project}?`,
 			yes: 'Delete',
 			callback: async () => {
 				const resp = await api.invoke('role.bind', {

--- a/src/routes/(auth)/(project)/route/+page.svelte
+++ b/src/routes/(auth)/(project)/route/+page.svelte
@@ -15,7 +15,7 @@
 	 */
 	function deleteRoute (route) {
 		modal.confirm({
-			title: `Delete route ${route.domain}${route.path} in ${route.location} ?`,
+			title: `Delete route ${route.domain}${route.path} in ${route.location}?`,
 			yes: 'Delete',
 			callback: async () => {
 				const resp = await api.invoke('route.delete', {

--- a/src/routes/(auth)/(project)/service-account/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/service-account/detail/+page.svelte
@@ -49,7 +49,7 @@
 
 	function deleteKey (secret) {
 		modal.confirm({
-			title: 'Confirm delete key ?',
+			title: 'Confirm delete key?',
 			yes: 'Delete',
 			callback: async () => {
 				const resp = await api.invoke('serviceAccount.deleteKey', { project, id, secret }, fetch)

--- a/src/routes/(auth)/(project)/workload-identity/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/workload-identity/detail/+page.svelte
@@ -21,7 +21,7 @@
 
 	function deleteItem () {
 		modal.confirm({
-			title: `Delete "${workloadIdentity.name}" ?`,
+			title: `Delete "${workloadIdentity.name}"?`,
 			yes: 'Delete',
 			callback: async () => {
 				const resp = await api.invoke('workloadIdentity.delete', {

--- a/src/routes/(auth)/Navbar.svelte
+++ b/src/routes/(auth)/Navbar.svelte
@@ -76,7 +76,7 @@
 						</li>
 						<li>
 							<div class="item" onclick={doSignOut} onkeypress={doSignOut} tabindex="0" role="button">
-								Signout
+								Sign Out
 							</div>
 							<form class="_dp-n" method="POST" action="/auth/signout" bind:this={signOut}>
 								<button>Sign Out</button>

--- a/src/routes/(auth)/Sidebar.svelte
+++ b/src/routes/(auth)/Sidebar.svelte
@@ -248,10 +248,10 @@
 		</div>
 		<div class="_dp-f _jtfct-spbtw _alit-ct _fdrt-cl">
 			<div class="social _dp-f _jtfct-fe _alit-ct _g-4 _w-100pct _pdh-6">
-				<a href="https://github.com/deploys-app" target="_blank" rel="external" class="_dp-f _jtfct-ct _alit-ct _bdrd-3 _w-8 _h-8" aria-label="Goto Github">
+				<a href="https://github.com/deploys-app" target="_blank" rel="external" class="_dp-f _jtfct-ct _alit-ct _bdrd-3 _w-8 _h-8" aria-label="Go to GitHub">
 					<i class="fa-brands fa-github"></i>
 				</a>
-				<a href="https://discord.gg/5ZttPJsypS" target="_blank" rel="external" class="_dp-f _jtfct-ct _alit-ct _bdrd-3 _w-8 _h-8" aria-label="Goto Discord">
+				<a href="https://discord.gg/5ZttPJsypS" target="_blank" rel="external" class="_dp-f _jtfct-ct _alit-ct _bdrd-3 _w-8 _h-8" aria-label="Go to Discord">
 					<i class="fa-brands fa-discord"></i>
 				</a>
 				<a href="mailto:contact@moonrhythm.io" target="_blank" class="_dp-f _jtfct-ct _alit-ct _bdrd-3 _w-8 _h-8" aria-label="Email">

--- a/src/routes/(auth)/billing/detail/+page.svelte
+++ b/src/routes/(auth)/billing/detail/+page.svelte
@@ -9,7 +9,7 @@
 
 	function deleteItem () {
 		modal.confirm({
-			title: `Delete "${billingAccount.name}" ?`,
+			title: `Delete "${billingAccount.name}"?`,
 			yes: 'Delete',
 			callback: async () => {
 				const resp = await api.invoke('billing.delete', { id: billingAccount.id }, fetch)

--- a/src/routes/(auth)/billing/report/+page.svelte
+++ b/src/routes/(auth)/billing/report/+page.svelte
@@ -124,7 +124,7 @@
 			<div class="nm-select">
 				<select bind:value={filter.range} onchange={fetchReport}>
 					<option value="this_month">This month</option>
-					<option value="prev_month">Prev month</option>
+					<option value="prev_month">Previous month</option>
 					<option value="3_months">3 months</option>
 					<option value="6_months">6 months</option>
 					<option value="year">1 year</option>

--- a/src/routes/(auth)/project/+page.svelte
+++ b/src/routes/(auth)/project/+page.svelte
@@ -14,7 +14,7 @@
 	 */
 	async function deleteItem (project) {
 		const result = await Swal.fire({
-			title: 'Are you sure ?',
+			title: 'Are you sure?',
 			text: `Type "${project}" to confirm!`,
 			icon: 'warning',
 			input: 'text',


### PR DESCRIPTION
## Summary

- **README**: fix title (`Console` → `deploys.app Console`), grammar (`for manage` → `for managing`), update commands to match CLAUDE.md (`bun -b run dev` → `bun dev`), fix Font Awesome Pro sentence, add `bun preview` section
- **Navbar**: "Signout" → "Sign Out" (consistent with the hidden form button)
- **Sidebar**: aria-labels `Goto Github/Discord` → `Go to GitHub/Discord`
- **Deploy page**: title-case headings (`Deploy new revision` → `Deploy New Revision`); fix CPU helper text grammar (`Autoscale trigger when CPU hit 80%` → `Autoscaling triggers when CPU usage reaches 80%`)
- **Billing report**: `Prev month` → `Previous month`
- **Role pages**: clean up select placeholders (`---Select Permission---` / `---Select Role---` → no dashes)
- **Deployment detail**: title-case `Deployment details` and `Environment variables` headings
- **Modal titles (13 files)**: remove erroneous space before `?` in all confirmation dialogs (e.g., `Delete "foo" ?` → `Delete "foo"?`)

## Test plan

- [ ] Review navbar user menu — "Sign Out" label
- [ ] Review sidebar aria-labels for GitHub/Discord icons
- [ ] Open the deploy form — check heading and CPU helper text
- [ ] Open billing report — check time-range dropdown
- [ ] Open role create — check permission/role select placeholder
- [ ] Trigger any delete/confirm modal — verify no space before `?`
- [ ] Check README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)