### PR TITLE
feat: mutual exclusivity between wildcard and CDN on domain create page

### DIFF
--- a/src/routes/(auth)/(project)/domain/create/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/create/+page.svelte
@@ -89,13 +89,15 @@
 
 		<div class="nm-field">
 			<div class="nm-checkbox">
-				<input id="input-wildcard" type="checkbox" bind:checked={form.wildcard}>
+				<input id="input-wildcard" type="checkbox" bind:checked={form.wildcard} disabled={form.cdn}
+					onchange={() => { if (form.wildcard) form.cdn = false }}>
 				<label for="input-wildcard">Wildcard</label>
 			</div>
 		</div>
 		<div class="nm-field">
 			<div class="nm-checkbox">
-				<input id="input-cdn" type="checkbox" bind:checked={form.cdn} disabled>
+				<input id="input-cdn" type="checkbox" bind:checked={form.cdn} disabled={form.wildcard}
+					onchange={() => { if (form.cdn) form.wildcard = false }}>
 				<label for="input-cdn">CDN</label>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary
- CDN checkbox is no longer disabled by default
- Checking CDN unchecks and disables the Wildcard checkbox
- Checking Wildcard unchecks and disables the CDN checkbox

## Test plan
- [ ] Check CDN → Wildcard becomes unchecked and disabled
- [ ] Check Wildcard → CDN becomes unchecked and disabled
- [ ] Uncheck either → the other becomes enabled again
- [ ] Form submits correctly with either option selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)