### PR TITLE
ci: add deploy GitHub Action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,24 @@
+name: Deploy
+on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+    branches: [main]
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+    - uses: google-github-actions/auth@v1
+      with:
+        credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+    - uses: google-github-actions/get-gke-credentials@v2
+      with:
+        project_id: ${{ vars.GKE_PROJECT }}
+        cluster_name: ${{ vars.GKE_CLUSTER }}
+        location: ${{ vars.GKE_LOCATION }}
+    - name: Deploy
+      env:
+        IMAGE: asia-southeast1-docker.pkg.dev/deploys-app/internal/console:${{ github.event.workflow_run.head_sha }}
+      run: kubectl set image -n deployer deployment/console app=$IMAGE


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy.yaml` to automate deployment after a successful build
- Triggers via `workflow_run` on the Build workflow completing on `main`
- Authenticates with Google, fetches GKE credentials using shared `GKE_PROJECT`/`GKE_CLUSTER`/`GKE_LOCATION` vars, and runs `kubectl set image -n deployer deployment/console app=$IMAGE`

Follows the same pattern as the `dropbox` service's deploy workflow.

## Test plan

- [ ] Merge to `main` and verify the Build workflow triggers Deploy on completion
- [ ] Confirm the new image is rolled out to `deployment/console` in the `deployer` namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)