### PR TITLE
Remove DDoS Protection text from CDN checkbox in Create Domain page

### DIFF
--- a/src/routes/(auth)/(project)/domain/create/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/create/+page.svelte
@@ -96,7 +96,7 @@
 		<div class="nm-field">
 			<div class="nm-checkbox">
 				<input id="input-cdn" type="checkbox" bind:checked={form.cdn} disabled>
-				<label for="input-cdn">CDN (DDoS Protection)</label>
+				<label for="input-cdn">CDN</label>
 			</div>
 		</div>
 

--- a/src/routes/(auth)/Sidebar.svelte
+++ b/src/routes/(auth)/Sidebar.svelte
@@ -81,7 +81,7 @@
 			icon: 'fa-user-lock',
 			link: '/service-account'
 		},
-{
+		{
 			id: 'dropbox',
 			title: 'Dropbox',
 			icon: 'fa-box-open',


### PR DESCRIPTION
## Summary
- Removed the "(DDoS Protection)" text from the CDN checkbox label on the Create Domain page

## Test plan
- [ ] Open the Create Domain page and verify the CDN checkbox label reads "CDN" only

🤖 Generated with [Claude Code](https://claude.com/claude-code)