### PR TITLE
docs: require reading project + nomimono CSS before CSS work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,12 @@ OAuth2 against `auth.deploys.app`. Token stored in httpOnly cookies. `src/hooks.
 
 Uses the **nomimono-css** design system (classes like `nm-panel`, `nm-button`, `nm-field`). SCSS files live in `src/style/`, imported via the `$style` alias. Theme (dark/light) is stored in a cookie and applied via `data-theme` attribute.
 
+**Before doing any CSS work**, read both:
+- The project styles in `src/style/` (`main.scss`, `_theme.scss`) to see project-level tokens, overrides, and conventions.
+- The nomimono-css atomic classes in `node_modules/@nomimono/nomimono-css/atomic.css` (also `reset.css`, `layout.css`, `component.css`) to prefer existing utility/component classes over writing new CSS.
+
+Reach for nomimono atomic/component classes first; only add custom SCSS when no existing class fits.
+
 ### Modals
 
 Centralized in `src/lib/modal/index.js` — wraps SweetAlert2. Use this for confirmations and form dialogs rather than inline alert/confirm.


### PR DESCRIPTION
## Summary
- Add a note in the Styling section of `CLAUDE.md` instructing Claude to read both `src/style/` (project tokens/conventions) and the nomimono-css files in `node_modules/@nomimono/nomimono-css/` (atomic, reset, layout, component) before doing any CSS work.
- Prefer existing nomimono utility/component classes over writing new SCSS.

## Why
Reduces duplicate/ad-hoc CSS by making sure existing utilities are considered first.

## Test plan
- [ ] Docs-only change; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)