### PR TITLE
feat: add env group management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ src/routes/
   auth/                        # sign-in / callback / sign-out (unauthenticated)
   (auth)/                      # layout group — redirects to /auth/signin if no token
     (project)/                 # layout group — requires ?project= param
-      audit-log/ deployment/ disk/ domain/ dropbox/ email/
+      audit-log/ deployment/ disk/ domain/ dropbox/ email/ env-group/
       pull-secret/ registry/ role/ route/
       service-account/ workload-identity/
     billing/

--- a/src/routes/(auth)/(project)/audit-log/+page.svelte
+++ b/src/routes/(auth)/(project)/audit-log/+page.svelte
@@ -18,6 +18,7 @@
 		{ value: 'deployment', label: 'Deployment' },
 		{ value: 'disk', label: 'Disk' },
 		{ value: 'domain', label: 'Domain' },
+		{ value: 'envGroup', label: 'Env Group' },
 		{ value: 'pullSecret', label: 'Pull Secret' },
 		{ value: 'role', label: 'Role' },
 		{ value: 'serviceAccount', label: 'Service Account' }

--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -252,6 +252,30 @@
 	</div>
 </div>
 
+<h6><strong>Env Groups</strong></h6>
+<div class="nm-table-container">
+	<table class="nm-table is-variant-compact" style="--table-data-border-color: none">
+		<thead>
+		<tr>
+			<th>Name</th>
+		</tr>
+		</thead>
+		<tbody>
+		{#each deployment.envGroups || [] as name (name)}
+			<tr>
+				<td>
+					<a class="nm-link" href={`/env-group/create?project=${deployment.project}&name=${name}`}>
+						{name}
+					</a>
+				</td>
+			</tr>
+		{:else}
+			<NoDataRow span={1} />
+		{/each}
+		</tbody>
+	</table>
+</div>
+
 <h6><strong>Environment Variables</strong></h6>
 <div class="nm-table-container">
 	<table class="nm-table is-variant-compact" style="--table-data-border-color: none">

--- a/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
@@ -17,7 +17,8 @@
 	const permission = $state({
 		pullSecrets: true,
 		workloadIdentities: true,
-		disks: true
+		disks: true,
+		envGroups: true
 	})
 
 	/** @type {Api.PullSecret[]} */
@@ -28,6 +29,9 @@
 
 	/** @type {Api.Disk[]} */
 	let disks = $state([])
+
+	/** @type {Api.EnvGroup[]} */
+	let envGroups = $state([])
 
 	const form = $state({
 		location: deployment?.location || '',
@@ -61,6 +65,8 @@
 		},
 		/** @type {{ k: string, v: string }[]} */
 		env: [],
+		/** @type {string[]} */
+		envGroups: [],
 		/** @type {{ k: string, v: string }[]} */
 		mountData: [],
 		/** @type {Api.SidecarForm[]} */
@@ -91,6 +97,7 @@
 		form.maxReplicas = deployment.maxReplicas
 		form.resources = deployment.resources
 		form.env = Object.entries(deployment.env || {}).map(([k, v]) => ({ k, v }))
+		form.envGroups = [...(deployment.envGroups || [])]
 		form.mountData = Object.entries(deployment.mountData || {}).map(([k, v]) => ({ k, v }))
 		form.sidecars = (deployment.sidecars || []).map((s) => {
 			if (s.cloudSqlProxy) {
@@ -178,6 +185,19 @@
 		disks = resp.result.items ?? []
 	}
 
+	async function fetchEnvGroups () {
+		const resp = await api.invoke('envGroup.list', { project }, fetch)
+		if (!resp.ok) {
+			if (resp.error?.forbidden) {
+				permission.envGroups = false
+				return
+			}
+			modal.error({ error: resp.error })
+			return
+		}
+		envGroups = resp.result.items ?? []
+	}
+
 	async function changeLocation () {
 		pullSecrets = []
 		workloadIdentities = []
@@ -206,6 +226,34 @@
 		envText = form.env
 			.map(({ k, v }) => `${k}=${v}`)
 			.join('\n')
+	}
+
+	let envGroupInput = $state('')
+
+	/**
+	 * @param {string} name
+	 */
+	function addEnvGroup (name) {
+		const n = name.trim()
+		if (!n || form.envGroups.includes(n)) return
+		form.envGroups = [...form.envGroups, n]
+	}
+
+	function selectEnvGroupChanged (e) {
+		addEnvGroup(e.target.value)
+		e.target.value = ''
+	}
+
+	function addEnvGroupFromInput () {
+		addEnvGroup(envGroupInput)
+		envGroupInput = ''
+	}
+
+	/**
+	 * @param {string} name
+	 */
+	function removeEnvGroup (name) {
+		form.envGroups = form.envGroups.filter((g) => g !== name)
 	}
 
 	function convertSidecars () {
@@ -283,6 +331,7 @@
 	onMount(() => {
 		changeLocation()
 		parseEnvValue()
+		fetchEnvGroups()
 	})
 </script>
 
@@ -665,6 +714,63 @@
 		<br>
 		<hr>
 		<br>
+
+		<h6><strong>Env Groups</strong></h6>
+		<small class="helper">
+			Env groups are project-scoped sets of environment variables that are merged into the deployment.
+			Variables defined here take precedence over those defined in env groups.
+		</small>
+		{#if permission.envGroups}
+			<div class="nm-field _dp-f">
+				<div class="nm-select">
+					{#key envGroups}
+						<select onchange={selectEnvGroupChanged}>
+							<option value="" disabled selected>Select Env Group</option>
+							{#each envGroups.filter((g) => !form.envGroups.includes(g.name)) as it (it.name)}
+								<option value={it.name}>{it.name}</option>
+							{/each}
+						</select>
+					{/key}
+				</div>
+			</div>
+		{:else}
+			<div class="nm-field _dp-f _g-5">
+				<div class="nm-input _f-1">
+					<input placeholder="Env Group Name" bind:value={envGroupInput}>
+				</div>
+				<button class="nm-button" type="button" onclick={addEnvGroupFromInput}>Add</button>
+			</div>
+			<p class="_fs-1">* You don't have permission to list env groups</p>
+		{/if}
+		<div class="nm-table-container">
+			<table class="nm-table is-variant-compact">
+				<thead>
+					<tr>
+						<th>Name</th>
+						<th class="is-collapse is-align-right"></th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each form.envGroups as name (name)}
+						<tr>
+							<td>{name}</td>
+							<td>
+								<button class="icon-button" type="button" aria-label="Remove env group"
+									onclick={() => removeEnvGroup(name)}>
+									<i class="fa-solid fa-trash-alt"></i>
+								</button>
+							</td>
+						</tr>
+					{:else}
+						<tr>
+							<td colspan="2" class="_tta-c _co-co-50">No env groups</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+
+		<hr>
 
 		<h6><strong>Environment Variables</strong></h6>
 		<div>

--- a/src/routes/(auth)/(project)/env-group/+layout.js
+++ b/src/routes/(auth)/(project)/env-group/+layout.js
@@ -1,0 +1,6 @@
+export function load () {
+	return {
+		menu: 'env-group',
+		overrideRedirect: '/env-group'
+	}
+}

--- a/src/routes/(auth)/(project)/env-group/+page.js
+++ b/src/routes/(auth)/(project)/env-group/+page.js
@@ -1,0 +1,12 @@
+import api from '$lib/api'
+
+export async function load ({ parent, fetch }) {
+	const { project } = await parent()
+
+	/** @type {Api.Response<Api.List<Api.EnvGroup>>} */
+	const res = await api.invoke('envGroup.list', { project }, fetch)
+	return {
+		envGroups: res.result?.items ?? [],
+		error: res.error
+	}
+}

--- a/src/routes/(auth)/(project)/env-group/+page.svelte
+++ b/src/routes/(auth)/(project)/env-group/+page.svelte
@@ -1,0 +1,60 @@
+<script>
+	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import * as format from '$lib/format'
+	import ErrorRow from '$lib/components/ErrorRow.svelte'
+
+	const { data } = $props()
+
+	const project = $derived(data.project)
+	const envGroups = $derived(data.envGroups)
+	const error = $derived(data.error)
+</script>
+
+<h6>Env Groups</h6>
+<br>
+<div class="nm-panel is-level-300">
+	<div class="_dp-f _jtfct-spbtw _alit-ct">
+		<div class="lo-grid-span-horizontal _g-4 _mgl-at">
+			<a class="nm-button" href="/env-group/create?project={project}">
+                Create
+            </a>
+		</div>
+	</div>
+
+	<div class="nm-table-container _mgt-6">
+		<table class="nm-table is-variant-compact">
+			<thead>
+			<tr>
+				<th>Name</th>
+				<th>Variables</th>
+				<th>Created at</th>
+				<th>Created by</th>
+				<th class="is-collapse is-align-right"></th>
+			</tr>
+			</thead>
+			<tbody>
+				{#each envGroups as it (it.name)}
+					<tr>
+						<td>
+							<a class="nm-link" href="/env-group/create?project={project}&name={it.name}">
+								<strong>{it.name}</strong>
+							</a>
+						</td>
+						<td>{Object.keys(it.env ?? {}).length}</td>
+						<td>{format.datetime(it.createdAt)}</td>
+						<td>{it.createdBy}</td>
+						<td>
+							<a href="/env-group/create?project={project}&name={it.name}" aria-label="Edit">
+								<div class="icon-button">
+									<i class="fa-solid fa-pen"></i>
+								</div>
+							</a>
+						</td>
+					</tr>
+				{/each}
+				<NoDataRow span={5} list={envGroups} />
+				<ErrorRow span={5} {error} />
+			</tbody>
+		</table>
+	</div>
+</div>

--- a/src/routes/(auth)/(project)/env-group/create/+page.js
+++ b/src/routes/(auth)/(project)/env-group/create/+page.js
@@ -1,0 +1,24 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+
+export async function load ({ url, parent, fetch }) {
+	const { project } = await parent()
+	const name = url.searchParams.get('name')
+
+	let envGroup = null
+	if (name) {
+		/** @type {Api.Response<Api.EnvGroup>} */
+		const res = await api.invoke('envGroup.get', { project, name }, fetch)
+		if (!res.ok) {
+			if (res.error?.notFound) redirect(302, `/env-group?project=${project}`)
+			error(500, res.error?.message)
+		}
+		if (!res.result) redirect(302, `/env-group?project=${project}`)
+		envGroup = res.result
+	}
+
+	return {
+		menu: 'env-group',
+		envGroup
+	}
+}

--- a/src/routes/(auth)/(project)/env-group/create/+page.svelte
+++ b/src/routes/(auth)/(project)/env-group/create/+page.svelte
@@ -1,0 +1,209 @@
+<script>
+	import { onMount, untrack } from 'svelte'
+	import { goto } from '$app/navigation'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+
+	const { data } = $props()
+
+	const project = $derived(data.project)
+	const envGroup = $derived(data.envGroup)
+
+	const form = $state(untrack(() => ({
+		name: envGroup?.name ?? '',
+		env: Object.entries(envGroup?.env ?? {}).map(([k, v]) => ({ k, v }))
+	})))
+
+	let showEnvText = $state(false)
+	let envText = $state('')
+
+	function parseEnvText () {
+		form.env = envText
+			.split('\n')
+			.filter((t) => t.length > 0)
+			.map((t) => t.split('='))
+			.map(([k, ...v]) => ({ k, v: v.join('=') }))
+	}
+
+	function parseEnvValue () {
+		envText = form.env
+			.map(({ k, v }) => `${k}=${v}`)
+			.join('\n')
+	}
+
+	function deleteItem () {
+		if (!envGroup) return
+
+		modal.confirm({
+			title: `Delete "${envGroup.name}"?`,
+			yes: 'Delete',
+			callback: async () => {
+				const resp = await api.invoke('envGroup.delete', {
+					project,
+					name: envGroup.name
+				}, fetch)
+				if (!resp.ok) {
+					modal.error({ error: resp.error })
+					return
+				}
+				await goto(`/env-group?project=${project}`)
+			}
+		})
+	}
+
+	let saving = $state(false)
+
+	/**
+	 * @param {Event} e
+	 */
+	async function save (e) {
+		e.preventDefault()
+
+		if (saving) {
+			return
+		}
+
+		saving = true
+		try {
+			const env = form.env.reduce((p, x) => {
+				if (x.k) p[x.k] = x.v
+				return p
+			}, {})
+
+			const fn = envGroup ? 'envGroup.update' : 'envGroup.create'
+			const resp = await api.invoke(fn, {
+				project,
+				name: form.name,
+				env
+			}, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+			await goto(`/env-group?project=${project}`)
+		} finally {
+			saving = false
+		}
+	}
+
+	onMount(() => {
+		parseEnvValue()
+	})
+</script>
+
+<div class="nm-breadcrumb">
+	<div class="nm-breadcrumb-item">
+		<a href={`/env-group?project=${project}`} class="nm-link"><h6>Env Groups</h6></a>
+	</div>
+	{#if envGroup}
+		<div class="nm-breadcrumb-item">
+			<h6>{envGroup.name}</h6>
+		</div>
+		<div class="nm-breadcrumb-item">
+			<h6>Update</h6>
+		</div>
+	{:else}
+		<div class="nm-breadcrumb-item">
+			<h6>Create</h6>
+		</div>
+	{/if}
+</div>
+
+<br>
+
+<div class="nm-panel is-level-300 _dp-g _g-6">
+	<div class="lo-12 _g-5">
+		<h3><strong>
+			{#if envGroup}
+				Update env group "{envGroup.name}"
+			{:else}
+				Create new env group
+			{/if}
+		</strong></h3>
+	</div>
+
+	<hr>
+
+	<form class="_dp-g _g-6 _w-100pct" onsubmit={save}>
+		<div class="nm-field">
+			<label for="input-name">Name</label>
+			<div class="nm-input">
+				<input id="input-name" placeholder="name" bind:value={form.name} required readonly={!!envGroup}>
+			</div>
+		</div>
+
+		<br>
+		<hr>
+		<br>
+
+		<h6><strong>Environment Variables</strong></h6>
+		<div>
+			<div class="nm-table-container">
+				<table class="nm-table">
+					<thead>
+						<tr>
+							<th>Key</th>
+							<th class="is-collapse _pd-0"></th>
+							<th>Value</th>
+							<th class="is-collapse is-align-right"></th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each form.env as it, i (i)}
+							<tr>
+								<td>
+									<div class="nm-input">
+										<input bind:value={it.k} placeholder="Variable name" onchange={parseEnvValue}>
+									</div>
+								</td>
+								<td class="_pd-0 _pdl-5">:</td>
+								<td class="_pdl-5">
+									<div class="nm-input">
+										<input bind:value={it.v} placeholder="Value" onchange={parseEnvValue}>
+									</div>
+								</td>
+								<td style="padding: 19px 12px;">
+									<button class="icon-button" type="button" aria-label="Remove an environment variable"
+										onclick={() => { form.env = form.env.filter((_, k) => k !== i); parseEnvValue() }}>
+										<i class="fa-solid fa-trash-alt"></i>
+									</button>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+					<tfoot>
+						<tr>
+							<td colspan="4">
+								<button class="nm-button _dp-f _mg-at" type="button"
+									onclick={() => { form.env = [...form.env, { k: '', v: '' }]; parseEnvValue() }}>
+									<i class="fa-solid fa-plus _mgr-5"></i>
+									<span>Add Variable</span>
+								</button>
+							</td>
+						</tr>
+					</tfoot>
+				</table>
+			</div>
+
+			<button class="nm-button _dp-f _mg-at" type="button" onclick={() => showEnvText = !showEnvText}>
+				{#if showEnvText}Hide{:else}Show{/if}&nbsp;Text Editor
+			</button>
+			{#if showEnvText}
+				<div class="nm-textarea _mgt-5">
+					<textarea rows="20" bind:value={envText} onchange={parseEnvText}></textarea>
+				</div>
+			{/if}
+		</div>
+
+		<hr>
+
+		<div class="_dp-f _g-6">
+			<button class="nm-button" class:is-loading={saving}>
+				{#if envGroup}Update{:else}Create{/if}
+			</button>
+			{#if envGroup}
+				<button class="nm-button" type="button" onclick={deleteItem}>Delete</button>
+			{/if}
+		</div>
+	</form>
+</div>

--- a/src/routes/(auth)/Sidebar.svelte
+++ b/src/routes/(auth)/Sidebar.svelte
@@ -58,6 +58,12 @@
 			link: '/pull-secret'
 		},
 		{
+			id: 'env-group',
+			title: 'Env Groups',
+			icon: 'fa-cog',
+			link: '/env-group'
+		},
+		{
 			id: 'role',
 			title: 'Roles',
 			icon: 'fa-user-tag',

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -294,6 +294,7 @@ declare namespace Api {
         revision: number
         image: string
         env: Env
+        envGroups: string[]
         command: string[]
         args: string[]
         workloadIdentity: string

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -201,6 +201,14 @@ declare namespace Api {
         [key: string]: string
     }
 
+    export type EnvGroup = {
+        project: string
+        name: string
+        env: Env
+        createdAt: string
+        createdBy: string
+    }
+
     export type MountData = {
         [key: string]: string
     }

--- a/tests/deployment.spec.js
+++ b/tests/deployment.spec.js
@@ -151,3 +151,79 @@ test.describe('deployment deploy — sidecars', () => {
 		await expect(main.locator('#input-sidecar-port-0')).toHaveValue('3306')
 	})
 })
+
+test.describe('deployment detail — env groups', () => {
+	test('lists attached env groups with links to their edit page', async ({ page }) => {
+		await setMocks({
+			'deployment.get': {
+				ok: true,
+				result: { ...sampleDeployment, envGroups: ['shared-config', 'secrets'] }
+			},
+			'location.get': { ok: true, result: defaultLocation }
+		})
+
+		await page.goto('/deployment/detail?project=test-project&location=gke&name=web')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Env Groups' })).toBeVisible()
+		await expect(main.getByRole('link', { name: 'shared-config' }))
+			.toHaveAttribute('href', '/env-group/create?project=test-project&name=shared-config')
+		await expect(main.getByRole('link', { name: 'secrets' }))
+			.toHaveAttribute('href', '/env-group/create?project=test-project&name=secrets')
+	})
+
+	test('shows no data when deployment has no env groups', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleDeployment },
+			'location.get': { ok: true, result: defaultLocation }
+		})
+
+		await page.goto('/deployment/detail?project=test-project&location=gke&name=web')
+
+		const main = page.locator('.content-wrapper')
+		const envGroupTable = main.locator('section, div').filter({
+			has: page.getByRole('heading', { name: 'Env Groups' })
+		})
+		await expect(main.getByRole('heading', { name: 'Env Groups' })).toBeVisible()
+		await expect(envGroupTable.getByText('No data').first()).toBeVisible()
+	})
+})
+
+test.describe('deployment deploy — env groups', () => {
+	test('hydrates existing env groups when editing a revision', async ({ page }) => {
+		await setMocks({
+			'deployment.get': {
+				ok: true,
+				result: { ...sampleDeployment, envGroups: ['shared-config'] }
+			},
+			'location.get': { ok: true, result: defaultLocation },
+			'envGroup.list': {
+				ok: true,
+				result: {
+					items: [
+						{
+							project: 'test-project',
+							name: 'shared-config',
+							env: {},
+							createdAt: '2024-01-01T00:00:00Z',
+							createdBy: '[email protected]'
+						},
+						{
+							project: 'test-project',
+							name: 'secrets',
+							env: {},
+							createdAt: '2024-01-01T00:00:00Z',
+							createdBy: '[email protected]'
+						}
+					]
+				}
+			}
+		})
+
+		await page.goto('/deployment/deploy?project=test-project&location=gke&name=web')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Env Groups' })).toBeVisible()
+		await expect(main.getByRole('cell', { name: 'shared-config' })).toBeVisible()
+	})
+})

--- a/tests/env-group.spec.js
+++ b/tests/env-group.spec.js
@@ -1,0 +1,45 @@
+import { test, expect, setMocks } from './helpers.js'
+import { sampleEnvGroup } from './fixtures/mocks.js'
+
+test.describe('env groups', () => {
+	test('lists env groups', async ({ page }) => {
+		await setMocks({
+			'envGroup.list': {
+				ok: true,
+				result: { items: [sampleEnvGroup] }
+			}
+		})
+
+		await page.goto('/env-group?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Env Groups' })).toBeVisible()
+		await expect(main.getByRole('link', { name: 'shared-config' })).toBeVisible()
+		await expect(main.getByRole('cell', { name: '2', exact: true })).toBeVisible()
+	})
+
+	test('empty state when no env groups', async ({ page }) => {
+		await page.goto('/env-group?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('No data')).toBeVisible()
+	})
+
+	test('shows existing env vars on update', async ({ page }) => {
+		await setMocks({
+			'envGroup.get': {
+				ok: true,
+				result: sampleEnvGroup
+			}
+		})
+
+		await page.goto('/env-group/create?project=test-project&name=shared-config')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Update env group "shared-config"' })).toBeVisible()
+		await expect(main.getByRole('textbox', { name: 'Name', exact: true })).toHaveValue('shared-config')
+		await expect(main.locator('input[placeholder="Variable name"]').nth(0)).toHaveValue('LOG_LEVEL')
+		await expect(main.locator('input[placeholder="Value"]').nth(0)).toHaveValue('info')
+		await expect(main.getByRole('button', { name: 'Update' })).toBeVisible()
+		await expect(main.getByRole('button', { name: 'Delete' })).toBeVisible()
+	})
+})

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -135,6 +135,7 @@ export const sampleDeployment = {
 	revision: 1,
 	image: 'nginx:latest',
 	env: {},
+	envGroups: [],
 	command: [],
 	args: [],
 	workloadIdentity: '',

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -108,6 +108,10 @@ export function defaultMocks () {
 			ok: true,
 			result: { items: [] }
 		},
+		'/envGroup.list': {
+			ok: true,
+			result: { items: [] }
+		},
 		'/__registry/list': {
 			ok: true,
 			result: { items: [] }
@@ -247,6 +251,17 @@ export const sampleWorkloadIdentity = {
 	name: 'gsa-binding',
 	gsa: '[email protected]',
 	status: 'success',
+	createdAt: now,
+	createdBy: '[email protected]'
+}
+
+export const sampleEnvGroup = {
+	project: 'test-project',
+	name: 'shared-config',
+	env: {
+		LOG_LEVEL: 'info',
+		FEATURE_FLAG: 'true'
+	},
 	createdAt: now,
 	createdBy: '[email protected]'
 }


### PR DESCRIPTION
## Summary
- Adds a console UI for the `EnvGroup` API (`/Users/acoshift/Projects/deploys-app/api/envgroup.go`): list, create, update, and delete project-scoped env groups.
- New routes under `src/routes/(auth)/(project)/env-group/` — list page plus a single create/update form (mirrors the role pattern). Update sends the full `env` map so the API overrides existing values.
- Reuses the deployment page's env editor pattern (key/value table rows + optional text-area editor).
- Adds an "Env Groups" item to the sidebar between Pull Secrets and Roles (`fa-cog` icon).
- Adds `Api.EnvGroup` to `src/types/api.d.ts`, a `sampleEnvGroup` fixture, default `envGroup.list` mock, and Playwright coverage for list / empty / update-prefill.

## Test plan
- [x] `bun check` clean
- [x] `bun lint` clean
- [x] `bun run build` succeeds
- [x] `bun run test tests/env-group.spec.js` — 3 passed
- [ ] Manually exercise create / update / delete against a live `API_ENDPOINT`

## Notes
- The pre-existing `tests/deployment.spec.js` "add, remove, and cap at two sidecars" failure also fails on `main` and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)