### PR TITLE
feat: allow allUsers and allAuthenticatedUsers in role bind email input

### DIFF
--- a/src/routes/(auth)/(project)/role/bind/+page.svelte
+++ b/src/routes/(auth)/(project)/role/bind/+page.svelte
@@ -86,8 +86,15 @@
 	<form class="_dp-g _g-6 _w-100pct" onsubmit={save}>
 		<div class="nm-field">
 			<div class="nm-input">
-				<input type="email" placeholder="Email" bind:value={form.email} readonly={!!email} required>
+				<input type="text" placeholder="Email / allUsers / allAuthenticatedUsers"
+					bind:value={form.email} readonly={!!email} required
+					list="email-suggestions"
+					pattern="^(allUsers|allAuthenticatedUsers|[^@\s]+@[^@\s]+\.[^@\s]+)$">
 			</div>
+			<datalist id="email-suggestions">
+				<option value="allUsers"></option>
+				<option value="allAuthenticatedUsers"></option>
+			</datalist>
 		</div>
 		<div class="nm-field">
 			<div class="nm-select">


### PR DESCRIPTION
## Summary

- Changes the email field on the Add Member page (`/role/bind`) from `type="email"` to `type="text"` so the special IAM principals `allUsers` and `allAuthenticatedUsers` can be entered
- Adds a `pattern` attribute that validates input as either a valid email address or one of the two special values
- Adds a `datalist` that provides autocomplete suggestions for `allUsers` and `allAuthenticatedUsers`
- Updates the placeholder to hint at the accepted values

## Test plan

- [ ] Enter a normal email address — form submits successfully
- [ ] Type `allUsers` — autocomplete suggestion appears; form submits successfully
- [ ] Type `allAuthenticatedUsers` — autocomplete suggestion appears; form submits successfully
- [ ] Enter an invalid string (e.g. `notanemail`) — browser validation blocks submission
- [ ] Open bind page with a pre-filled email via query param — field remains readonly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)