### PR TITLE
Show all billing usage metrics on dashboard widget

### DIFF
--- a/src/routes/(auth)/(project)/+page.js
+++ b/src/routes/(auth)/(project)/+page.js
@@ -10,7 +10,7 @@ export async function load ({ parent, fetch }) {
 	] = await Promise.all([
 		api.invoke('project.usage', { project }, fetch),
 		api.invoke('billing.project', { project }, fetch),
-		api.invoke('auditLog.list', { project, limit: 4 }, fetch)
+		api.invoke('auditLog.list', { project, limit: 6 }, fetch)
 	])
 	return {
 		menu: 'dashboard',

--- a/src/routes/(auth)/(project)/+page.svelte
+++ b/src/routes/(auth)/(project)/+page.svelte
@@ -329,6 +329,18 @@
 		line-height: 1.25rem;
 	}
 
+	@supports (grid-template-rows: subgrid) {
+		.billing-card {
+			display: grid;
+			grid-template-rows: subgrid;
+			grid-row: span 2;
+		}
+
+		.billing-card-head {
+			min-height: 0;
+		}
+	}
+
 	.billing-card-value {
 		display: flex;
 		align-items: baseline;

--- a/src/routes/(auth)/(project)/+page.svelte
+++ b/src/routes/(auth)/(project)/+page.svelte
@@ -104,8 +104,8 @@
 
 <h6>Dashboard</h6>
 <br>
-<div class="lo-12 lo-6:md _g-7 _alit-st">
-	<div class="nm-panel is-level-300 lo-12 _g-7">
+<div class="lo-12 lo-6:md _g-7 _alit-str">
+	<div class="nm-panel is-level-300 lo-12 _g-7 dashboard-panel">
 		<h6>
 			<i class="fa-solid fa-project-diagram"></i>
 			<strong class="_mgl-6">Project Info</strong>
@@ -144,7 +144,7 @@
 <!--		</a>-->
 	</div>
 
-	<div class="nm-panel is-level-300 lo-12 _g-7">
+	<div class="nm-panel is-level-300 lo-12 _g-7 dashboard-panel">
 		<div class="_dp-f _alit-ct _jtfct-spbtw">
 			<h6>
 				<i class="fa-solid fa-credit-card"></i>
@@ -181,7 +181,7 @@
 		</div>
 	</div>
 
-	<div class="nm-panel is-level-300 lo-12 _g-7">
+	<div class="nm-panel is-level-300 lo-12 _g-7 dashboard-panel">
 		<div class="_dp-f _alit-ct _jtfct-spbtw">
 			<h6>
 				<i class="fa-solid fa-clock-rotate-left"></i>
@@ -231,6 +231,10 @@
 </div>
 
 <style lang="scss">
+	.dashboard-panel {
+		min-height: 28rem;
+	}
+
 	.billing-total {
 		display: flex;
 		align-items: baseline;

--- a/src/routes/(auth)/(project)/+page.svelte
+++ b/src/routes/(auth)/(project)/+page.svelte
@@ -233,6 +233,7 @@
 <style lang="scss">
 	.dashboard-panel {
 		min-height: 28rem;
+		align-content: start;
 	}
 
 	.billing-total {

--- a/src/routes/(auth)/(project)/+page.svelte
+++ b/src/routes/(auth)/(project)/+page.svelte
@@ -20,21 +20,71 @@
 	})
 
 	function formatNumber (v) {
-		if (Number.isNaN(v)) return '?'
-		return v?.toLocaleString(undefined, { maximumFractionDigits: 2 }) ?? '?'
+		if (v == null || Number.isNaN(v)) return '?'
+		return v.toLocaleString(undefined, { maximumFractionDigits: 2 })
 	}
 	const projectInfo = $derived(data.projectInfo)
 	const usage = $derived(data.usage)
 	const price = $derived(data.price)
 	const auditLog = $derived(data.auditLog)
-	const billing = $derived({
-		price: formatNumber(price.price),
-		cpu: formatNumber(usage.cpuUsage),
-		memory: formatNumber(usage.memory / unitGiB),
-		egress: formatNumber(usage.egress / unitGiB),
-		disk: formatNumber(usage.disk / unitGiB),
-		replica: formatNumber(usage.replica)
-	})
+	const billing = $derived([
+		{
+			key: 'cpuUsage',
+			icon: 'fa-microchip',
+			label: 'CPU Usage',
+			value: formatNumber(usage.cpuUsage),
+			unit: 'vCPU-s'
+		},
+		{
+			key: 'cpu',
+			icon: 'fa-gauge-high',
+			label: 'CPU Allocated',
+			value: formatNumber(usage.cpu),
+			unit: 'vCPU-s'
+		},
+		{
+			key: 'memory',
+			icon: 'fa-memory',
+			label: 'Memory',
+			value: formatNumber(usage.memory / unitGiB),
+			unit: 'GiB-s'
+		},
+		{
+			key: 'disk',
+			icon: 'fa-hard-drive',
+			label: 'Disk',
+			value: formatNumber(usage.disk / unitGiB),
+			unit: 'GiB-s'
+		},
+		{
+			key: 'egress',
+			icon: 'fa-cloud-arrow-up',
+			label: 'Egress',
+			value: formatNumber(usage.egress / unitGiB),
+			unit: 'GiB'
+		},
+		{
+			key: 'registryEgress',
+			icon: 'fa-box-archive',
+			label: 'Registry Egress',
+			value: formatNumber(usage.registryEgress / unitGiB),
+			unit: 'GiB'
+		},
+		{
+			key: 'replica',
+			icon: 'fa-clone',
+			label: 'Replica',
+			value: formatNumber(usage.replica),
+			unit: 'replica-s'
+		},
+		{
+			key: 'domainCdn',
+			icon: 'fa-globe',
+			label: 'Domain CDN',
+			value: formatNumber(usage.domainCdn),
+			unit: 'domain-s'
+		}
+	])
 </script>
 
 <h6>Dashboard</h6>
@@ -80,53 +130,39 @@
 	</div>
 
 	<div class="nm-panel is-level-300 lo-12 _g-7">
-		<h6>
-			<i class="fa-solid fa-credit-card"></i>
-			<strong class="_mgl-6">Billing</strong>
-		</h6>
+		<div class="_dp-f _alit-ct _jtfct-spbtw">
+			<h6>
+				<i class="fa-solid fa-credit-card"></i>
+				<strong class="_mgl-6">Billing</strong>
+			</h6>
+			<a class="nm-link" href="/billing">
+				View billing
+				<i class="fa-solid fa-arrow-right _mgl-3"></i>
+			</a>
+		</div>
 		<hr>
-		<div class="lo-12 lo-6:sm _g-5">
-			<div class="_bgcl-base-200 _bdrd-3 _pd-6">
-				<h4 class="_cl-primary">CPU</h4>
-				<div class="_mgt-4">
-					<span class="_fs-6">{billing?.cpu}</span>
-					<span>&nbsp;seconds</span>
-				</div>
+
+		<div class="billing-total">
+			<div class="billing-total-label">Estimated Cost (This Month)</div>
+			<div class="billing-total-value">
+				<span class="billing-total-amount">{formatNumber(price.price)}</span>
+				<span class="billing-total-currency">THB</span>
 			</div>
-			<div class="_bgcl-base-200 _bdrd-3 _pd-6">
-				<h4 class="_cl-primary">Memory</h4>
-				<div class="_mgt-4">
-					<span class="_fs-6">{billing?.memory}</span>
-					<span>&nbsp;GiB-s</span>
+		</div>
+
+		<div class="billing-grid">
+			{#each billing as item (item.key)}
+				<div class="billing-card">
+					<div class="billing-card-head">
+						<i class="fa-solid {item.icon}"></i>
+						<span class="billing-card-label">{item.label}</span>
+					</div>
+					<div class="billing-card-value">
+						<span class="billing-card-amount">{item.value}</span>
+						<span class="billing-card-unit">{item.unit}</span>
+					</div>
 				</div>
-			</div>
-			<div class="_bgcl-base-200 _bdrd-3 _pd-6">
-				<h4 class="_cl-primary">Egress</h4>
-				<div class="_mgt-4">
-					<span class="_fs-6">{billing?.egress}</span>
-					<span>&nbsp;GiB</span>
-				</div>
-			</div>
-			<div class="_bgcl-base-200 _bdrd-3 _pd-6">
-				<h4 class="_cl-primary">Disk</h4>
-				<div class="_mgt-4">
-					<span class="_fs-6">{billing?.disk}</span>
-					<span>&nbsp;GiB-s</span>
-				</div>
-			</div>
-			<div class="_bgcl-base-200 _bdrd-3 _pd-6">
-				<h4 class="_cl-primary">Replica</h4>
-				<div class="_mgt-4">
-					<span class="_fs-6">{billing?.replica}</span>
-				</div>
-			</div>
-			<div class="_bgcl-base-200 _bdrd-3 _pd-6">
-				<h4 class="_cl-primary">Price</h4>
-				<div class="_mgt-4">
-					<span class="_fs-6">{billing?.price}</span>
-					<span>&nbsp;THB</span>
-				</div>
-			</div>
+			{/each}
 		</div>
 	</div>
 
@@ -180,6 +216,121 @@
 </div>
 
 <style lang="scss">
+	.billing-total {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+		padding: 1rem 1.25rem;
+		border-radius: 0.625rem;
+		background: linear-gradient(
+			135deg,
+			hsl(var(--hsl-primary)/0.12) 0%,
+			hsl(var(--hsl-accent)/0.12) 100%
+		);
+		border: 1px solid hsl(var(--hsl-primary)/0.18);
+		margin-bottom: 1rem;
+	}
+
+	.billing-total-label {
+		font-size: 0.8125rem;
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: hsl(var(--hsl-content)/0.7);
+	}
+
+	.billing-total-value {
+		display: flex;
+		align-items: baseline;
+		gap: 0.4rem;
+	}
+
+	.billing-total-amount {
+		font-size: 2rem;
+		font-weight: 700;
+		line-height: 1;
+		color: hsl(var(--hsl-primary));
+		font-variant-numeric: tabular-nums;
+	}
+
+	.billing-total-currency {
+		font-size: 0.9375rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content)/0.7);
+	}
+
+	.billing-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 0.625rem;
+
+		@media (min-width: 640px) {
+			grid-template-columns: repeat(4, minmax(0, 1fr));
+		}
+	}
+
+	.billing-card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+		padding: 0.75rem 0.875rem;
+		border-radius: 0.5rem;
+		background: hsl(var(--hsl-base-200));
+		border: 1px solid hsl(var(--hsl-line)/0.6);
+		transition:
+			background var(--timing-fastest) ease,
+			border-color var(--timing-fastest) ease,
+			transform var(--timing-fastest) ease;
+
+		&:hover {
+			border-color: hsl(var(--hsl-primary)/0.45);
+			background: hsl(var(--hsl-base-200));
+			transform: translateY(-1px);
+		}
+	}
+
+	.billing-card-head {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		color: hsl(var(--hsl-primary));
+		font-size: 0.8125rem;
+
+		i {
+			font-size: 0.875rem;
+			width: 1rem;
+			text-align: center;
+		}
+	}
+
+	.billing-card-label {
+		font-weight: 600;
+		color: hsl(var(--hsl-content)/0.85);
+		font-size: 0.8125rem;
+	}
+
+	.billing-card-value {
+		display: flex;
+		align-items: baseline;
+		gap: 0.3rem;
+		flex-wrap: wrap;
+	}
+
+	.billing-card-amount {
+		font-size: 1.25rem;
+		font-weight: 700;
+		line-height: 1.1;
+		color: hsl(var(--hsl-content));
+		font-variant-numeric: tabular-nums;
+	}
+
+	.billing-card-unit {
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-content)/0.55);
+	}
+
 	.activity-feed {
 		list-style: none;
 		margin: 0;

--- a/src/routes/(auth)/(project)/+page.svelte
+++ b/src/routes/(auth)/(project)/+page.svelte
@@ -308,15 +308,17 @@
 
 	.billing-card-head {
 		display: flex;
-		align-items: center;
+		align-items: flex-start;
 		gap: 0.4rem;
 		color: hsl(var(--hsl-primary));
 		font-size: 0.8125rem;
+		min-height: 2.5rem;
 
 		i {
 			font-size: 0.875rem;
 			width: 1rem;
 			text-align: center;
+			line-height: 1.25rem;
 		}
 	}
 
@@ -324,6 +326,7 @@
 		font-weight: 600;
 		color: hsl(var(--hsl-content)/0.85);
 		font-size: 0.8125rem;
+		line-height: 1.25rem;
 	}
 
 	.billing-card-value {

--- a/src/routes/(auth)/(project)/+page.svelte
+++ b/src/routes/(auth)/(project)/+page.svelte
@@ -23,6 +23,13 @@
 		if (v == null || Number.isNaN(v)) return '?'
 		return v.toLocaleString(undefined, { maximumFractionDigits: 2 })
 	}
+	function formatCompact (v) {
+		if (v == null || Number.isNaN(v)) return '?'
+		return v.toLocaleString(undefined, {
+			notation: 'compact',
+			maximumFractionDigits: 2
+		})
+	}
 	const projectInfo = $derived(data.projectInfo)
 	const usage = $derived(data.usage)
 	const price = $derived(data.price)
@@ -32,56 +39,64 @@
 			key: 'cpuUsage',
 			icon: 'fa-microchip',
 			label: 'CPU Usage',
-			value: formatNumber(usage.cpuUsage),
+			value: formatCompact(usage.cpuUsage),
+			full: formatNumber(usage.cpuUsage),
 			unit: 'vCPU-s'
 		},
 		{
 			key: 'cpu',
 			icon: 'fa-gauge-high',
 			label: 'CPU Allocated',
-			value: formatNumber(usage.cpu),
+			value: formatCompact(usage.cpu),
+			full: formatNumber(usage.cpu),
 			unit: 'vCPU-s'
 		},
 		{
 			key: 'memory',
 			icon: 'fa-memory',
 			label: 'Memory',
-			value: formatNumber(usage.memory / unitGiB),
+			value: formatCompact(usage.memory / unitGiB),
+			full: formatNumber(usage.memory / unitGiB),
 			unit: 'GiB-s'
 		},
 		{
 			key: 'disk',
 			icon: 'fa-hard-drive',
 			label: 'Disk',
-			value: formatNumber(usage.disk / unitGiB),
+			value: formatCompact(usage.disk / unitGiB),
+			full: formatNumber(usage.disk / unitGiB),
 			unit: 'GiB-s'
 		},
 		{
 			key: 'egress',
 			icon: 'fa-cloud-arrow-up',
 			label: 'Egress',
-			value: formatNumber(usage.egress / unitGiB),
+			value: formatCompact(usage.egress / unitGiB),
+			full: formatNumber(usage.egress / unitGiB),
 			unit: 'GiB'
 		},
 		{
 			key: 'registryEgress',
 			icon: 'fa-box-archive',
 			label: 'Registry Egress',
-			value: formatNumber(usage.registryEgress / unitGiB),
+			value: formatCompact(usage.registryEgress / unitGiB),
+			full: formatNumber(usage.registryEgress / unitGiB),
 			unit: 'GiB'
 		},
 		{
 			key: 'replica',
 			icon: 'fa-clone',
 			label: 'Replica',
-			value: formatNumber(usage.replica),
+			value: formatCompact(usage.replica),
+			full: formatNumber(usage.replica),
 			unit: 'replica-s'
 		},
 		{
 			key: 'domainCdn',
 			icon: 'fa-globe',
 			label: 'Domain CDN',
-			value: formatNumber(usage.domainCdn),
+			value: formatCompact(usage.domainCdn),
+			full: formatNumber(usage.domainCdn),
 			unit: 'domain-s'
 		}
 	])
@@ -152,7 +167,7 @@
 
 		<div class="billing-grid">
 			{#each billing as item (item.key)}
-				<div class="billing-card">
+				<div class="billing-card" title={`${item.full} ${item.unit}`}>
 					<div class="billing-card-head">
 						<i class="fa-solid {item.icon}"></i>
 						<span class="billing-card-label">{item.label}</span>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -57,8 +57,10 @@ declare namespace Api {
         cpu: number
         memory: number
         egress: number
+        registryEgress: number
         disk: number
         replica: number
+        domainCdn: number
     }
 
     export type BillingProject = {


### PR DESCRIPTION
## Summary

- Surface every field returned by `project.usage` in the dashboard billing panel — previously only 5 of the 8 fields were displayed. The new cards are **CPU Allocated** (`cpu`), **Registry Egress** (`registryEgress`), and **Domain CDN** (`domainCdn`).
- Split the estimated cost into its own hero tile at the top of the panel (primary→accent gradient, tabular-number figure) so the bill total is immediately scannable.
- Repack the metrics into a 2-col mobile / 4-col desktop grid with icon + label headers, larger numerals, and a subtle hover lift — replaces the looser 2×3 grid that mixed the price in with the metrics.
- Add a "View billing" link in the panel header, matching the Recent Activity panel's pattern.
- Update `Api.ProjectUsage` in `src/types/api.d.ts` to include the two missing fields (`registryEgress`, `domainCdn`) that the backend already returns.

## Notes for reviewer

- Field reference: [`api/project.go:142-151`](https://github.com/deploys-app/api/blob/main/project.go#L142-L151) — `ProjectUsageResult`.
- Units come from [`api/price.go`](https://github.com/deploys-app/api/blob/main/price.go): `cpu`/`cpuUsage` in vCPU-seconds, `memory`/`disk` in GiB-seconds, `egress`/`registryEgress` in bytes (divided by GiB in the widget), `replica` in replica-seconds, `domainCdn` in domain-seconds.
- The previous "CPU" card sourced from `cpuUsage`; it is now labeled "CPU Usage" to disambiguate from the newly-added "CPU Allocated" (which sources from `cpu`).

## Test plan

- [ ] Open the dashboard on a project with usage — verify all 8 metric cards render with the correct values and units.
- [ ] Verify the estimated cost tile shows the same `price.price` value as before.
- [ ] Toggle between light and dark themes — confirm the gradient hero tile and card borders look right in both.
- [ ] Resize the viewport — cards should be 2-up on narrow screens and 4-up at ≥640px.
- [ ] Confirm `bun check` and `bun lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)