### PR TITLE
feat: copy tooltip on icon click + copy/delete UX for service account keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,12 @@ bun lint         # ESLint
 bun test         # Playwright e2e tests
 ```
 
+Before marking any task as complete, always run:
+```bash
+bun lint   # must pass with zero errors
+bun check  # must pass with zero errors
+```
+
 For deployment:
 ```bash
 make build   # build Docker image and push to registry.deploys.app

--- a/src/lib/clipboard.js
+++ b/src/lib/clipboard.js
@@ -1,0 +1,16 @@
+import ClipboardJS from 'clipboard'
+
+/**
+ * @param {string} selector
+ * @returns {() => void}
+ */
+export function setupCopy(selector) {
+	const clip = new ClipboardJS(selector)
+	clip.on('success', (e) => {
+		const trigger = /** @type {HTMLElement} */ (e.trigger)
+		trigger.setAttribute('data-copied', '')
+		setTimeout(() => trigger.removeAttribute('data-copied'), 1500)
+		e.clearSelection()
+	})
+	return () => clip.destroy()
+}

--- a/src/lib/clipboard.js
+++ b/src/lib/clipboard.js
@@ -4,7 +4,7 @@ import ClipboardJS from 'clipboard'
  * @param {string} selector
  * @returns {() => void}
  */
-export function setupCopy(selector) {
+export function setupCopy (selector) {
 	const clip = new ClipboardJS(selector)
 	clip.on('success', (e) => {
 		const trigger = /** @type {HTMLElement} */ (e.trigger)

--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { onMount } from 'svelte'
-	import ClipboardJS from 'clipboard'
+	import { setupCopy } from '$lib/clipboard'
 	import * as format from '$lib/format'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
@@ -17,10 +17,7 @@
 	const hasInternalTCPAddress = $derived(['WebService', 'TCPService', 'InternalTCPService'].includes(deployment.type))
 
 	onMount(() => {
-		const copyList = new ClipboardJS('.copy')
-		return () => {
-			copyList.destroy()
-		}
+		return setupCopy('.copy')
 	})
 
 	function deleteItem () {

--- a/src/routes/(auth)/(project)/domain/cdn-downgrade/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/cdn-downgrade/+page.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { onMount } from 'svelte'
-	import ClipboardJS from 'clipboard'
+	import { setupCopy } from '$lib/clipboard'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
@@ -12,10 +12,7 @@
 	const location = $derived(data.location)
 
 	onMount(() => {
-		const copyList = new ClipboardJS('.copy')
-		return () => {
-			copyList.destroy()
-		}
+		return setupCopy('.copy')
 	})
 
 	function downgradeCdn () {

--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -1,7 +1,7 @@
 <script>
 	import * as format from '$lib/format'
 	import { onMount } from 'svelte'
-	import ClipboardJS from 'clipboard'
+	import { setupCopy } from '$lib/clipboard'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
@@ -13,10 +13,7 @@
 	const domain = $derived(data.domain)
 
 	onMount(() => {
-		const copyList = new ClipboardJS('.copy')
-		return () => {
-			copyList.destroy()
-		}
+		return setupCopy('.copy')
 	})
 
 	let reloadTimeout

--- a/src/routes/(auth)/(project)/pull-secret/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/pull-secret/detail/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import ClipboardJS from 'clipboard'
+	import { setupCopy } from '$lib/clipboard'
 	import { onMount } from 'svelte'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
@@ -13,10 +13,7 @@
 	const pullSecret = $derived(data.pullSecret)
 
 	onMount(() => {
-		const copyList = new ClipboardJS('.copy')
-		return () => {
-			copyList?.destroy()
-		}
+		return setupCopy('.copy')
 	})
 
 	function deleteItem () {

--- a/src/routes/(auth)/(project)/registry/detail/tags/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/detail/tags/+page.svelte
@@ -1,7 +1,7 @@
 <script>
 	import * as format from '$lib/format'
 	import { onMount } from 'svelte'
-	import ClipboardJS from 'clipboard'
+	import { setupCopy } from '$lib/clipboard'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as modal from '$lib/modal'
@@ -15,10 +15,7 @@
 	const error = $derived(data.error)
 
 	onMount(() => {
-		const copyList = new ClipboardJS('.copy')
-		return () => {
-			copyList.destroy()
-		}
+		return setupCopy('.copy')
 	})
 
 	function untagTag (tag) {

--- a/src/routes/(auth)/(project)/service-account/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/service-account/detail/+page.svelte
@@ -1,8 +1,12 @@
 <script>
+	import { onMount } from 'svelte'
 	import { goto } from '$app/navigation'
 	import * as format from '$lib/format'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
+	import { setupCopy } from '$lib/clipboard'
+
+	onMount(() => setupCopy('.copy'))
 
 	const { data } = $props()
 
@@ -120,9 +124,14 @@
 		<h6><strong>Keys</strong></h6>
 		<div class="grid gap-4 w-full">
 			{#each (serviceAccount.keys ?? []) as key, i (i)}
-				<div class="input -has-icon-right">
-					<input value="{key.secret}" readonly>
-					<button class="icon -is-right" onclick={() => deleteKey(key.secret)} type="button" aria-label="Remove">
+				<div class="flex items-center gap-2">
+					<div class="input -has-icon-right flex-1">
+						<input value={key.secret} readonly>
+						<span class="icon -is-right copy" data-clipboard-text={key.secret} aria-label="Copy">
+							<i class="fa-light fa-copy"></i>
+						</span>
+					</div>
+					<button class="icon" onclick={() => deleteKey(key.secret)} type="button" aria-label="Delete">
 						<i class="fa-solid fa-trash-alt"></i>
 					</button>
 				</div>

--- a/src/routes/(auth)/(project)/workload-identity/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/workload-identity/detail/+page.svelte
@@ -1,7 +1,7 @@
 <script>
 	import * as format from '$lib/format'
 	import { onMount } from 'svelte'
-	import ClipboardJS from 'clipboard'
+	import { setupCopy } from '$lib/clipboard'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
@@ -13,10 +13,7 @@
 	const projectInfo = $derived(data.projectInfo)
 
 	onMount(() => {
-		const copyList = new ClipboardJS('.copy')
-		return () => {
-			copyList.destroy()
-		}
+		return setupCopy('.copy')
 	})
 
 	function deleteItem () {

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -1014,7 +1014,25 @@
 	}
 
 	.icon.copy {
+		position: relative;
 		font-size: var(--fs-6);
+	}
+
+	.icon.copy[data-copied]::after {
+		content: 'Copied!';
+		position: absolute;
+		bottom: calc(100% + 6px);
+		left: 50%;
+		transform: translateX(-50%);
+		background: hsl(var(--hsl-content));
+		color: hsl(var(--hsl-base-100));
+		padding: 2px 8px;
+		border-radius: 4px;
+		font-size: var(--fs-7);
+		line-height: 1.5;
+		white-space: nowrap;
+		pointer-events: none;
+		z-index: 50;
 	}
 
 	.icon:hover {

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -1021,14 +1021,14 @@
 	.icon.copy[data-copied]::after {
 		content: 'Copied!';
 		position: absolute;
-		bottom: calc(100% + 6px);
+		bottom: calc(100% + 4px);
 		left: 50%;
 		transform: translateX(-50%);
 		background: hsl(var(--hsl-content));
 		color: hsl(var(--hsl-base-100));
-		padding: 2px 8px;
-		border-radius: 4px;
-		font-size: var(--fs-7);
+		padding: 1px 6px;
+		border-radius: 3px;
+		font-size: var(--fs-1);
 		line-height: 1.5;
 		white-space: nowrap;
 		pointer-events: none;


### PR DESCRIPTION
## Summary

- **Shared clipboard utility** (`src/lib/clipboard.js`): `setupCopy(selector)` wraps ClipboardJS and sets `data-copied` on the trigger element for 1.5 s after a successful copy, then removes it.
- **"Copied!" tooltip** (`src/style/app.css`): `.icon.copy[data-copied]::after` renders a small tooltip above the icon using existing design tokens (`--hsl-content` / `--hsl-base-100`). No third-party library needed.
- **6 detail pages migrated**: deployment, domain, domain/cdn-downgrade, registry/tags, pull-secret, workload-identity — all replace the inline `new ClipboardJS('.copy')` block with `return setupCopy('.copy')`.
- **Service account detail page**: adds a copy button (same pattern as pull-secret) inside each key field, and moves the delete button outside the `<div class="input">` wrapper so it can't be accidentally triggered while interacting with the field.

## Test plan

- [ ] Click any copy icon on deployment/domain/registry/pull-secret/workload-identity detail pages — "Copied!" tooltip appears above the icon and disappears after ~1.5 s
- [ ] Verify clipboard content matches the displayed value
- [ ] Service account detail: confirm copy icon copies the key secret
- [ ] Service account detail: confirm delete button is visually separated from the input, requires intentional click, and still triggers the confirmation modal
- [ ] Check light and dark themes — tooltip uses CSS vars so both should look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)