### PR TITLE
Remove DDoS Protection text from CDN in Domain detail page

### DIFF
--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -234,7 +234,7 @@
 		<div class="nm-field _mgt-5">
 			<div class="nm-checkbox">
 				<input id="input-cdn" type="checkbox" bind:checked={domain.cdn} disabled readonly>
-				<label for="input-cdn">CDN (DDoS Protection)</label>
+				<label for="input-cdn">CDN</label>
 			</div>
 		</div>
 		<div class="nm-field">
@@ -435,11 +435,11 @@
 	<hr>
 	{#if domain.cdn}
 		<div class="_dp-f _alit-ct _fw-w">
-			<a class="nm-button" href="/domain/cdn-downgrade?project={project}&domain={domain.domain}">Remove CDN (DDoS Protection)</a>
+			<a class="nm-button" href="/domain/cdn-downgrade?project={project}&domain={domain.domain}">Remove CDN</a>
 		</div>
 	{:else}
 		<div class="_dp-f _alit-ct _fw-w">
-			<button class="nm-button" onclick={upgradeCdn} disabled>Add CDN (DDoS Protection)</button>
+			<button class="nm-button" onclick={upgradeCdn} disabled>Add CDN</button>
 		</div>
 	{/if}
 


### PR DESCRIPTION
## Summary

- Removes `(DDoS Protection)` from the CDN checkbox label, "Remove CDN" button, and "Add CDN" button on the Domain detail page.

Follows the same change made to the Create Domain page in #96.

## Test plan

- [ ] Open a domain detail page and verify the CDN checkbox label reads "CDN" (not "CDN (DDoS Protection)")
- [ ] Verify the "Remove CDN" and "Add CDN" buttons no longer include "(DDoS Protection)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)