### PR TITLE
chore: disable CDN toggles in domain UI

### DIFF
--- a/src/routes/(auth)/(project)/domain/create/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/create/+page.svelte
@@ -96,7 +96,7 @@
 		</div>
 		<div class="nm-field">
 			<div class="nm-checkbox">
-				<input id="input-cdn" type="checkbox" bind:checked={form.cdn} disabled={!projectInfo.config.domainAllowDisableCdn}>
+				<input id="input-cdn" type="checkbox" bind:checked={form.cdn} disabled>
 				<label for="input-cdn">CDN (DDoS Protection)</label>
 			</div>
 		</div>

--- a/src/routes/(auth)/(project)/domain/create/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/create/+page.svelte
@@ -6,7 +6,6 @@
 	const { data } = $props()
 	const project = $derived(data.project)
 	const locations = $derived(data.locations)
-	const projectInfo = $derived(data.projectInfo)
 
 	const form = $state({
 		domain: '',

--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -439,7 +439,7 @@
 		</div>
 	{:else}
 		<div class="_dp-f _alit-ct _fw-w">
-			<button class="nm-button" onclick={upgradeCdn}>Add CDN (DDoS Protection)</button>
+			<button class="nm-button" onclick={upgradeCdn} disabled>Add CDN (DDoS Protection)</button>
 		</div>
 	{/if}
 


### PR DESCRIPTION
## Summary
- Disable the **Add CDN (DDoS Protection)** button on the domain detail page.
- Disable the **CDN (DDoS Protection)** checkbox on the domain create page (was previously gated on `projectInfo.config.domainAllowDisableCdn`).

Users can no longer opt in to CDN from the console; existing CDN-enabled domains still show the Remove CDN flow on the detail page.

## Test plan
- [ ] Open a project's domain create page and confirm the CDN checkbox is disabled.
- [ ] Open a non-CDN domain's detail page and confirm the Add CDN button is disabled.
- [ ] Open a CDN-enabled domain's detail page and confirm the Remove CDN link is still active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)