### PR TITLE
fix: show zero baseline on deployment metrics charts when no data in range

### DIFF
--- a/src/lib/components/Chart.svelte
+++ b/src/lib/components/Chart.svelte
@@ -124,15 +124,18 @@
 
 	$effect(() => {
 		if (!chart) return
-		const ms = rangeToMs(range)
-		if (ms) {
-			const now = Date.now()
-			chart.xAxis[0].setExtremes(now - ms, now, false)
-		}
+
 		if (series?.length === 0) clear()
 		series?.forEach((s) => {
 			update(s.prefix, s.lines, s.dashStyle, s.color)
 		})
+
+		const ms = rangeToMs(range)
+		if (ms) {
+			const now = Date.now()
+			chart.xAxis[0].update({ min: now - ms, max: now }, false)
+		}
+
 		chart?.redraw()
 	})
 </script>

--- a/src/lib/components/Chart.svelte
+++ b/src/lib/components/Chart.svelte
@@ -122,20 +122,14 @@
 	}
 
 	$effect(() => {
-		// Read reactive deps before any early return so Svelte tracks them.
-		// Without this, if chart is undefined on first run (before onMount),
-		// the effect would never re-run when series or range change.
-		const _series = series
-		const _range = range
 		if (!chart) return
-
-		const ms = rangeToMs(_range)
+		const ms = rangeToMs(range)
 		if (ms) {
 			const now = Date.now()
 			chart.xAxis[0].setExtremes(now - ms, now, false)
 		}
-		if (_series?.length === 0) clear()
-		_series?.forEach((s) => {
+		if (series?.length === 0) clear()
+		series?.forEach((s) => {
 			update(s.prefix, s.lines, s.dashStyle, s.color)
 		})
 		chart?.redraw()

--- a/src/lib/components/Chart.svelte
+++ b/src/lib/components/Chart.svelte
@@ -16,6 +16,7 @@
 	 * @property {string} unit
 	 * @property {Series[]} series
 	 * @property {'line' | 'spline'} [type]
+	 * @property {string} [range]
 	 */
 
 	/** @type {Props} */
@@ -23,7 +24,8 @@
 		title,
 		unit,
 		series,
-		type = 'line'
+		type = 'line',
+		range = ''
 	} = $props()
 
 	/** @type {HTMLDivElement} */
@@ -40,9 +42,12 @@
 				text: title
 			},
 			xAxis: {
-				type: 'datetime'
+				type: 'datetime',
+				showEmpty: true
 			},
 			yAxis: {
+				min: 0,
+				showEmpty: true,
 				labels: {
 					formatter () {
 						return formatter(this.value)
@@ -106,7 +111,23 @@
 		return v
 	}
 
+	/** @param {string} r */
+	function rangeToMs (r) {
+		if (!r) return null
+		const base = r.replace('agg', '')
+		const num = parseInt(base)
+		const unit = base.slice(String(num).length)
+		const multiplier = unit === 'h' ? 60 * 60 * 1000 : 24 * 60 * 60 * 1000
+		return num * multiplier
+	}
+
 	$effect(() => {
+		if (!chart) return
+		const ms = rangeToMs(range)
+		if (ms) {
+			const now = Date.now()
+			chart.xAxis[0].setExtremes(now - ms, now, false)
+		}
 		if (series?.length === 0) clear()
 		series?.forEach((s) => {
 			update(s.prefix, s.lines, s.dashStyle, s.color)

--- a/src/lib/components/Chart.svelte
+++ b/src/lib/components/Chart.svelte
@@ -65,20 +65,21 @@
 
 	function update (name, lines, dashStyle, color) {
 		if (!browser || !chart) return
+		const c = chart
 		if (!lines) lines = []
 
 		lines.forEach((l) => {
 			const lineName = name + ' ' + l.name
 			const data = l.points.map((pt) => [pt[0] * 1000, +pt[1]])
 
-			const s = chart.series?.find((it) => it.name === lineName)
+			const s = c.series?.find((it) => it.name === lineName)
 			// already exists, update
 			if (s) {
 				s.setData(data, false)
 				return
 			}
 
-			chart.addSeries({
+			c.addSeries({
 				type,
 				name: lineName,
 				marker: {

--- a/src/lib/components/Chart.svelte
+++ b/src/lib/components/Chart.svelte
@@ -122,14 +122,20 @@
 	}
 
 	$effect(() => {
+		// Read reactive deps before any early return so Svelte tracks them.
+		// Without this, if chart is undefined on first run (before onMount),
+		// the effect would never re-run when series or range change.
+		const _series = series
+		const _range = range
 		if (!chart) return
-		const ms = rangeToMs(range)
+
+		const ms = rangeToMs(_range)
 		if (ms) {
 			const now = Date.now()
 			chart.xAxis[0].setExtremes(now - ms, now, false)
 		}
-		if (series?.length === 0) clear()
-		series?.forEach((s) => {
+		if (_series?.length === 0) clear()
+		_series?.forEach((s) => {
 			update(s.prefix, s.lines, s.dashStyle, s.color)
 		})
 		chart?.redraw()

--- a/src/lib/components/Chart.svelte
+++ b/src/lib/components/Chart.svelte
@@ -124,18 +124,15 @@
 
 	$effect(() => {
 		if (!chart) return
-
+		const ms = rangeToMs(range)
+		if (ms) {
+			const now = Date.now()
+			chart.xAxis[0].setExtremes(now - ms, now, false)
+		}
 		if (series?.length === 0) clear()
 		series?.forEach((s) => {
 			update(s.prefix, s.lines, s.dashStyle, s.color)
 		})
-
-		const ms = rangeToMs(range)
-		if (ms) {
-			const now = Date.now()
-			chart.xAxis[0].update({ min: now - ms, max: now }, false)
-		}
-
 		chart?.redraw()
 	})
 </script>

--- a/src/lib/components/Chart.svelte
+++ b/src/lib/components/Chart.svelte
@@ -31,8 +31,8 @@
 	/** @type {HTMLDivElement} */
 	let el
 
-	/** @type {import('highcharts').Chart} */
-	let chart
+	/** @type {import('highcharts').Chart | undefined} */
+	let chart = $state.raw(undefined)
 
 	onMount(() => {
 		hc.init()

--- a/src/lib/components/Chart.svelte
+++ b/src/lib/components/Chart.svelte
@@ -124,36 +124,15 @@
 
 	$effect(() => {
 		if (!chart) return
-
+		const ms = rangeToMs(range)
+		if (ms) {
+			const now = Date.now()
+			chart.xAxis[0].setExtremes(now - ms, now, false)
+		}
 		if (series?.length === 0) clear()
 		series?.forEach((s) => {
 			update(s.prefix, s.lines, s.dashStyle, s.color)
 		})
-
-		// Remove stale placeholder (may have been added on a previous run)
-		chart.series?.find((s) => s.name === '__placeholder__')?.remove(false)
-
-		const ms = rangeToMs(range)
-		if (ms) {
-			const now = Date.now()
-			if (chart.series?.length === 0) {
-				// No real data — add an invisible two-point series so Highcharts
-				// renders the axes over the correct time window with a 0 baseline.
-				chart.addSeries({
-					type: 'line',
-					name: '__placeholder__',
-					data: [[now - ms, 0], [now, 0]],
-					showInLegend: false,
-					enableMouseTracking: false,
-					lineWidth: 0,
-					marker: { enabled: false },
-					color: 'transparent'
-				}, false)
-			} else {
-				chart.xAxis[0].setExtremes(now - ms, now, false)
-			}
-		}
-
 		chart?.redraw()
 	})
 </script>

--- a/src/lib/components/Chart.svelte
+++ b/src/lib/components/Chart.svelte
@@ -124,15 +124,36 @@
 
 	$effect(() => {
 		if (!chart) return
-		const ms = rangeToMs(range)
-		if (ms) {
-			const now = Date.now()
-			chart.xAxis[0].setExtremes(now - ms, now, false)
-		}
+
 		if (series?.length === 0) clear()
 		series?.forEach((s) => {
 			update(s.prefix, s.lines, s.dashStyle, s.color)
 		})
+
+		// Remove stale placeholder (may have been added on a previous run)
+		chart.series?.find((s) => s.name === '__placeholder__')?.remove(false)
+
+		const ms = rangeToMs(range)
+		if (ms) {
+			const now = Date.now()
+			if (chart.series?.length === 0) {
+				// No real data — add an invisible two-point series so Highcharts
+				// renders the axes over the correct time window with a 0 baseline.
+				chart.addSeries({
+					type: 'line',
+					name: '__placeholder__',
+					data: [[now - ms, 0], [now, 0]],
+					showInLegend: false,
+					enableMouseTracking: false,
+					lineWidth: 0,
+					marker: { enabled: false },
+					color: 'transparent'
+				}, false)
+			} else {
+				chart.xAxis[0].setExtremes(now - ms, now, false)
+			}
+		}
+
 		chart?.redraw()
 	})
 </script>

--- a/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
@@ -97,9 +97,9 @@
 	</div>
 </div>
 
-<Chart title="vCPU (second)" unit="seconds" series={cpu} />
-<Chart title="Memory (bytes)" unit="bytes" series={memory} />
+<Chart title="vCPU (second)" unit="seconds" series={cpu} range={filter.range} />
+<Chart title="Memory (bytes)" unit="bytes" series={memory} range={filter.range} />
 {#if deployment.type === 'WebService'}
-	<Chart title="Request (rps)" unit="rps" series={request} />
+	<Chart title="Request (rps)" unit="rps" series={request} range={filter.range} />
 {/if}
-<Chart title="Egress (bytes)" unit="bytes" series={egress} />
+<Chart title="Egress (bytes)" unit="bytes" series={egress} range={filter.range} />


### PR DESCRIPTION
## Summary

- When no data exists for the selected time range, Highcharts was hiding both axes entirely, leaving a blank chart with no context
- Now charts always show a y-axis starting at 0 and an x-axis spanning the full selected time window, so users see a flat 0 baseline instead of a disappearing chart

## Changes

**`src/lib/components/Chart.svelte`**
- `yAxis.min: 0` + `yAxis.showEmpty: true` — y-axis always renders from 0, even with no series data
- `xAxis.showEmpty: true` — x-axis renders even when empty
- New `range` prop + `rangeToMs()` helper — parses range strings like `1h`, `30dagg` into milliseconds and calls `xAxis.setExtremes()` so the axis spans the selected window regardless of data presence

**`src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte`**
- Passes `range={filter.range}` to all four Chart instances (CPU, Memory, Request, Egress)

## Test plan

- [ ] Select a time range with no data (e.g. a newly created deployment on a long range like 30 days) — charts should show axes with 0 baseline instead of going blank
- [ ] Select a time range with data — charts should render normally as before
- [ ] Switch between ranges — x-axis should update to match the selected window

🤖 Generated with [Claude Code](https://claude.com/claude-code)