### PR TITLE
feat: support multiple deployment sidecars

### DIFF
--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -191,10 +191,27 @@
 				<td>Memory allocated</td>
 				<td>{format.memory(deployment.resources.requests.memory)}</td>
 			</tr>
-			<tr>
-				<td>Sidecars</td>
-				<td>{deployment.sidecars?.length || 0}</td>
-			</tr>
+			{#if deployment.sidecars?.length}
+				<tr>
+					<td>Sidecars</td>
+					<td>
+						<ul class="_mg-0 _pdl-6">
+							{#each deployment.sidecars as s, i (i)}
+								{#if s.cloudSqlProxy}
+									<li>
+										<strong>Cloud SQL Proxy</strong>
+										&nbsp;—&nbsp;
+										<span>{s.cloudSqlProxy.instance}</span>
+										{#if s.cloudSqlProxy.port}
+											<span class="_cl-light">:{s.cloudSqlProxy.port}</span>
+										{/if}
+									</li>
+								{/if}
+							{/each}
+						</ul>
+					</td>
+				</tr>
+			{/if}
 			{#if deployment.ttl === -1}
 				<tr>
 					<td>Auto-delete</td>

--- a/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
@@ -63,17 +63,8 @@
 		env: [],
 		/** @type {{ k: string, v: string }[]} */
 		mountData: [],
-		// /** @type {Api.Sidecar[]} */
-		// sidecars: [],
-		sidecar: {
-			type: '',
-			cloudSqlProxy: {
-				instance: '',
-				/** @type {?number} */
-				port: null,
-				credentials: ''
-			}
-		},
+		/** @type {Api.SidecarForm[]} */
+		sidecars: [],
 		ttlValue: 0,
 		// unit in seconds; '0' means no auto-delete
 		ttlUnit: '0'
@@ -101,23 +92,22 @@
 		form.resources = deployment.resources
 		form.env = Object.entries(deployment.env || {}).map(([k, v]) => ({ k, v }))
 		form.mountData = Object.entries(deployment.mountData || {}).map(([k, v]) => ({ k, v }))
-		form.sidecar = (deployment.sidecars || []).length > 0
-			? {
-				type: 'cloudSqlProxy',
-				cloudSqlProxy: {
-					instance: deployment.sidecars[0].cloudSqlProxy?.instance ?? '',
-					port: deployment.sidecars[0].cloudSqlProxy?.port ?? null,
-					credentials: deployment.sidecars[0].cloudSqlProxy?.credentials ?? ''
+		form.sidecars = (deployment.sidecars || []).map((s) => {
+			if (s.cloudSqlProxy) {
+				return {
+					type: 'cloudSqlProxy',
+					cloudSqlProxy: {
+						instance: s.cloudSqlProxy.instance ?? '',
+						port: s.cloudSqlProxy.port ?? null,
+						credentials: s.cloudSqlProxy.credentials ?? ''
+					}
 				}
 			}
-			: {
+			return {
 				type: '',
-				cloudSqlProxy: {
-					instance: '',
-					port: null,
-					credentials: ''
-				}
+				cloudSqlProxy: { instance: '', port: null, credentials: '' }
 			}
+		})
 		if (deployment.ttl > 0) {
 			if (deployment.ttl % 86400 === 0) {
 				form.ttlUnit = '86400'
@@ -218,19 +208,41 @@
 			.join('\n')
 	}
 
-	function convertSidecar () {
-		if (!form.sidecar.type) {
-			return []
-		}
-		return [
-			{
-				cloudSqlProxy: {
-					instance: form.sidecar.cloudSqlProxy.instance,
-					port: form.sidecar.cloudSqlProxy.port,
-					credentials: form.sidecar.cloudSqlProxy.credentials
+	function convertSidecars () {
+		return form.sidecars
+			.filter((s) => s.type)
+			.map((s) => {
+				if (s.type === 'cloudSqlProxy') {
+					return {
+						cloudSqlProxy: {
+							instance: s.cloudSqlProxy.instance,
+							port: s.cloudSqlProxy.port,
+							credentials: s.cloudSqlProxy.credentials
+						}
+					}
 				}
+				return {}
+			})
+	}
+
+	const sidecarMax = 2
+
+	function addSidecar () {
+		if (form.sidecars.length >= sidecarMax) {
+			return
+		}
+		form.sidecars = [
+			...form.sidecars,
+			{
+				type: 'cloudSqlProxy',
+				cloudSqlProxy: { instance: '', port: null, credentials: '' }
 			}
 		]
+	}
+
+	/** @param {number} i */
+	function removeSidecar (i) {
+		form.sidecars = form.sidecars.filter((_, k) => k !== i)
 	}
 
 	let saving = $state(false)
@@ -255,7 +267,7 @@
 				protocol: form.type === 'WebService' ? form.protocol : '',
 				env: form.env.reduce((p, x) => { p[x.k] = x.v; return p }, {}),
 				mountData: form.mountData.reduce((p, x) => { p[x.k] = x.v; return p }, {}),
-				sidecars: convertSidecar(),
+				sidecars: convertSidecars(),
 				ttl: ttlSeconds
 			}, fetch)
 			if (!resp.ok) {
@@ -767,42 +779,54 @@
 
 		<hr>
 
-		<h6><strong>Sidecar</strong></h6>
+		<h6><strong>Sidecars</strong></h6>
 		<div class="_dp-g _g-6">
-			<div class="nm-field">
-				<label for="input-sidecar-type">Type</label>
-				<div class="nm-select">
-					<select id="input-sidecar-type" bind:value={form.sidecar.type}>
-						<option value="">None</option>
-						<option value="cloudSqlProxy">Cloud SQL Proxy</option>
-					</select>
-				</div>
-			</div>
-			{#if form.sidecar.type === 'cloudSqlProxy'}
-				<div class="nm-field">
-					<label for="input-sidecar-instance">Instance</label>
-					<div class="nm-input">
-						<input id="input-sidecar-instance" placeholder="Instance" bind:value={form.sidecar.cloudSqlProxy.instance} required>
+			{#each form.sidecars as sidecar, i (i)}
+				<div class="nm-panel is-level-200 _dp-g _g-5">
+					<div class="_dp-f _jtfit-sb _atit-c">
+						<strong>Sidecar #{i + 1}</strong>
+						<button class="icon-button" type="button" aria-label="Remove sidecar"
+							onclick={() => removeSidecar(i)}>
+							<i class="fa-solid fa-trash-alt"></i>
+						</button>
 					</div>
-				</div>
-				<div class="nm-field">
-					<label for="input-sidecar-port">Port</label>
-					<div class="nm-input">
-						<input class="-no-arrow" id="input-sidecar-port" placeholder="Port" type="number" bind:value={form.sidecar.cloudSqlProxy.port} required>
+					<div class="nm-field">
+						<label for="input-sidecar-type-{i}">Type</label>
+						<div class="nm-select">
+							<select id="input-sidecar-type-{i}" bind:value={sidecar.type}>
+								<option value="" disabled>Select Type</option>
+								<option value="cloudSqlProxy">Cloud SQL Proxy</option>
+							</select>
+						</div>
 					</div>
+					{#if sidecar.type === 'cloudSqlProxy'}
+						<div class="nm-field">
+							<label for="input-sidecar-instance-{i}">Instance</label>
+							<div class="nm-input">
+								<input id="input-sidecar-instance-{i}" placeholder="project:region:instance" bind:value={sidecar.cloudSqlProxy.instance} required>
+							</div>
+						</div>
+						<div class="nm-field">
+							<label for="input-sidecar-port-{i}">Port</label>
+							<div class="nm-input">
+								<input class="-no-arrow" id="input-sidecar-port-{i}" placeholder="3300" type="number" bind:value={sidecar.cloudSqlProxy.port}>
+							</div>
+						</div>
+						<div class="nm-field">
+							<label for="input-sidecar-credentials-{i}">Credentials</label>
+							<div class="nm-input">
+								<input id="input-sidecar-credentials-{i}" placeholder="Credentials JSON" bind:value={sidecar.cloudSqlProxy.credentials}>
+							</div>
+						</div>
+					{/if}
 				</div>
-				<div class="nm-field">
-					<label for="input-sidecar-credentials">Credentials</label>
-					<div class="nm-input">
-						<input id="input-sidecar-credentials" placeholder="Credentials" bind:value={form.sidecar.cloudSqlProxy.credentials}>
-					</div>
-				</div>
+			{/each}
+			{#if form.sidecars.length < sidecarMax}
+				<button class="nm-button _dp-f _mg-at" type="button" onclick={addSidecar}>
+					<i class="fa-solid fa-plus _mgr-5"></i>
+					<span>Add Sidecar</span>
+				</button>
 			{/if}
-<!--			<button class="nm-button _dp-f _mg-at" type="button"-->
-<!--					onclick={() => { form.sidecars.push({}) }}>-->
-<!--				<i class="fa-solid fa-plus _mgr-5"></i>-->
-<!--				<span>Add Sidecar</span>-->
-<!--			</button>-->
 		</div>
 
 		<hr>

--- a/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
@@ -783,7 +783,7 @@
 		<div class="_dp-g _g-6">
 			{#each form.sidecars as sidecar, i (i)}
 				<div class="nm-panel is-level-200 _dp-g _g-5">
-					<div class="_dp-f _jtfit-sb _atit-c">
+					<div class="_dp-f _jtfct-spbtw _alit-ct">
 						<strong>Sidecar #{i + 1}</strong>
 						<button class="icon-button" type="button" aria-label="Remove sidecar"
 							onclick={() => removeSidecar(i)}>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -234,10 +234,28 @@ declare namespace Api {
         limits: Resource
     }
 
+    export type CloudSqlProxySidecar = {
+        instance: string
+        port: number
+        credentials: string
+    }
+
     export type Sidecar = {
-        cloudSqlProxy?: {
+        cloudSqlProxy?: CloudSqlProxySidecar
+    }
+
+    export type SidecarType = '' | 'cloudSqlProxy'
+
+    /**
+     * Editable form shape for a sidecar. Carries a discriminator plus a
+     * config slot per variant so the form can switch between types without
+     * losing partial input.
+     */
+    export type SidecarForm = {
+        type: SidecarType
+        cloudSqlProxy: {
             instance: string
-            port: number
+            port: number | null
             credentials: string
         }
     }

--- a/tests/deployment.spec.js
+++ b/tests/deployment.spec.js
@@ -1,5 +1,9 @@
 import { test, expect, setMocks } from './helpers.js'
-import { sampleDeployment } from './fixtures/mocks.js'
+import {
+	defaultLocation,
+	sampleCloudSqlProxySidecar,
+	sampleDeployment
+} from './fixtures/mocks.js'
 
 test.describe('deployments', () => {
 	test('lists deployments', async ({ page }) => {
@@ -43,5 +47,107 @@ test.describe('deployments', () => {
 		await page.goto('/deployment?project=test-project')
 		const main = page.locator('.content-wrapper')
 		await expect(main.getByText('api: internal error')).toBeVisible()
+	})
+})
+
+test.describe('deployment detail — sidecars', () => {
+	test('hides sidecar row when none are configured', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleDeployment },
+			'location.get': { ok: true, result: defaultLocation }
+		})
+
+		await page.goto('/deployment/detail?project=test-project&location=gke&name=web')
+
+		await expect(page.getByRole('cell', { name: 'Sidecars' })).toHaveCount(0)
+	})
+
+	test('renders each configured sidecar', async ({ page }) => {
+		await setMocks({
+			'deployment.get': {
+				ok: true,
+				result: {
+					...sampleDeployment,
+					sidecars: [
+						sampleCloudSqlProxySidecar,
+						{
+							cloudSqlProxy: {
+								instance: 'my-project:asia-southeast1:replica',
+								port: 3307,
+								credentials: ''
+							}
+						}
+					]
+				}
+			},
+			'location.get': { ok: true, result: defaultLocation }
+		})
+
+		await page.goto('/deployment/detail?project=test-project&location=gke&name=web')
+
+		const row = page.getByRole('row').filter({ hasText: 'Sidecars' })
+		await expect(row).toBeVisible()
+		await expect(row.getByText('my-project:us-central1:my-db')).toBeVisible()
+		await expect(row.getByText(':3306')).toBeVisible()
+		await expect(row.getByText('my-project:asia-southeast1:replica')).toBeVisible()
+		await expect(row.getByText(':3307')).toBeVisible()
+	})
+})
+
+test.describe('deployment deploy — sidecars', () => {
+	test('add, remove, and cap at two sidecars', async ({ page }) => {
+		// Start from an existing deployment with no sidecars so the form is
+		// fully hydrated — the new-deployment path requires picking a location
+		// from a dropdown, which bind:value won't pick up via selectOption.
+		await setMocks({
+			'deployment.get': {
+				ok: true,
+				result: { ...sampleDeployment, sidecars: [] }
+			},
+			'location.get': { ok: true, result: defaultLocation }
+		})
+
+		await page.goto('/deployment/deploy?project=test-project&location=gke&name=web')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Sidecars' })).toBeVisible()
+
+		const addBtn = main.getByRole('button', { name: 'Add Sidecar' })
+
+		await addBtn.click()
+		await expect(main.getByText('Sidecar #1')).toBeVisible()
+
+		await addBtn.click()
+		await expect(main.getByText('Sidecar #2')).toBeVisible()
+
+		// Capped at 2 — the add button should disappear.
+		await expect(addBtn).toHaveCount(0)
+
+		// Remove the first sidecar and the button should reappear.
+		await main.getByRole('button', { name: 'Remove sidecar' }).first().click()
+		await expect(main.getByText('Sidecar #2')).toHaveCount(0)
+		await expect(main.getByRole('button', { name: 'Add Sidecar' })).toBeVisible()
+	})
+
+	test('hydrates existing sidecars when editing a revision', async ({ page }) => {
+		await setMocks({
+			'deployment.get': {
+				ok: true,
+				result: {
+					...sampleDeployment,
+					sidecars: [sampleCloudSqlProxySidecar]
+				}
+			},
+			'location.get': { ok: true, result: defaultLocation }
+		})
+
+		await page.goto('/deployment/deploy?project=test-project&location=gke&name=web')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('Sidecar #1')).toBeVisible()
+		await expect(main.locator('#input-sidecar-instance-0')).toHaveValue(
+			'my-project:us-central1:my-db'
+		)
+		await expect(main.locator('#input-sidecar-port-0')).toHaveValue('3306')
 	})
 })

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -162,6 +162,14 @@ export const sampleDeployment = {
 	ttl: 0
 }
 
+export const sampleCloudSqlProxySidecar = {
+	cloudSqlProxy: {
+		instance: 'my-project:us-central1:my-db',
+		port: 3306,
+		credentials: ''
+	}
+}
+
 export const sampleDomain = {
 	project: 'test-project',
 	location: 'gke',


### PR DESCRIPTION
## Summary
- The API accepts up to **two** sidecars per deployment (`api/deployment.go` validator: `len(m.Sidecars) <= 2`), but the console only exposed a single slot. This PR brings the UI in line with the API.
- Refactors the deploy form to use an array of sidecars with add/remove controls, capped at 2. Existing revisions hydrate all configured sidecars (previously only the first one was loaded).
- Detail page now lists each configured sidecar (type + instance:port) instead of just showing a count, and hides the row entirely when there are none.
- Extracts `Api.CloudSqlProxySidecar` and a new `Api.SidecarForm` type into `src/types/api.d.ts` so the editable form shape is named rather than inline JSDoc.

## Test plan
- [x] `bun check` — type-check passes
- [x] `bun lint` — clean
- [x] `PLAYWRIGHT_USE_BUILD=1 bun run test` — all 38 tests pass, including new coverage:
  - detail page hides the sidecars row when none configured
  - detail page renders each configured sidecar (multiple)
  - deploy page add/remove flow and 2-sidecar cap
  - deploy page hydrates existing sidecars when editing a revision

🤖 Generated with [Claude Code](https://claude.com/claude-code)