### PR TITLE
ci: install kubectl in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,6 +18,7 @@ jobs:
         project_id: ${{ vars.GKE_PROJECT }}
         cluster_name: ${{ vars.GKE_CLUSTER }}
         location: ${{ vars.GKE_LOCATION }}
+    - uses: azure/setup-kubectl@v4
     - name: Deploy
       env:
         IMAGE: asia-southeast1-docker.pkg.dev/deploys-app/internal/console:${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
## Summary
- The deploy workflow was failing with `kubectl: command not found` on the self-hosted runner.
- `google-github-actions/get-gke-credentials` only writes the kubeconfig — it does not install `kubectl`.
- Added `azure/setup-kubectl@v4` before the deploy step so the binary is available.

## Test plan
- [ ] Next push to `main` triggers Build → Deploy and the Deploy job succeeds at the `kubectl set image` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)