### PR TITLE
feat: show expired-pending-deletion state for TTL=-1 deployments

### DIFF
--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -195,7 +195,15 @@
 				<td>Sidecars</td>
 				<td>{deployment.sidecars?.length || 0}</td>
 			</tr>
-			{#if deployment.ttl > 0}
+			{#if deployment.ttl === -1}
+				<tr>
+					<td>Auto-delete</td>
+					<td>
+						<i class="fa-regular fa-clock _mgr-5 _cl-danger"></i>
+						Expired — pending deletion
+					</td>
+				</tr>
+			{:else if deployment.ttl > 0}
 				<tr>
 					<td>Auto-delete</td>
 					<td>

--- a/src/routes/(auth)/(project)/deployment/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/+page.svelte
@@ -41,7 +41,9 @@
 					<tr>
 						<td>
 							<DeploymentStatusIcon action={it.action} status={it.status} url={it.statusUrl} type={it.type} />
-							{#if it.ttl > 0}
+							{#if it.ttl === -1}
+								<i class="fa-regular fa-clock _mgr-5 _cl-danger" title="Expired — pending deletion"></i>
+							{:else if it.ttl > 0}
 								<i class="fa-regular fa-clock _mgr-5 _cl-warning"
 									title={`Auto-delete at ${format.ttlExpireAt(it.ttl)} (in ${format.duration(it.ttl)})`}></i>
 							{/if}


### PR DESCRIPTION
## Summary

- The deployment list and get APIs now return `ttl=-1` when a deployment has expired but GC hasn't cleaned it up yet.
- Previously the UI only handled `ttl > 0` (active TTL) and `ttl <= 0` (no TTL), so `-1` was silently treated as "no TTL" and nothing was shown.
- This PR adds an explicit branch for `ttl === -1` in both the deployment list view and the detail view, showing a danger-colored clock icon with an "Expired — pending deletion" label.

## Changes

- [`src/routes/(auth)/(project)/deployment/+page.svelte`](src/routes/(auth)/(project)/deployment/+page.svelte) — list row: red clock icon with tooltip "Expired — pending deletion"
- [`src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte`](src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte) — detail table row: red clock icon + inline text

## Reviewer notes

No logic change to the deploy form — it already guards TTL pre-fill with `ttl > 0`, so `-1` is correctly ignored there.