### PR TITLE
Add recent activity widget to dashboard

### DIFF
--- a/src/lib/components/OutcomeBadge.svelte
+++ b/src/lib/components/OutcomeBadge.svelte
@@ -1,0 +1,43 @@
+<script>
+	/**
+	 * @typedef {Object} Props
+	 * @property {Api.AuditOutcome} outcome
+	 */
+
+	/** @type {Props} */
+	const { outcome } = $props()
+
+	const badge = $derived.by(() => {
+		if (outcome === 'success') return { icon: 'fa-circle-check', cls: 'is-positive', label: 'Success' }
+		if (outcome === 'failure') return { icon: 'fa-circle-xmark', cls: 'is-negative', label: 'Failure' }
+		return { icon: 'fa-circle', cls: '', label: outcome }
+	})
+</script>
+
+<style lang="scss">
+	.outcome-badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		padding: 0.15rem 0.55rem;
+		border-radius: 999px;
+		font-size: 0.8125rem;
+		line-height: 1.25;
+		background: hsl(var(--hsl-content)/0.08);
+
+		&.is-positive {
+			color: hsl(var(--hsl-positive));
+			background: hsl(var(--hsl-positive)/0.12);
+		}
+
+		&.is-negative {
+			color: hsl(var(--hsl-negative));
+			background: hsl(var(--hsl-negative)/0.12);
+		}
+	}
+</style>
+
+<span class="outcome-badge {badge.cls}" title={badge.label}>
+	<i class="fa-solid {badge.icon}"></i>
+	{badge.label}
+</span>

--- a/src/routes/(auth)/(project)/+page.js
+++ b/src/routes/(auth)/(project)/+page.js
@@ -10,7 +10,7 @@ export async function load ({ parent, fetch }) {
 	] = await Promise.all([
 		api.invoke('project.usage', { project }, fetch),
 		api.invoke('billing.project', { project }, fetch),
-		api.invoke('auditLog.list', { project, limit: 5 }, fetch)
+		api.invoke('auditLog.list', { project, limit: 4 }, fetch)
 	])
 	return {
 		menu: 'dashboard',

--- a/src/routes/(auth)/(project)/+page.js
+++ b/src/routes/(auth)/(project)/+page.js
@@ -5,14 +5,20 @@ export async function load ({ parent, fetch }) {
 
 	const [
 		usage,
-		price
+		price,
+		auditLog
 	] = await Promise.all([
 		api.invoke('project.usage', { project }, fetch),
-		api.invoke('billing.project', { project }, fetch)
+		api.invoke('billing.project', { project }, fetch),
+		api.invoke('auditLog.list', { project, limit: 5 }, fetch)
 	])
 	return {
 		menu: 'dashboard',
 		usage: usage.result ?? {},
-		price: price.result ?? {}
+		price: price.result ?? {},
+		auditLog: {
+			items: auditLog.result?.items ?? [],
+			error: auditLog.error
+		}
 	}
 }

--- a/src/routes/(auth)/(project)/+page.svelte
+++ b/src/routes/(auth)/(project)/+page.svelte
@@ -133,29 +133,29 @@
 
 <br>
 
-<div class="nm-panel is-level-300">
-	<div class="_dp-f _alit-ct _jtfct-sb">
-		<h6>
+<div class="nm-panel is-level-300 audit-widget">
+	<div class="_dp-f _alit-ct _jtfct-spbtw">
+		<div class="widget-title">
 			<i class="fa-solid fa-clock-rotate-left"></i>
-			<strong class="_mgl-6">Recent Activity</strong>
-		</h6>
-		<a class="nm-link" href="/audit-log?project={projectInfo.project}">
+			<strong class="_mgl-4">Recent Activity</strong>
+		</div>
+		<a class="nm-link _fs-2" href="/audit-log?project={projectInfo.project}">
 			View all
-			<i class="fa-solid fa-arrow-right _mgl-4"></i>
+			<i class="fa-solid fa-arrow-right _mgl-3"></i>
 		</a>
 	</div>
 	<hr>
 	{#if auditLog.error?.forbidden}
-		<div class="_tal-ct _pd-6 _cl-content-600">
-			<i class="fa-solid fa-lock _mgr-4"></i>
+		<div class="_tal-ct _pd-5 _cl-content-600 _fs-2">
+			<i class="fa-solid fa-lock _mgr-3"></i>
 			You don't have permission to view audit logs
 		</div>
 	{:else if auditLog.error}
-		<div class="_tal-ct _pd-6 _cl-content-600">
+		<div class="_tal-ct _pd-5 _cl-content-600 _fs-2">
 			{auditLog.error.message || auditLog.error}
 		</div>
 	{:else if !auditLog.items.length}
-		<div class="_tal-ct _pd-6 _cl-content-600">
+		<div class="_tal-ct _pd-5 _cl-content-600 _fs-2">
 			No recent activity
 		</div>
 	{:else}
@@ -194,6 +194,31 @@
 </div>
 
 <style lang="scss">
+	.audit-widget {
+		font-size: 0.875rem;
+
+		.widget-title {
+			display: inline-flex;
+			align-items: center;
+			font-size: 0.9375rem;
+			font-weight: 600;
+		}
+
+		hr {
+			margin: 0.5rem 0 0.25rem;
+		}
+	}
+
+	.audit-widget :global(.nm-table) {
+		font-size: 0.8125rem;
+	}
+
+	.audit-widget :global(.nm-table th),
+	.audit-widget :global(.nm-table td) {
+		padding-top: 0.4rem;
+		padding-bottom: 0.4rem;
+	}
+
 	.action-cell {
 		font-family: var(--font-family-mono, ui-monospace, monospace);
 		font-size: 0.8125rem;

--- a/src/routes/(auth)/(project)/+page.svelte
+++ b/src/routes/(auth)/(project)/+page.svelte
@@ -129,103 +129,89 @@
 			</div>
 		</div>
 	</div>
-</div>
 
-<br>
-
-<div class="nm-panel is-level-300 audit-widget">
-	<div class="_dp-f _alit-ct _jtfct-spbtw">
-		<div class="widget-title">
-			<i class="fa-solid fa-clock-rotate-left"></i>
-			<strong class="_mgl-4">Recent Activity</strong>
+	<div class="nm-panel is-level-300 lo-12 _g-7">
+		<div class="_dp-f _alit-ct _jtfct-spbtw">
+			<h6>
+				<i class="fa-solid fa-clock-rotate-left"></i>
+				<strong class="_mgl-6">Recent Activity</strong>
+			</h6>
+			<a class="nm-link" href="/audit-log?project={projectInfo.project}">
+				View all
+				<i class="fa-solid fa-arrow-right _mgl-3"></i>
+			</a>
 		</div>
-		<a class="nm-link _fs-2" href="/audit-log?project={projectInfo.project}">
-			View all
-			<i class="fa-solid fa-arrow-right _mgl-3"></i>
-		</a>
-	</div>
-	<hr>
-	{#if auditLog.error?.forbidden}
-		<div class="_tal-ct _pd-5 _cl-content-600 _fs-2">
-			<i class="fa-solid fa-lock _mgr-3"></i>
-			You don't have permission to view audit logs
-		</div>
-	{:else if auditLog.error}
-		<div class="_tal-ct _pd-5 _cl-content-600 _fs-2">
-			{auditLog.error.message || auditLog.error}
-		</div>
-	{:else if !auditLog.items.length}
-		<div class="_tal-ct _pd-5 _cl-content-600 _fs-2">
-			No recent activity
-		</div>
-	{:else}
-		<div class="nm-table-container">
-			<table class="nm-table is-variant-compact">
-				<thead>
-					<tr>
-						<th>Time</th>
-						<th>Outcome</th>
-						<th>Actor</th>
-						<th>Action</th>
-						<th>Resource</th>
-					</tr>
-				</thead>
-				<tbody>
-					{#each auditLog.items as it (it.id)}
+		<hr>
+		{#if auditLog.error?.forbidden}
+			<div class="_tal-ct _pd-6 _cl-content-600">
+				<i class="fa-solid fa-lock _mgr-4"></i>
+				You don't have permission to view audit logs
+			</div>
+		{:else if auditLog.error}
+			<div class="_tal-ct _pd-6 _cl-content-600">
+				{auditLog.error.message || auditLog.error}
+			</div>
+		{:else if !auditLog.items.length}
+			<div class="_tal-ct _pd-6 _cl-content-600">
+				No recent activity
+			</div>
+		{:else}
+			<div class="nm-table-container">
+				<table class="nm-table is-variant-compact">
+					<thead>
 						<tr>
-							<td>{format.datetime(it.createdAt)}</td>
-							<td><OutcomeBadge outcome={it.outcome} /></td>
-							<td>{it.actor.email}</td>
-							<td><span class="action-cell">{it.action}</span></td>
-							<td>
-								{#if it.resource.type}
-									<strong>{it.resource.type}</strong>
-									{#if it.resource.name}
-										<span class="resource-name">/ {it.resource.name}</span>
-									{/if}
-								{/if}
-							</td>
+							<th>Time</th>
+							<th>Outcome</th>
+							<th>Actor</th>
+							<th>Action</th>
 						</tr>
-					{/each}
-				</tbody>
-			</table>
-		</div>
-	{/if}
+					</thead>
+					<tbody>
+						{#each auditLog.items as it (it.id)}
+							<tr>
+								<td>{format.datetime(it.createdAt)}</td>
+								<td><OutcomeBadge outcome={it.outcome} /></td>
+								<td class="ellipsis">{it.actor.email}</td>
+								<td>
+									<span class="action-cell">{it.action}</span>
+									{#if it.resource.type}
+										<div class="resource-line">
+											<strong>{it.resource.type}</strong>
+											{#if it.resource.name}
+												<span class="resource-name">/ {it.resource.name}</span>
+											{/if}
+										</div>
+									{/if}
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+	</div>
 </div>
 
 <style lang="scss">
-	.audit-widget {
-		font-size: 0.875rem;
-
-		.widget-title {
-			display: inline-flex;
-			align-items: center;
-			font-size: 0.9375rem;
-			font-weight: 600;
-		}
-
-		hr {
-			margin: 0.5rem 0 0.25rem;
-		}
-	}
-
-	.audit-widget :global(.nm-table) {
-		font-size: 0.8125rem;
-	}
-
-	.audit-widget :global(.nm-table th),
-	.audit-widget :global(.nm-table td) {
-		padding-top: 0.4rem;
-		padding-bottom: 0.4rem;
-	}
-
 	.action-cell {
 		font-family: var(--font-family-mono, ui-monospace, monospace);
 		font-size: 0.8125rem;
 		color: hsl(var(--hsl-content)/0.85);
 	}
 
+	.resource-line {
+		font-size: 0.8125rem;
+		margin-top: 0.15rem;
+	}
+
 	.resource-name {
 		color: hsl(var(--hsl-content)/0.65);
+	}
+
+	.ellipsis {
+		max-width: 14rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 </style>

--- a/src/routes/(auth)/(project)/+page.svelte
+++ b/src/routes/(auth)/(project)/+page.svelte
@@ -1,6 +1,8 @@
 <script>
 	import { onMount } from 'svelte'
 	import api from '$lib/api'
+	import * as format from '$lib/format'
+	import OutcomeBadge from '$lib/components/OutcomeBadge.svelte'
 
 	const { data } = $props()
 
@@ -24,6 +26,7 @@
 	const projectInfo = $derived(data.projectInfo)
 	const usage = $derived(data.usage)
 	const price = $derived(data.price)
+	const auditLog = $derived(data.auditLog)
 	const billing = $derived({
 		price: formatNumber(price.price),
 		cpu: formatNumber(usage.cpuUsage),
@@ -127,3 +130,77 @@
 		</div>
 	</div>
 </div>
+
+<br>
+
+<div class="nm-panel is-level-300">
+	<div class="_dp-f _alit-ct _jtfct-sb">
+		<h6>
+			<i class="fa-solid fa-clock-rotate-left"></i>
+			<strong class="_mgl-6">Recent Activity</strong>
+		</h6>
+		<a class="nm-link" href="/audit-log?project={projectInfo.project}">
+			View all
+			<i class="fa-solid fa-arrow-right _mgl-4"></i>
+		</a>
+	</div>
+	<hr>
+	{#if auditLog.error?.forbidden}
+		<div class="_tal-ct _pd-6 _cl-content-600">
+			<i class="fa-solid fa-lock _mgr-4"></i>
+			You don't have permission to view audit logs
+		</div>
+	{:else if auditLog.error}
+		<div class="_tal-ct _pd-6 _cl-content-600">
+			{auditLog.error.message || auditLog.error}
+		</div>
+	{:else if !auditLog.items.length}
+		<div class="_tal-ct _pd-6 _cl-content-600">
+			No recent activity
+		</div>
+	{:else}
+		<div class="nm-table-container">
+			<table class="nm-table is-variant-compact">
+				<thead>
+					<tr>
+						<th>Time</th>
+						<th>Outcome</th>
+						<th>Actor</th>
+						<th>Action</th>
+						<th>Resource</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each auditLog.items as it (it.id)}
+						<tr>
+							<td>{format.datetime(it.createdAt)}</td>
+							<td><OutcomeBadge outcome={it.outcome} /></td>
+							<td>{it.actor.email}</td>
+							<td><span class="action-cell">{it.action}</span></td>
+							<td>
+								{#if it.resource.type}
+									<strong>{it.resource.type}</strong>
+									{#if it.resource.name}
+										<span class="resource-name">/ {it.resource.name}</span>
+									{/if}
+								{/if}
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	{/if}
+</div>
+
+<style lang="scss">
+	.action-cell {
+		font-family: var(--font-family-mono, ui-monospace, monospace);
+		font-size: 0.8125rem;
+		color: hsl(var(--hsl-content)/0.85);
+	}
+
+	.resource-name {
+		color: hsl(var(--hsl-content)/0.65);
+	}
+</style>

--- a/src/routes/(auth)/(project)/+page.svelte
+++ b/src/routes/(auth)/(project)/+page.svelte
@@ -156,62 +156,90 @@
 				No recent activity
 			</div>
 		{:else}
-			<div class="nm-table-container">
-				<table class="nm-table is-variant-compact">
-					<thead>
-						<tr>
-							<th>Time</th>
-							<th>Outcome</th>
-							<th>Actor</th>
-							<th>Action</th>
-						</tr>
-					</thead>
-					<tbody>
-						{#each auditLog.items as it (it.id)}
-							<tr>
-								<td>{format.datetime(it.createdAt)}</td>
-								<td><OutcomeBadge outcome={it.outcome} /></td>
-								<td class="ellipsis">{it.actor.email}</td>
-								<td>
-									<span class="action-cell">{it.action}</span>
-									{#if it.resource.type}
-										<div class="resource-line">
-											<strong>{it.resource.type}</strong>
-											{#if it.resource.name}
-												<span class="resource-name">/ {it.resource.name}</span>
-											{/if}
-										</div>
-									{/if}
-								</td>
-							</tr>
-						{/each}
-					</tbody>
-				</table>
-			</div>
+			<ul class="activity-feed">
+				{#each auditLog.items as it (it.id)}
+					<li>
+						<OutcomeBadge outcome={it.outcome} />
+						<div class="activity-body">
+							<div class="activity-line">
+								<span class="actor">{it.actor.email}</span>
+								<span class="action">{it.action}</span>
+								{#if it.resource.type}
+									<span class="resource">
+										<strong>{it.resource.type}</strong>{#if it.resource.name}<span class="resource-name">/{it.resource.name}</span>{/if}
+									</span>
+								{/if}
+							</div>
+							<time class="activity-time">{format.datetime(it.createdAt)}</time>
+						</div>
+					</li>
+				{/each}
+			</ul>
 		{/if}
 	</div>
 </div>
 
 <style lang="scss">
-	.action-cell {
+	.activity-feed {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+
+		li {
+			display: flex;
+			align-items: flex-start;
+			gap: 0.625rem;
+			padding: 0.5rem 0;
+
+			& + li {
+				border-top: 1px solid hsl(var(--hsl-content)/0.08);
+			}
+		}
+	}
+
+	.activity-body {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.activity-line {
+		display: flex;
+		align-items: baseline;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+		font-size: 0.875rem;
+		line-height: 1.3;
+	}
+
+	.actor {
+		color: hsl(var(--hsl-content));
+		font-weight: 500;
+		max-width: 16rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.action {
 		font-family: var(--font-family-mono, ui-monospace, monospace);
 		font-size: 0.8125rem;
 		color: hsl(var(--hsl-content)/0.85);
 	}
 
-	.resource-line {
+	.resource {
 		font-size: 0.8125rem;
-		margin-top: 0.15rem;
+		color: hsl(var(--hsl-content)/0.9);
 	}
 
 	.resource-name {
-		color: hsl(var(--hsl-content)/0.65);
+		color: hsl(var(--hsl-content)/0.6);
+		margin-left: 0.1rem;
 	}
 
-	.ellipsis {
-		max-width: 14rem;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+	.activity-time {
+		display: block;
+		margin-top: 0.15rem;
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-content)/0.55);
 	}
 </style>

--- a/src/routes/(auth)/(project)/audit-log/+page.svelte
+++ b/src/routes/(auth)/(project)/audit-log/+page.svelte
@@ -6,6 +6,7 @@
 	import dayjs from 'dayjs'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import OutcomeBadge from '$lib/components/OutcomeBadge.svelte'
 	import * as format from '$lib/format'
 
 	const { data } = $props()
@@ -98,14 +99,6 @@
 		}
 	}
 
-	/**
-	 * @param {Api.AuditOutcome} o
-	 */
-	function outcomeBadge (o) {
-		if (o === 'success') return { icon: 'fa-circle-check', cls: 'is-positive', label: 'Success' }
-		if (o === 'failure') return { icon: 'fa-circle-xmark', cls: 'is-negative', label: 'Failure' }
-		return { icon: 'fa-circle', cls: '', label: o }
-	}
 </script>
 
 <style lang="scss">
@@ -243,27 +236,6 @@
 		--datepicker-presets-button-background-active: hsl(var(--hsl-primary));
 	}
 
-	.outcome-badge {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.375rem;
-		padding: 0.15rem 0.55rem;
-		border-radius: 999px;
-		font-size: 0.8125rem;
-		line-height: 1.25;
-		background: hsl(var(--hsl-content)/0.08);
-
-		&.is-positive {
-			color: hsl(var(--hsl-positive));
-			background: hsl(var(--hsl-positive)/0.12);
-		}
-
-		&.is-negative {
-			color: hsl(var(--hsl-negative));
-			background: hsl(var(--hsl-negative)/0.12);
-		}
-	}
-
 	.action-cell {
 		font-family: var(--font-family-mono, ui-monospace, monospace);
 		font-size: 0.8125rem;
@@ -383,15 +355,9 @@
 			</thead>
 			<tbody>
 				{#each items as it (it.id)}
-					{@const o = outcomeBadge(it.outcome)}
 					<tr>
 						<td>{format.datetime(it.createdAt)}</td>
-						<td>
-							<span class="outcome-badge {o.cls}" title={o.label}>
-								<i class="fa-solid {o.icon}"></i>
-								{o.label}
-							</span>
-						</td>
+						<td><OutcomeBadge outcome={it.outcome} /></td>
 						<td>
 							{it.actor.email}
 							{#if it.actor.type === 'ServiceAccount'}


### PR DESCRIPTION
## Summary
- Show the latest 5 audit log entries on the project dashboard, with a "View all" link to `/audit-log`.
- Render a permission-aware placeholder ("You don't have permission to view audit logs") when `auditLog.list` returns `api: forbidden` / `iam: forbidden`; also handles other errors and the empty state.
- Extract the success/failure outcome pill into a shared `OutcomeBadge` component and reuse it on both the dashboard widget and the full audit log page.

## Test plan
- [ ] Dashboard loads and shows the Recent Activity panel with up to 5 entries for a project with audit log access.
- [ ] "View all" links to `/audit-log?project=<project>`.
- [ ] For a user without `auditLog.list` permission, the panel shows the lock-icon placeholder instead of the table; the Project Info and Billing panels still render normally.
- [ ] Empty state ("No recent activity") renders when the project has no audit logs.
- [ ] The audit log page still renders outcome badges identically to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)