### PR TITLE
feat: add audit log view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ src/routes/
   auth/                        # sign-in / callback / sign-out (unauthenticated)
   (auth)/                      # layout group — redirects to /auth/signin if no token
     (project)/                 # layout group — requires ?project= param
-      deployment/ disk/ domain/ dropbox/ email/
+      audit-log/ deployment/ disk/ domain/ dropbox/ email/
       pull-secret/ registry/ role/ route/
       service-account/ workload-identity/
     billing/

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "console",
+      "dependencies": {
+        "date-picker-svelte": "^2.17.0",
+      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@nomimono/nomimono-css": "^0.6.0",
@@ -419,6 +422,8 @@
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
+
+    "date-picker-svelte": ["date-picker-svelte@2.17.0", "", { "peerDependencies": { "svelte": "^3.24.0 || ^4.0.0 || ^5.0.0" } }, "sha512-lv558Odoyh0+yYFvC2DAKCALMtGKv9hfGBS+CjdSi1xB0qcJm+dtaVABcLQaAJ5Bj+jizRBVRqfC1Tq2Gcpsog=="],
 
     "dayjs": ["dayjs@1.11.20", "", {}, "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "console",
       "dependencies": {
-        "date-picker-svelte": "^2.17.0",
+        "@svelte-plugins/datepicker": "^1.0.11",
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -343,6 +343,8 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
+    "@svelte-plugins/datepicker": ["@svelte-plugins/datepicker@1.0.11", "", {}, "sha512-Tqc07QLyRkCpc3Glg6oRLTUApLtCrOh52d6vJ7L32QI17HrwvcDDjaH3LF3X1SBm3CWdMrnqfJp3xjUZmB4wzw=="],
+
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.8", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA=="],
 
     "@sveltejs/adapter-cloudflare": ["@sveltejs/adapter-cloudflare@7.2.8", "", { "dependencies": { "@cloudflare/workers-types": "^4.20250507.0", "worktop": "0.8.0-next.18" }, "peerDependencies": { "@sveltejs/kit": "^2.0.0", "wrangler": "^4.0.0" } }, "sha512-bIdhY/Fi4AQmqiBdQVKnafH1h9Gw+xbCvHyUu4EouC8rJOU02zwhi14k/FDhQ0mJF1iblIu3m8UNQ8GpGIvIOQ=="],
@@ -422,8 +424,6 @@
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
-
-    "date-picker-svelte": ["date-picker-svelte@2.17.0", "", { "peerDependencies": { "svelte": "^3.24.0 || ^4.0.0 || ^5.0.0" } }, "sha512-lv558Odoyh0+yYFvC2DAKCALMtGKv9hfGBS+CjdSi1xB0qcJm+dtaVABcLQaAJ5Bj+jizRBVRqfC1Tq2Gcpsog=="],
 
     "dayjs": ["dayjs@1.11.20", "", {}, "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ=="],
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
   },
   "type": "module",
   "dependencies": {
-    "date-picker-svelte": "^2.17.0"
+    "@svelte-plugins/datepicker": "^1.0.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "vite": "^8.0.13",
     "wrangler": "^4.91.0"
   },
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "date-picker-svelte": "^2.17.0"
+  }
 }

--- a/src/routes/(auth)/(project)/audit-log/+layout.js
+++ b/src/routes/(auth)/(project)/audit-log/+layout.js
@@ -1,0 +1,6 @@
+export function load () {
+	return {
+		menu: 'audit-log',
+		overrideRedirect: '/audit-log'
+	}
+}

--- a/src/routes/(auth)/(project)/audit-log/+page.js
+++ b/src/routes/(auth)/(project)/audit-log/+page.js
@@ -1,7 +1,5 @@
 import api from '$lib/api'
 
-const ALLOWED_LIMITS = [25, 50, 100]
-
 /**
  * @param {string | null} v
  * @returns {string | undefined}
@@ -19,8 +17,9 @@ function toRFC3339 (v) {
  */
 function parseLimit (v) {
 	const n = Number(v)
-	if (ALLOWED_LIMITS.includes(n)) return n
-	return 50
+	if (!Number.isInteger(n) || n < 1) return 50
+	if (n > 100) return 100
+	return n
 }
 
 export async function load ({ url, parent, fetch }) {

--- a/src/routes/(auth)/(project)/audit-log/+page.js
+++ b/src/routes/(auth)/(project)/audit-log/+page.js
@@ -1,5 +1,7 @@
 import api from '$lib/api'
 
+const LIMIT = 50
+
 /**
  * @param {string | null} v
  * @returns {string | undefined}
@@ -11,17 +13,6 @@ function toRFC3339 (v) {
 	return d.toISOString()
 }
 
-/**
- * @param {string | null} v
- * @returns {number}
- */
-function parseLimit (v) {
-	const n = Number(v)
-	if (!Number.isInteger(n) || n < 1) return 50
-	if (n > 100) return 100
-	return n
-}
-
 export async function load ({ url, parent, fetch }) {
 	const { project } = await parent()
 
@@ -30,8 +21,7 @@ export async function load ({ url, parent, fetch }) {
 		actor: url.searchParams.get('actor') ?? '',
 		outcome: url.searchParams.get('outcome') ?? '',
 		after: url.searchParams.get('after') ?? '',
-		before: url.searchParams.get('before') ?? '',
-		limit: parseLimit(url.searchParams.get('limit'))
+		before: url.searchParams.get('before') ?? ''
 	}
 
 	const args = {
@@ -41,7 +31,7 @@ export async function load ({ url, parent, fetch }) {
 		outcome: filters.outcome,
 		after: toRFC3339(filters.after),
 		before: toRFC3339(filters.before),
-		limit: filters.limit
+		limit: LIMIT
 	}
 
 	/** @type {Api.Response<Api.List<Api.AuditLogItem>>} */

--- a/src/routes/(auth)/(project)/audit-log/+page.js
+++ b/src/routes/(auth)/(project)/audit-log/+page.js
@@ -1,0 +1,43 @@
+import api from '$lib/api'
+
+/**
+ * @param {string | null} v
+ * @returns {string | undefined}
+ */
+function toRFC3339 (v) {
+	if (!v) return undefined
+	const d = new Date(v)
+	if (isNaN(d.getTime())) return undefined
+	return d.toISOString()
+}
+
+export async function load ({ url, parent, fetch }) {
+	const { project } = await parent()
+
+	const filters = {
+		resourceType: url.searchParams.get('resourceType') ?? '',
+		actor: url.searchParams.get('actor') ?? '',
+		outcome: url.searchParams.get('outcome') ?? '',
+		after: url.searchParams.get('after') ?? '',
+		before: url.searchParams.get('before') ?? '',
+		limit: Number(url.searchParams.get('limit')) || 50
+	}
+
+	const args = {
+		project,
+		resourceType: filters.resourceType,
+		actor: filters.actor,
+		outcome: filters.outcome,
+		after: toRFC3339(filters.after),
+		before: toRFC3339(filters.before),
+		limit: filters.limit
+	}
+
+	/** @type {Api.Response<Api.List<Api.AuditLogItem>>} */
+	const res = await api.invoke('auditLog.list', args, fetch)
+	return {
+		items: res.result?.items ?? [],
+		filters,
+		error: res.error
+	}
+}

--- a/src/routes/(auth)/(project)/audit-log/+page.js
+++ b/src/routes/(auth)/(project)/audit-log/+page.js
@@ -1,5 +1,7 @@
 import api from '$lib/api'
 
+const ALLOWED_LIMITS = [25, 50, 100]
+
 /**
  * @param {string | null} v
  * @returns {string | undefined}
@@ -11,6 +13,16 @@ function toRFC3339 (v) {
 	return d.toISOString()
 }
 
+/**
+ * @param {string | null} v
+ * @returns {number}
+ */
+function parseLimit (v) {
+	const n = Number(v)
+	if (ALLOWED_LIMITS.includes(n)) return n
+	return 50
+}
+
 export async function load ({ url, parent, fetch }) {
 	const { project } = await parent()
 
@@ -20,7 +32,7 @@ export async function load ({ url, parent, fetch }) {
 		outcome: url.searchParams.get('outcome') ?? '',
 		after: url.searchParams.get('after') ?? '',
 		before: url.searchParams.get('before') ?? '',
-		limit: Number(url.searchParams.get('limit')) || 50
+		limit: parseLimit(url.searchParams.get('limit'))
 	}
 
 	const args = {

--- a/src/routes/(auth)/(project)/audit-log/+page.svelte
+++ b/src/routes/(auth)/(project)/audit-log/+page.svelte
@@ -1,0 +1,169 @@
+<script>
+	import { untrack } from 'svelte'
+	import { SvelteURLSearchParams } from 'svelte/reactivity'
+	import { goto } from '$app/navigation'
+	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import * as format from '$lib/format'
+
+	const { data } = $props()
+
+	const project = $derived(data.project)
+	const items = $derived(data.items)
+	const error = $derived(data.error)
+
+	const form = $state(untrack(() => ({ ...data.filters })))
+
+	/**
+	 * @param {Event} e
+	 */
+	async function apply (e) {
+		e.preventDefault()
+		const q = new SvelteURLSearchParams()
+		q.set('project', project)
+		if (form.resourceType) q.set('resourceType', form.resourceType)
+		if (form.actor) q.set('actor', form.actor)
+		if (form.outcome) q.set('outcome', form.outcome)
+		if (form.after) q.set('after', form.after)
+		if (form.before) q.set('before', form.before)
+		if (form.limit && form.limit !== 50) q.set('limit', String(form.limit))
+		await goto(`/audit-log?${q.toString()}`, { keepFocus: true })
+	}
+
+	function reset () {
+		form.resourceType = ''
+		form.actor = ''
+		form.outcome = ''
+		form.after = ''
+		form.before = ''
+		form.limit = 50
+		goto(`/audit-log?project=${project}`, { keepFocus: true })
+	}
+
+	/**
+	 * @param {Api.AuditOutcome} o
+	 */
+	function outcomeIcon (o) {
+		if (o === 'success') return { icon: 'fa-circle-check', cls: '_cl-positive', title: 'Success' }
+		if (o === 'failure') return { icon: 'fa-circle-xmark', cls: '_cl-negative', title: 'Failure' }
+		return { icon: 'fa-circle', cls: '', title: o }
+	}
+</script>
+
+<h6>Audit Logs</h6>
+<br>
+<div class="nm-panel is-level-300">
+	<form class="lo-grid _g-5" onsubmit={apply}>
+		<div class="lo-12 lo-6:md lo-4:lg _g-5">
+			<div class="nm-field">
+				<label class="nm-label" for="filter-resource-type">Resource type</label>
+				<div class="nm-input">
+					<input id="filter-resource-type" type="text" placeholder="e.g. deployment"
+						bind:value={form.resourceType}>
+				</div>
+			</div>
+		</div>
+		<div class="lo-12 lo-6:md lo-4:lg _g-5">
+			<div class="nm-field">
+				<label class="nm-label" for="filter-actor">Actor</label>
+				<div class="nm-input">
+					<input id="filter-actor" type="text" placeholder="email or service account"
+						bind:value={form.actor}>
+				</div>
+			</div>
+		</div>
+		<div class="lo-12 lo-6:md lo-4:lg _g-5">
+			<div class="nm-field">
+				<label class="nm-label" for="filter-outcome">Outcome</label>
+				<div class="nm-select">
+					<select id="filter-outcome" bind:value={form.outcome}>
+						<option value="">All</option>
+						<option value="success">Success</option>
+						<option value="failure">Failure</option>
+					</select>
+				</div>
+			</div>
+		</div>
+		<div class="lo-12 lo-6:md lo-4:lg _g-5">
+			<div class="nm-field">
+				<label class="nm-label" for="filter-after">After</label>
+				<div class="nm-input">
+					<input id="filter-after" type="datetime-local" bind:value={form.after}>
+				</div>
+			</div>
+		</div>
+		<div class="lo-12 lo-6:md lo-4:lg _g-5">
+			<div class="nm-field">
+				<label class="nm-label" for="filter-before">Before</label>
+				<div class="nm-input">
+					<input id="filter-before" type="datetime-local" bind:value={form.before}>
+				</div>
+			</div>
+		</div>
+		<div class="lo-12 lo-6:md lo-4:lg _g-5">
+			<div class="nm-field">
+				<label class="nm-label" for="filter-limit">Limit</label>
+				<div class="nm-input">
+					<input id="filter-limit" type="number" min="1" max="100"
+						bind:value={form.limit}>
+				</div>
+			</div>
+		</div>
+		<div class="lo-12 _dp-f _jtfct-fe _g-4">
+			<button type="button" class="nm-button is-variant-ghost" onclick={reset}>Reset</button>
+			<button type="submit" class="nm-button">Apply</button>
+		</div>
+	</form>
+
+	<div class="nm-table-container _mgt-6">
+		<table class="nm-table is-variant-compact">
+			<thead>
+				<tr>
+					<th>Time</th>
+					<th>Outcome</th>
+					<th>Actor</th>
+					<th>Action</th>
+					<th>Resource</th>
+					<th>Detail</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each items as it (it.id)}
+					{@const o = outcomeIcon(it.outcome)}
+					<tr>
+						<td>{format.datetime(it.createdAt)}</td>
+						<td>
+							<i class="fa-solid {o.icon} {o.cls}" title={o.title}></i>
+							{o.title}
+						</td>
+						<td>
+							{it.actor.email}
+							{#if it.actor.type === 'ServiceAccount'}
+								<small class="_cl-content-2">(service account)</small>
+							{/if}
+						</td>
+						<td><code>{it.action}</code></td>
+						<td>
+							{#if it.resource.type}
+								<strong>{it.resource.type}</strong>
+								{#if it.resource.name}
+									/ {it.resource.name}
+								{/if}
+								{#if it.resource.locationId}
+									<small class="_cl-content-2">@ {it.resource.locationId}</small>
+								{/if}
+							{/if}
+						</td>
+						<td>
+							{#if it.detail}
+								<span class="_cl-content-2">{it.detail}</span>
+							{/if}
+						</td>
+					</tr>
+				{/each}
+				<NoDataRow span={6} list={items} />
+				<ErrorRow span={6} {error} />
+			</tbody>
+		</table>
+	</div>
+</div>

--- a/src/routes/(auth)/(project)/audit-log/+page.svelte
+++ b/src/routes/(auth)/(project)/audit-log/+page.svelte
@@ -108,10 +108,18 @@
 </script>
 
 <style lang="scss">
-	.filter-grid {
+	.filter-row {
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+		grid-template-columns: repeat(3, 1fr);
 		gap: 1rem;
+
+		@media (max-width: 768px) {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.actor-row {
+		margin-top: 1rem;
 	}
 
 	.filter-actions {
@@ -291,7 +299,7 @@
 <br>
 <div class="nm-panel is-level-300">
 	<form onsubmit={apply}>
-		<div class="filter-grid">
+		<div class="filter-row">
 			<div class="nm-field">
 				<label class="nm-label" for="filter-resource-type">Resource type</label>
 				<div class="nm-select">
@@ -301,13 +309,6 @@
 							<option value={t.value}>{t.label}</option>
 						{/each}
 					</select>
-				</div>
-			</div>
-			<div class="nm-field">
-				<label class="nm-label" for="filter-actor">Actor</label>
-				<div class="nm-input">
-					<input id="filter-actor" type="text" placeholder="email or service account"
-						bind:value={form.actor}>
 				</div>
 			</div>
 			<div class="nm-field">
@@ -348,6 +349,15 @@
 						{/if}
 					</button>
 				</DatePicker>
+			</div>
+		</div>
+		<div class="actor-row">
+			<div class="nm-field">
+				<label class="nm-label" for="filter-actor">Actor</label>
+				<div class="nm-input">
+					<input id="filter-actor" type="text" placeholder="email or service account"
+						bind:value={form.actor}>
+				</div>
 			</div>
 		</div>
 

--- a/src/routes/(auth)/(project)/audit-log/+page.svelte
+++ b/src/routes/(auth)/(project)/audit-log/+page.svelte
@@ -2,6 +2,7 @@
 	import { untrack } from 'svelte'
 	import { SvelteURLSearchParams } from 'svelte/reactivity'
 	import { goto } from '$app/navigation'
+	import { DateInput } from 'date-picker-svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import * as format from '$lib/format'
@@ -12,7 +13,34 @@
 	const items = $derived(data.items)
 	const error = $derived(data.error)
 
-	const form = $state(untrack(() => ({ ...data.filters })))
+	const RESOURCE_TYPES = [
+		{ value: 'deployment', label: 'Deployment' },
+		{ value: 'disk', label: 'Disk' },
+		{ value: 'domain', label: 'Domain' },
+		{ value: 'pullSecret', label: 'Pull Secret' },
+		{ value: 'role', label: 'Role' },
+		{ value: 'serviceAccount', label: 'Service Account' }
+	]
+	const LIMIT_OPTIONS = [25, 50, 100]
+
+	/**
+	 * @param {string} v
+	 * @returns {Date | null}
+	 */
+	function parseDate (v) {
+		if (!v) return null
+		const d = new Date(v)
+		return isNaN(d.getTime()) ? null : d
+	}
+
+	const form = $state(untrack(() => ({
+		resourceType: data.filters.resourceType,
+		actor: data.filters.actor,
+		outcome: data.filters.outcome,
+		after: parseDate(data.filters.after),
+		before: parseDate(data.filters.before),
+		limit: data.filters.limit
+	})))
 
 	let applying = $state(false)
 
@@ -29,8 +57,8 @@
 			if (form.resourceType) q.set('resourceType', form.resourceType)
 			if (form.actor) q.set('actor', form.actor)
 			if (form.outcome) q.set('outcome', form.outcome)
-			if (form.after) q.set('after', form.after)
-			if (form.before) q.set('before', form.before)
+			if (form.after) q.set('after', form.after.toISOString())
+			if (form.before) q.set('before', form.before.toISOString())
 			if (form.limit && form.limit !== 50) q.set('limit', String(form.limit))
 			await goto(`/audit-log?${q.toString()}`, { keepFocus: true })
 		} finally {
@@ -45,8 +73,8 @@
 			form.resourceType = ''
 			form.actor = ''
 			form.outcome = ''
-			form.after = ''
-			form.before = ''
+			form.after = null
+			form.before = null
 			form.limit = 50
 			await goto(`/audit-log?project=${project}`, { keepFocus: true })
 		} finally {
@@ -129,6 +157,44 @@
 		color: hsl(var(--hsl-content)/0.7);
 		vertical-align: middle;
 	}
+
+	.date-field :global(.date-time-field) {
+		width: 100%;
+	}
+
+	.date-field :global(.date-time-field input) {
+		width: 100%;
+		min-height: var(--form-element-height, 2.25rem);
+		padding: 0 0.625rem;
+		border: 1px solid hsl(var(--hsl-content)/0.15);
+		border-radius: var(--form-element-border-radius, 0.25rem);
+		background: transparent;
+		color: hsl(var(--hsl-content));
+		font: inherit;
+		transition: border-color 0.16s ease-in-out, box-shadow 0.16s ease-in-out;
+
+		&:hover {
+			border-color: hsl(var(--hsl-content)/0.25);
+		}
+
+		&:focus {
+			outline: none;
+			border-color: hsl(var(--hsl-primary));
+			box-shadow: 0 0 0 0.175rem hsl(var(--hsl-primary)/0.3);
+		}
+	}
+
+	.date-field :global(.date-time-picker) {
+		background: hsl(var(--hsl-base-200));
+		color: hsl(var(--hsl-content));
+		border: 1px solid hsl(var(--hsl-content)/0.15);
+		--date-picker-background: hsl(var(--hsl-base-200));
+		--date-picker-foreground: hsl(var(--hsl-content));
+		--date-picker-highlight-border: hsl(var(--hsl-primary));
+		--date-picker-highlight-shadow: hsl(var(--hsl-primary)/0.3);
+		--date-picker-selected-color: hsl(var(--hsl-primary-content));
+		--date-picker-selected-background: hsl(var(--hsl-primary));
+	}
 </style>
 
 <h6>Audit Logs</h6>
@@ -138,9 +204,13 @@
 		<div class="filter-grid">
 			<div class="nm-field">
 				<label class="nm-label" for="filter-resource-type">Resource type</label>
-				<div class="nm-input">
-					<input id="filter-resource-type" type="text" placeholder="e.g. deployment"
-						bind:value={form.resourceType}>
+				<div class="nm-select">
+					<select id="filter-resource-type" bind:value={form.resourceType}>
+						<option value="">All</option>
+						{#each RESOURCE_TYPES as t (t.value)}
+							<option value={t.value}>{t.label}</option>
+						{/each}
+					</select>
 				</div>
 			</div>
 			<div class="nm-field">
@@ -160,23 +230,24 @@
 					</select>
 				</div>
 			</div>
-			<div class="nm-field">
+			<div class="nm-field date-field">
 				<label class="nm-label" for="filter-after">After</label>
-				<div class="nm-input">
-					<input id="filter-after" type="datetime-local" bind:value={form.after}>
-				</div>
+				<DateInput id="filter-after" bind:value={form.after}
+					format="yyyy-MM-dd HH:mm" placeholder="From" closeOnSelection={true} />
 			</div>
-			<div class="nm-field">
+			<div class="nm-field date-field">
 				<label class="nm-label" for="filter-before">Before</label>
-				<div class="nm-input">
-					<input id="filter-before" type="datetime-local" bind:value={form.before}>
-				</div>
+				<DateInput id="filter-before" bind:value={form.before}
+					format="yyyy-MM-dd HH:mm" placeholder="To" closeOnSelection={true} />
 			</div>
 			<div class="nm-field">
 				<label class="nm-label" for="filter-limit">Limit</label>
-				<div class="nm-input">
-					<input id="filter-limit" type="number" min="1" max="100"
-						bind:value={form.limit}>
+				<div class="nm-select">
+					<select id="filter-limit" bind:value={form.limit}>
+						{#each LIMIT_OPTIONS as n (n)}
+							<option value={n}>{n}</option>
+						{/each}
+					</select>
 				</div>
 			</div>
 		</div>

--- a/src/routes/(auth)/(project)/audit-log/+page.svelte
+++ b/src/routes/(auth)/(project)/audit-log/+page.svelte
@@ -176,6 +176,8 @@
 	}
 
 	:global(.datepicker[data-picker-theme='audit-log-dp']) {
+		--range-tint: hsl(var(--hsl-primary) / 0.22);
+
 		--datepicker-container-background: hsl(var(--hsl-base-200));
 		--datepicker-container-border: 1px solid hsl(var(--hsl-content)/0.2);
 		--datepicker-color: hsl(var(--hsl-content));
@@ -203,15 +205,21 @@
 		--datepicker-calendar-today-background: transparent;
 
 		--datepicker-calendar-range-color: hsl(var(--hsl-content));
-		--datepicker-calendar-range-background: hsl(var(--hsl-primary)/0.18);
-		--datepicker-calendar-range-included-background: hsl(var(--hsl-primary)/0.18);
+		--datepicker-calendar-range-background: var(--range-tint);
+		--datepicker-calendar-range-background-disabled: var(--range-tint);
+
+		--datepicker-calendar-range-included-background: var(--range-tint);
 		--datepicker-calendar-range-included-color: hsl(var(--hsl-content));
-		--datepicker-calendar-range-included-box-shadow: inset 20px 0 0 hsl(var(--hsl-primary)/0.18);
-		--datepicker-calendar-range-start-box-shadow: inset -20px 0 0 hsl(var(--hsl-primary)/0.18);
-		--datepicker-calendar-range-end-box-shadow: inset 20px 0 0 hsl(var(--hsl-primary)/0.18);
+		--datepicker-calendar-range-included-box-shadow: inset 20px 0 0 var(--range-tint);
+
+		--datepicker-calendar-range-start-box-shadow: inset -20px 0 0 var(--range-tint);
+		--datepicker-calendar-range-end-box-shadow: inset 20px 0 0 var(--range-tint);
+		--datepicker-calendar-range-start-box-shadow-selected: inset -20px 0 0 var(--range-tint);
+		--datepicker-calendar-range-end-box-shadow-selected: inset 20px 0 0 var(--range-tint);
+
 		--datepicker-calendar-range-selected-background: hsl(var(--hsl-primary));
 		--datepicker-calendar-range-selected-color: hsl(var(--hsl-primary-content));
-		--datepicker-calendar-range-start-end-background: hsl(var(--hsl-content)/0.1);
+		--datepicker-calendar-range-start-end-background: var(--range-tint);
 		--datepicker-calendar-range-start-end-color: hsl(var(--hsl-content));
 
 		--datepicker-calendar-split-border: 1px solid hsl(var(--hsl-content)/0.12);

--- a/src/routes/(auth)/(project)/audit-log/+page.svelte
+++ b/src/routes/(auth)/(project)/audit-log/+page.svelte
@@ -14,47 +14,128 @@
 
 	const form = $state(untrack(() => ({ ...data.filters })))
 
+	let applying = $state(false)
+
 	/**
 	 * @param {Event} e
 	 */
 	async function apply (e) {
 		e.preventDefault()
-		const q = new SvelteURLSearchParams()
-		q.set('project', project)
-		if (form.resourceType) q.set('resourceType', form.resourceType)
-		if (form.actor) q.set('actor', form.actor)
-		if (form.outcome) q.set('outcome', form.outcome)
-		if (form.after) q.set('after', form.after)
-		if (form.before) q.set('before', form.before)
-		if (form.limit && form.limit !== 50) q.set('limit', String(form.limit))
-		await goto(`/audit-log?${q.toString()}`, { keepFocus: true })
+		if (applying) return
+		applying = true
+		try {
+			const q = new SvelteURLSearchParams()
+			q.set('project', project)
+			if (form.resourceType) q.set('resourceType', form.resourceType)
+			if (form.actor) q.set('actor', form.actor)
+			if (form.outcome) q.set('outcome', form.outcome)
+			if (form.after) q.set('after', form.after)
+			if (form.before) q.set('before', form.before)
+			if (form.limit && form.limit !== 50) q.set('limit', String(form.limit))
+			await goto(`/audit-log?${q.toString()}`, { keepFocus: true })
+		} finally {
+			applying = false
+		}
 	}
 
-	function reset () {
-		form.resourceType = ''
-		form.actor = ''
-		form.outcome = ''
-		form.after = ''
-		form.before = ''
-		form.limit = 50
-		goto(`/audit-log?project=${project}`, { keepFocus: true })
+	async function reset () {
+		if (applying) return
+		applying = true
+		try {
+			form.resourceType = ''
+			form.actor = ''
+			form.outcome = ''
+			form.after = ''
+			form.before = ''
+			form.limit = 50
+			await goto(`/audit-log?project=${project}`, { keepFocus: true })
+		} finally {
+			applying = false
+		}
 	}
 
 	/**
 	 * @param {Api.AuditOutcome} o
 	 */
-	function outcomeIcon (o) {
-		if (o === 'success') return { icon: 'fa-circle-check', cls: '_cl-positive', title: 'Success' }
-		if (o === 'failure') return { icon: 'fa-circle-xmark', cls: '_cl-negative', title: 'Failure' }
-		return { icon: 'fa-circle', cls: '', title: o }
+	function outcomeBadge (o) {
+		if (o === 'success') return { icon: 'fa-circle-check', cls: 'is-positive', label: 'Success' }
+		if (o === 'failure') return { icon: 'fa-circle-xmark', cls: 'is-negative', label: 'Failure' }
+		return { icon: 'fa-circle', cls: '', label: o }
 	}
 </script>
+
+<style lang="scss">
+	.filter-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+		gap: 1rem;
+	}
+
+	.filter-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 0.5rem;
+		margin-top: 1rem;
+	}
+
+	.outcome-badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		padding: 0.15rem 0.55rem;
+		border-radius: 999px;
+		font-size: 0.8125rem;
+		line-height: 1.25;
+		background: hsl(var(--hsl-content)/0.08);
+
+		&.is-positive {
+			color: hsl(var(--hsl-positive));
+			background: hsl(var(--hsl-positive)/0.12);
+		}
+
+		&.is-negative {
+			color: hsl(var(--hsl-negative));
+			background: hsl(var(--hsl-negative)/0.12);
+		}
+	}
+
+	.action-cell {
+		font-family: var(--font-family-mono, ui-monospace, monospace);
+		font-size: 0.8125rem;
+		color: hsl(var(--hsl-content)/0.85);
+	}
+
+	.resource-name {
+		color: hsl(var(--hsl-content)/0.65);
+	}
+
+	.resource-location {
+		color: hsl(var(--hsl-content)/0.55);
+		font-size: 0.8125rem;
+		margin-left: 0.25rem;
+	}
+
+	.detail-text {
+		color: hsl(var(--hsl-content)/0.75);
+	}
+
+	.actor-tag {
+		display: inline-block;
+		margin-left: 0.25rem;
+		padding: 0.05rem 0.4rem;
+		border-radius: 4px;
+		font-size: 0.7rem;
+		background: hsl(var(--hsl-content)/0.08);
+		color: hsl(var(--hsl-content)/0.7);
+		vertical-align: middle;
+	}
+</style>
 
 <h6>Audit Logs</h6>
 <br>
 <div class="nm-panel is-level-300">
-	<form class="lo-grid _g-5" onsubmit={apply}>
-		<div class="lo-12 lo-6:md lo-4:lg _g-5">
+	<form onsubmit={apply}>
+		<div class="filter-grid">
 			<div class="nm-field">
 				<label class="nm-label" for="filter-resource-type">Resource type</label>
 				<div class="nm-input">
@@ -62,8 +143,6 @@
 						bind:value={form.resourceType}>
 				</div>
 			</div>
-		</div>
-		<div class="lo-12 lo-6:md lo-4:lg _g-5">
 			<div class="nm-field">
 				<label class="nm-label" for="filter-actor">Actor</label>
 				<div class="nm-input">
@@ -71,8 +150,6 @@
 						bind:value={form.actor}>
 				</div>
 			</div>
-		</div>
-		<div class="lo-12 lo-6:md lo-4:lg _g-5">
 			<div class="nm-field">
 				<label class="nm-label" for="filter-outcome">Outcome</label>
 				<div class="nm-select">
@@ -83,24 +160,18 @@
 					</select>
 				</div>
 			</div>
-		</div>
-		<div class="lo-12 lo-6:md lo-4:lg _g-5">
 			<div class="nm-field">
 				<label class="nm-label" for="filter-after">After</label>
 				<div class="nm-input">
 					<input id="filter-after" type="datetime-local" bind:value={form.after}>
 				</div>
 			</div>
-		</div>
-		<div class="lo-12 lo-6:md lo-4:lg _g-5">
 			<div class="nm-field">
 				<label class="nm-label" for="filter-before">Before</label>
 				<div class="nm-input">
 					<input id="filter-before" type="datetime-local" bind:value={form.before}>
 				</div>
 			</div>
-		</div>
-		<div class="lo-12 lo-6:md lo-4:lg _g-5">
 			<div class="nm-field">
 				<label class="nm-label" for="filter-limit">Limit</label>
 				<div class="nm-input">
@@ -109,9 +180,11 @@
 				</div>
 			</div>
 		</div>
-		<div class="lo-12 _dp-f _jtfct-fe _g-4">
-			<button type="button" class="nm-button is-variant-ghost" onclick={reset}>Reset</button>
-			<button type="submit" class="nm-button">Apply</button>
+
+		<div class="filter-actions">
+			<button type="button" class="nm-button is-variant-secondary"
+				onclick={reset} disabled={applying}>Reset</button>
+			<button type="submit" class="nm-button" class:is-loading={applying}>Apply</button>
 		</div>
 	</form>
 
@@ -129,34 +202,36 @@
 			</thead>
 			<tbody>
 				{#each items as it (it.id)}
-					{@const o = outcomeIcon(it.outcome)}
+					{@const o = outcomeBadge(it.outcome)}
 					<tr>
 						<td>{format.datetime(it.createdAt)}</td>
 						<td>
-							<i class="fa-solid {o.icon} {o.cls}" title={o.title}></i>
-							{o.title}
+							<span class="outcome-badge {o.cls}" title={o.label}>
+								<i class="fa-solid {o.icon}"></i>
+								{o.label}
+							</span>
 						</td>
 						<td>
 							{it.actor.email}
 							{#if it.actor.type === 'ServiceAccount'}
-								<small class="_cl-content-2">(service account)</small>
+								<span class="actor-tag">service account</span>
 							{/if}
 						</td>
-						<td><code>{it.action}</code></td>
+						<td><span class="action-cell">{it.action}</span></td>
 						<td>
 							{#if it.resource.type}
 								<strong>{it.resource.type}</strong>
 								{#if it.resource.name}
-									/ {it.resource.name}
+									<span class="resource-name">/ {it.resource.name}</span>
 								{/if}
 								{#if it.resource.locationId}
-									<small class="_cl-content-2">@ {it.resource.locationId}</small>
+									<span class="resource-location">@ {it.resource.locationId}</span>
 								{/if}
 							{/if}
 						</td>
 						<td>
 							{#if it.detail}
-								<span class="_cl-content-2">{it.detail}</span>
+								<span class="detail-text">{it.detail}</span>
 							{/if}
 						</td>
 					</tr>

--- a/src/routes/(auth)/(project)/audit-log/+page.svelte
+++ b/src/routes/(auth)/(project)/audit-log/+page.svelte
@@ -22,7 +22,6 @@
 		{ value: 'role', label: 'Role' },
 		{ value: 'serviceAccount', label: 'Service Account' }
 	]
-	const LIMIT_OPTIONS = [10, 25, 50, 100]
 
 	/**
 	 * @param {string} v
@@ -39,8 +38,7 @@
 		actor: data.filters.actor,
 		outcome: data.filters.outcome,
 		startDate: parseDate(data.filters.after),
-		endDate: parseDate(data.filters.before),
-		limit: data.filters.limit
+		endDate: parseDate(data.filters.before)
 	})))
 
 	let isDatePickerOpen = $state(false)
@@ -78,7 +76,6 @@
 			if (form.outcome) q.set('outcome', form.outcome)
 			if (form.startDate) q.set('after', new Date(form.startDate).toISOString())
 			if (form.endDate) q.set('before', new Date(form.endDate).toISOString())
-			if (form.limit && form.limit !== 50) q.set('limit', String(form.limit))
 			await goto(`/audit-log?${q.toString()}`, { keepFocus: true })
 		} finally {
 			applying = false
@@ -94,7 +91,6 @@
 			form.outcome = ''
 			form.startDate = null
 			form.endDate = null
-			form.limit = 50
 			await goto(`/audit-log?project=${project}`, { keepFocus: true })
 		} finally {
 			applying = false
@@ -181,24 +177,53 @@
 
 	:global(.datepicker[data-picker-theme='audit-log-dp']) {
 		--datepicker-container-background: hsl(var(--hsl-base-200));
-		--datepicker-container-border: 1px solid hsl(var(--hsl-content)/0.15);
+		--datepicker-container-border: 1px solid hsl(var(--hsl-content)/0.2);
 		--datepicker-color: hsl(var(--hsl-content));
 		--datepicker-border-color: hsl(var(--hsl-content)/0.15);
 		--datepicker-state-active: hsl(var(--hsl-primary));
-		--datepicker-state-hover: hsl(var(--hsl-content)/0.08);
+		--datepicker-state-hover: hsl(var(--hsl-content)/0.1);
+
 		--datepicker-calendar-header-color: hsl(var(--hsl-content));
-		--datepicker-calendar-dow-color: hsl(var(--hsl-content)/0.7);
-		--datepicker-calendar-day-color: hsl(var(--hsl-content));
-		--datepicker-calendar-day-color-disabled: hsl(var(--hsl-content)/0.3);
-		--datepicker-calendar-range-selected-background: hsl(var(--hsl-primary)/0.18);
-		--datepicker-calendar-range-selected-color: hsl(var(--hsl-content));
+		--datepicker-calendar-header-text-color: hsl(var(--hsl-content));
 		--datepicker-calendar-header-month-nav-color: hsl(var(--hsl-content));
-		--datepicker-calendar-header-month-nav-background-hover: hsl(var(--hsl-content)/0.08);
-		--datepicker-calendar-split-border: 1px solid hsl(var(--hsl-content)/0.1);
-		--datepicker-calendar-presets-background: hsl(var(--hsl-base-300));
-		--datepicker-calendar-presets-button-color: hsl(var(--hsl-content));
-		--datepicker-calendar-presets-button-background: transparent;
-		--datepicker-calendar-presets-button-background-hover: hsl(var(--hsl-content)/0.08);
+		--datepicker-calendar-header-month-nav-background-hover: hsl(var(--hsl-content)/0.1);
+		--datepicker-calendar-header-month-nav-icon-next-filter: invert(1);
+		--datepicker-calendar-header-month-nav-icon-prev-filter: invert(1);
+		--datepicker-calendar-header-year-nav-icon-next-filter: invert(1);
+		--datepicker-calendar-header-year-nav-icon-prev-filter: invert(1);
+
+		--datepicker-calendar-dow-color: hsl(var(--hsl-content)/0.65);
+		--datepicker-calendar-day-color: hsl(var(--hsl-content));
+		--datepicker-calendar-day-color-hover: hsl(var(--hsl-content));
+		--datepicker-calendar-day-background-hover: hsl(var(--hsl-content)/0.1);
+		--datepicker-calendar-day-color-disabled: hsl(var(--hsl-content)/0.35);
+		--datepicker-calendar-day-other-color: hsl(var(--hsl-content)/0.35);
+
+		--datepicker-calendar-today-border: 1px solid hsl(var(--hsl-primary));
+		--datepicker-calendar-today-background: transparent;
+
+		--datepicker-calendar-range-color: hsl(var(--hsl-content));
+		--datepicker-calendar-range-background: hsl(var(--hsl-primary)/0.18);
+		--datepicker-calendar-range-included-background: hsl(var(--hsl-primary)/0.18);
+		--datepicker-calendar-range-included-color: hsl(var(--hsl-content));
+		--datepicker-calendar-range-included-box-shadow: inset 20px 0 0 hsl(var(--hsl-primary)/0.18);
+		--datepicker-calendar-range-start-box-shadow: inset -20px 0 0 hsl(var(--hsl-primary)/0.18);
+		--datepicker-calendar-range-end-box-shadow: inset 20px 0 0 hsl(var(--hsl-primary)/0.18);
+		--datepicker-calendar-range-selected-background: hsl(var(--hsl-primary));
+		--datepicker-calendar-range-selected-color: hsl(var(--hsl-primary-content));
+		--datepicker-calendar-range-start-end-background: hsl(var(--hsl-content)/0.1);
+		--datepicker-calendar-range-start-end-color: hsl(var(--hsl-content));
+
+		--datepicker-calendar-split-border: 1px solid hsl(var(--hsl-content)/0.12);
+
+		--datepicker-presets-border: 1px solid hsl(var(--hsl-content)/0.12);
+		--datepicker-presets-button-color: hsl(var(--hsl-content));
+		--datepicker-presets-button-color-hover: hsl(var(--hsl-content));
+		--datepicker-presets-button-color-focus: hsl(var(--hsl-content));
+		--datepicker-presets-button-color-active: hsl(var(--hsl-primary-content));
+		--datepicker-presets-button-background: transparent;
+		--datepicker-presets-button-background-hover: hsl(var(--hsl-content)/0.1);
+		--datepicker-presets-button-background-active: hsl(var(--hsl-primary));
 	}
 
 	.outcome-badge {
@@ -315,16 +340,6 @@
 						{/if}
 					</button>
 				</DatePicker>
-			</div>
-			<div class="nm-field">
-				<label class="nm-label" for="filter-limit">Limit</label>
-				<div class="nm-select">
-					<select id="filter-limit" bind:value={form.limit}>
-						{#each LIMIT_OPTIONS as n (n)}
-							<option value={n}>{n}</option>
-						{/each}
-					</select>
-				</div>
 			</div>
 		</div>
 

--- a/src/routes/(auth)/(project)/audit-log/+page.svelte
+++ b/src/routes/(auth)/(project)/audit-log/+page.svelte
@@ -2,7 +2,8 @@
 	import { untrack } from 'svelte'
 	import { SvelteURLSearchParams } from 'svelte/reactivity'
 	import { goto } from '$app/navigation'
-	import { DateInput } from 'date-picker-svelte'
+	import { DatePicker } from '@svelte-plugins/datepicker'
+	import dayjs from 'dayjs'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import * as format from '$lib/format'
@@ -21,7 +22,7 @@
 		{ value: 'role', label: 'Role' },
 		{ value: 'serviceAccount', label: 'Service Account' }
 	]
-	const LIMIT_OPTIONS = [25, 50, 100]
+	const LIMIT_OPTIONS = [10, 25, 50, 100]
 
 	/**
 	 * @param {string} v
@@ -37,12 +38,30 @@
 		resourceType: data.filters.resourceType,
 		actor: data.filters.actor,
 		outcome: data.filters.outcome,
-		after: parseDate(data.filters.after),
-		before: parseDate(data.filters.before),
+		startDate: parseDate(data.filters.after),
+		endDate: parseDate(data.filters.before),
 		limit: data.filters.limit
 	})))
 
+	let isDatePickerOpen = $state(false)
 	let applying = $state(false)
+
+	const dateRangeLabel = $derived.by(() => {
+		const s = form.startDate ? dayjs(form.startDate).format('YYYY-MM-DD') : ''
+		const e = form.endDate ? dayjs(form.endDate).format('YYYY-MM-DD') : ''
+		if (!s && !e) return ''
+		return `${s || '…'}  →  ${e || '…'}`
+	})
+
+	function toggleDatePicker () {
+		isDatePickerOpen = !isDatePickerOpen
+	}
+
+	function clearDateRange (e) {
+		e.stopPropagation()
+		form.startDate = null
+		form.endDate = null
+	}
 
 	/**
 	 * @param {Event} e
@@ -57,8 +76,8 @@
 			if (form.resourceType) q.set('resourceType', form.resourceType)
 			if (form.actor) q.set('actor', form.actor)
 			if (form.outcome) q.set('outcome', form.outcome)
-			if (form.after) q.set('after', form.after.toISOString())
-			if (form.before) q.set('before', form.before.toISOString())
+			if (form.startDate) q.set('after', new Date(form.startDate).toISOString())
+			if (form.endDate) q.set('before', new Date(form.endDate).toISOString())
 			if (form.limit && form.limit !== 50) q.set('limit', String(form.limit))
 			await goto(`/audit-log?${q.toString()}`, { keepFocus: true })
 		} finally {
@@ -73,8 +92,8 @@
 			form.resourceType = ''
 			form.actor = ''
 			form.outcome = ''
-			form.after = null
-			form.before = null
+			form.startDate = null
+			form.endDate = null
 			form.limit = 50
 			await goto(`/audit-log?project=${project}`, { keepFocus: true })
 		} finally {
@@ -104,6 +123,82 @@
 		justify-content: flex-end;
 		gap: 0.5rem;
 		margin-top: 1rem;
+	}
+
+	.date-range-trigger {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		width: 100%;
+		min-height: var(--form-element-height, 2.25rem);
+		padding: 0 0.625rem;
+		border: 1px solid hsl(var(--hsl-content)/0.15);
+		border-radius: var(--form-element-border-radius, 0.25rem);
+		background: transparent;
+		color: hsl(var(--hsl-content));
+		font: inherit;
+		text-align: left;
+		cursor: pointer;
+		transition: border-color 0.16s ease-in-out, box-shadow 0.16s ease-in-out;
+
+		&:hover {
+			border-color: hsl(var(--hsl-content)/0.25);
+		}
+
+		&:focus-visible {
+			outline: none;
+			border-color: hsl(var(--hsl-primary));
+			box-shadow: 0 0 0 0.175rem hsl(var(--hsl-primary)/0.3);
+		}
+
+		.placeholder {
+			color: hsl(var(--hsl-content)/0.5);
+		}
+
+		.value {
+			flex: 1;
+		}
+
+		.icon-clear {
+			display: inline-flex;
+			padding: 0.2rem;
+			border-radius: 4px;
+			color: hsl(var(--hsl-content)/0.6);
+			background: transparent;
+			border: 0;
+			cursor: pointer;
+
+			&:hover {
+				color: hsl(var(--hsl-content));
+				background: hsl(var(--hsl-content)/0.08);
+			}
+		}
+
+		.icon-cal {
+			color: hsl(var(--hsl-content)/0.5);
+		}
+	}
+
+	:global(.datepicker[data-picker-theme='audit-log-dp']) {
+		--datepicker-container-background: hsl(var(--hsl-base-200));
+		--datepicker-container-border: 1px solid hsl(var(--hsl-content)/0.15);
+		--datepicker-color: hsl(var(--hsl-content));
+		--datepicker-border-color: hsl(var(--hsl-content)/0.15);
+		--datepicker-state-active: hsl(var(--hsl-primary));
+		--datepicker-state-hover: hsl(var(--hsl-content)/0.08);
+		--datepicker-calendar-header-color: hsl(var(--hsl-content));
+		--datepicker-calendar-dow-color: hsl(var(--hsl-content)/0.7);
+		--datepicker-calendar-day-color: hsl(var(--hsl-content));
+		--datepicker-calendar-day-color-disabled: hsl(var(--hsl-content)/0.3);
+		--datepicker-calendar-range-selected-background: hsl(var(--hsl-primary)/0.18);
+		--datepicker-calendar-range-selected-color: hsl(var(--hsl-content));
+		--datepicker-calendar-header-month-nav-color: hsl(var(--hsl-content));
+		--datepicker-calendar-header-month-nav-background-hover: hsl(var(--hsl-content)/0.08);
+		--datepicker-calendar-split-border: 1px solid hsl(var(--hsl-content)/0.1);
+		--datepicker-calendar-presets-background: hsl(var(--hsl-base-300));
+		--datepicker-calendar-presets-button-color: hsl(var(--hsl-content));
+		--datepicker-calendar-presets-button-background: transparent;
+		--datepicker-calendar-presets-button-background-hover: hsl(var(--hsl-content)/0.08);
 	}
 
 	.outcome-badge {
@@ -157,44 +252,6 @@
 		color: hsl(var(--hsl-content)/0.7);
 		vertical-align: middle;
 	}
-
-	.date-field :global(.date-time-field) {
-		width: 100%;
-	}
-
-	.date-field :global(.date-time-field input) {
-		width: 100%;
-		min-height: var(--form-element-height, 2.25rem);
-		padding: 0 0.625rem;
-		border: 1px solid hsl(var(--hsl-content)/0.15);
-		border-radius: var(--form-element-border-radius, 0.25rem);
-		background: transparent;
-		color: hsl(var(--hsl-content));
-		font: inherit;
-		transition: border-color 0.16s ease-in-out, box-shadow 0.16s ease-in-out;
-
-		&:hover {
-			border-color: hsl(var(--hsl-content)/0.25);
-		}
-
-		&:focus {
-			outline: none;
-			border-color: hsl(var(--hsl-primary));
-			box-shadow: 0 0 0 0.175rem hsl(var(--hsl-primary)/0.3);
-		}
-	}
-
-	.date-field :global(.date-time-picker) {
-		background: hsl(var(--hsl-base-200));
-		color: hsl(var(--hsl-content));
-		border: 1px solid hsl(var(--hsl-content)/0.15);
-		--date-picker-background: hsl(var(--hsl-base-200));
-		--date-picker-foreground: hsl(var(--hsl-content));
-		--date-picker-highlight-border: hsl(var(--hsl-primary));
-		--date-picker-highlight-shadow: hsl(var(--hsl-primary)/0.3);
-		--date-picker-selected-color: hsl(var(--hsl-primary-content));
-		--date-picker-selected-background: hsl(var(--hsl-primary));
-	}
 </style>
 
 <h6>Audit Logs</h6>
@@ -230,15 +287,34 @@
 					</select>
 				</div>
 			</div>
-			<div class="nm-field date-field">
-				<label class="nm-label" for="filter-after">After</label>
-				<DateInput id="filter-after" bind:value={form.after}
-					format="yyyy-MM-dd HH:mm" placeholder="From" closeOnSelection={true} />
-			</div>
-			<div class="nm-field date-field">
-				<label class="nm-label" for="filter-before">Before</label>
-				<DateInput id="filter-before" bind:value={form.before}
-					format="yyyy-MM-dd HH:mm" placeholder="To" closeOnSelection={true} />
+			<div class="nm-field">
+				<span class="nm-label">Date range</span>
+				<DatePicker
+					theme="audit-log-dp"
+					bind:isOpen={isDatePickerOpen}
+					bind:startDate={form.startDate}
+					bind:endDate={form.endDate}
+					isRange
+					isMultipane
+					showPresets
+					align="left"
+					includeFont={false}
+				>
+					<button type="button" class="date-range-trigger" onclick={toggleDatePicker}>
+						<i class="fa-regular fa-calendar icon-cal"></i>
+						{#if dateRangeLabel}
+							<span class="value">{dateRangeLabel}</span>
+							<span class="icon-clear" role="button" tabindex="-1"
+								aria-label="Clear date range"
+								onclick={clearDateRange}
+								onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && clearDateRange(e)}>
+								<i class="fa-solid fa-xmark"></i>
+							</span>
+						{:else}
+							<span class="placeholder value">Any time</span>
+						{/if}
+					</button>
+				</DatePicker>
 			</div>
 			<div class="nm-field">
 				<label class="nm-label" for="filter-limit">Limit</label>

--- a/src/routes/(auth)/Sidebar.svelte
+++ b/src/routes/(auth)/Sidebar.svelte
@@ -92,6 +92,12 @@
 			title: 'Registry',
 			icon: 'fa-warehouse-full',
 			link: '/registry'
+		},
+		{
+			id: 'audit-log',
+			title: 'Audit Logs',
+			icon: 'fa-clipboard-list',
+			link: '/audit-log'
 		}
 	]
 </script>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -362,4 +362,30 @@ declare namespace Api {
     export type RepositoryManifestResult =
         List<RepositoryManifest>
         & { name: string }
+
+    export type AuditActorType = 'User' | 'ServiceAccount'
+
+    export type AuditOutcome = 'success' | 'failure'
+
+    export type AuditLogActor = {
+        email: string
+        type: AuditActorType
+    }
+
+    export type AuditLogResource = {
+        type: string
+        id: string
+        name: string
+        locationId: string
+    }
+
+    export type AuditLogItem = {
+        id: number
+        resource: AuditLogResource
+        actor: AuditLogActor
+        action: string
+        outcome: AuditOutcome
+        detail: string
+        createdAt: string
+    }
 }

--- a/tests/audit-log.spec.js
+++ b/tests/audit-log.spec.js
@@ -1,0 +1,45 @@
+import { test, expect, setMocks } from './helpers.js'
+import { sampleAuditLogItem } from './fixtures/mocks.js'
+
+test.describe('audit log', () => {
+	test('lists audit log entries', async ({ page }) => {
+		await setMocks({
+			'auditLog.list': {
+				ok: true,
+				result: { items: [sampleAuditLogItem] }
+			}
+		})
+
+		await page.goto('/audit-log?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Audit Logs' })).toBeVisible()
+		await expect(main.getByText('deployment.deploy')).toBeVisible()
+		await expect(main.getByText('[email protected]')).toBeVisible()
+		await expect(main.getByRole('cell', { name: /Success/ })).toBeVisible()
+		await expect(main.getByText('deployed revision 1')).toBeVisible()
+	})
+
+	test('empty state when no entries', async ({ page }) => {
+		await page.goto('/audit-log?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('No data')).toBeVisible()
+	})
+
+	test('applies filters via query string', async ({ page }) => {
+		await setMocks({
+			'auditLog.list': {
+				ok: true,
+				result: { items: [sampleAuditLogItem] }
+			}
+		})
+
+		await page.goto('/audit-log?project=test-project&resourceType=deployment&actor=user@example.com&outcome=success')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.locator('#filter-resource-type')).toHaveValue('deployment')
+		await expect(main.locator('#filter-actor')).toHaveValue('user@example.com')
+		await expect(main.locator('#filter-outcome')).toHaveValue('success')
+		await expect(main.getByText('deployment.deploy')).toBeVisible()
+	})
+})

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -115,6 +115,10 @@ export function defaultMocks () {
 		'/__registry/getProjectStorage': {
 			ok: true,
 			result: { size: 0 }
+		},
+		'/auditLog.list': {
+			ok: true,
+			result: { items: [] }
 		}
 	}
 }
@@ -264,6 +268,24 @@ export const sampleBillingAccount = {
 export const sampleRepository = {
 	name: 'web',
 	size: 12345678,
+	createdAt: now
+}
+
+export const sampleAuditLogItem = {
+	id: 1,
+	resource: {
+		type: 'deployment',
+		id: 'd-1',
+		name: 'web',
+		locationId: 'gke'
+	},
+	actor: {
+		email: '[email protected]',
+		type: 'User'
+	},
+	action: 'deployment.deploy',
+	outcome: 'success',
+	detail: 'deployed revision 1',
 	createdAt: now
 }
 


### PR DESCRIPTION
## Summary
- New **Audit Logs** page under each project that calls `auditLog.list` with filters for resource type, actor, outcome, and a time window (after/before, limit).
- Filters round-trip through the URL so any filtered view is linkable.
- Sidebar entry + types + Playwright tests added.

## Notes for reviewers
- API: payload uses `outcome` as a string (`""` / `"success"` / `"failure"`) to match the recent `AuditOutcome` enum change in `deploys-app/api` (string instead of int).
- Endpoint name uses camelCase `auditLog.list` to match the existing frontend convention (`pullSecret.list`, `workloadIdentity.list`, etc.). If the server only accepts `auditlog.list`, update the string in `+page.js` and the mock key.
- Files: `src/routes/(auth)/(project)/audit-log/`, sidebar entry in `src/routes/(auth)/Sidebar.svelte`, types in `src/types/api.d.ts`, mocks + spec in `tests/`.

## Test plan
- [x] `bun check` (svelte-check)
- [x] `bun lint`
- [x] `bunx playwright test tests/audit-log.spec.js` (3/3 pass)
- [ ] Manual: visit `/audit-log?project=...`, apply each filter, confirm query string and table render

🤖 Generated with [Claude Code](https://claude.com/claude-code)