### PR TITLE
feat: exclude TTL deployments from route create deployment dropdown

### DIFF
--- a/src/routes/(auth)/(project)/route/create/+page.svelte
+++ b/src/routes/(auth)/(project)/route/create/+page.svelte
@@ -65,6 +65,7 @@
 		deployments = list
 			.filter((x) => x.location === form.location)
 			.filter((x) => x.type === 'WebService')
+			.filter((x) => x.ttl === 0)
 			.map((x) => x.name)
 	}
 


### PR DESCRIPTION
## Summary

- Filters out deployments with a TTL set (`ttl !== 0`) from the deployment dropdown on the route create page
- TTL deployments are temporary (auto-deleted after a period) or expired (`ttl === -1`, pending deletion), so they should not be valid route targets

## Reviewer notes

The filter `x.ttl === 0` aligns with the existing convention used throughout the codebase: `ttl === 0` = permanent, `ttl > 0` = has TTL, `ttl === -1` = expired/pending deletion.