### PR TITLE
feat: surface DNS verification flow for non-CDN domains

### DIFF
--- a/src/lib/format/index.js
+++ b/src/lib/format/index.js
@@ -46,11 +46,11 @@ export function storage (v) {
 }
 
 /**
- * @param {string} v
+ * @param {string | undefined | null} v
  * @returns {string}
  */
 export function datetime (v) {
-	if (!v) {
+	if (!v || v.startsWith('0001-01-01')) {
 		return ''
 	}
 	return dayjs(v).format('YYYY-MM-DD HH:mm:ss')

--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -290,16 +290,12 @@
 				</p>
 			{/if}
 
-			{#if domain.verification?.dns?.verifiedAt}
-				<p class="text-sm opacity-80">
-					Last verified: {format.datetime(domain.verification.dns.verifiedAt)}
-				</p>
-			{/if}
-			{#if domain.verification?.dns?.lastCheckedAt}
-				<p class="text-sm opacity-80">
-					Last checked: {format.datetime(domain.verification.dns.lastCheckedAt)}
-				</p>
-			{/if}
+			<p class="text-sm opacity-80">
+				Last verified: {format.datetime(domain.verification?.dns?.verifiedAt) || '-'}
+			</p>
+			<p class="text-sm opacity-80">
+				Last checked: {format.datetime(domain.verification?.dns?.lastCheckedAt) || '-'}
+			</p>
 			{#if (domain.verification?.dns?.errors ?? []).length > 0}
 				{#each domain.verification.dns.errors as e, i (i)}
 					<p class="text-negative text-content/80">{e}</p>

--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -307,51 +307,57 @@
 			{/if}
 		{/if}
 
-		{#if domain.verification?.ownership?.type}
-			<hr>
-			<p>
-				<strong>
-					{#if domain.cdn}
-						Domain Verification
-					{:else if domain.wildcard}
-						Ownership TXT Record
-					{:else}
-						Proxied DNS (alternative)
-					{/if}
-				</strong>
-			</p>
-			{#if !domain.cdn && !domain.wildcard}
-				<p class="text-sm opacity-80">
-					If your DNS sits behind a CDN/proxy (e.g. Cloudflare) so the A/AAAA
-					records can't resolve to this location directly, add this TXT record
-					to prove ownership and we'll accept the proxied setup.
+		{#snippet ownershipBlock()}
+			{#if domain.verification?.ownership?.type}
+				<hr>
+				<p>
+					<strong>
+						{#if domain.cdn}
+							Domain Verification
+						{:else if domain.wildcard}
+							Ownership TXT Record
+						{:else}
+							Proxied DNS (alternative)
+						{/if}
+					</strong>
 				</p>
-			{/if}
-			{#if (domain.verification.ownership.errors ?? []).length > 0}
-				{#each domain.verification.ownership.errors as e, i (i)}
-					<p class="text-negative text-content/80">{e}</p>
-				{/each}
-			{/if}
-			<div class="field">
-				<label for="input-owner_name">TXT Name</label>
-				<div class="input -has-icon-right mb-1">
-					<input id="input-owner_name" value={domain.verification.ownership.name} readonly disabled>
-					<span class="icon -is-right copy"
-						data-clipboard-text={domain.verification.ownership.name}>
-						<i class="fa-light fa-copy"></i>
-					</span>
+				{#if !domain.cdn && !domain.wildcard}
+					<p class="text-sm opacity-80">
+						If your DNS sits behind a CDN/proxy (e.g. Cloudflare) so the A/AAAA
+						records can't resolve to this location directly, add this TXT record
+						to prove ownership and we'll accept the proxied setup.
+					</p>
+				{/if}
+				{#if (domain.verification.ownership.errors ?? []).length > 0}
+					{#each domain.verification.ownership.errors as e, i (i)}
+						<p class="text-negative text-content/80">{e}</p>
+					{/each}
+				{/if}
+				<div class="field">
+					<label for="input-owner_name">TXT Name</label>
+					<div class="input -has-icon-right mb-1">
+						<input id="input-owner_name" value={domain.verification.ownership.name} readonly disabled>
+						<span class="icon -is-right copy"
+							data-clipboard-text={domain.verification.ownership.name}>
+							<i class="fa-light fa-copy"></i>
+						</span>
+					</div>
 				</div>
-			</div>
-			<div class="field">
-				<label for="input-owner_value">TXT Value</label>
-				<div class="input -has-icon-right mb-1">
-					<input id="input-owner_value" value={domain.verification.ownership.value} readonly disabled>
-					<span class="icon -is-right copy"
-						data-clipboard-text={domain.verification.ownership.value}>
-						<i class="fa-light fa-copy"></i>
-					</span>
+				<div class="field">
+					<label for="input-owner_value">TXT Value</label>
+					<div class="input -has-icon-right mb-1">
+						<input id="input-owner_value" value={domain.verification.ownership.value} readonly disabled>
+						<span class="icon -is-right copy"
+							data-clipboard-text={domain.verification.ownership.value}>
+							<i class="fa-light fa-copy"></i>
+						</span>
+					</div>
 				</div>
-			</div>
+			{/if}
+		{/snippet}
+
+		{#if domain.cdn || domain.wildcard}
+			{@render ownershipBlock()}
 		{/if}
 
 		{#if (domain.verification?.ssl?.records ?? []).length > 0}
@@ -449,6 +455,10 @@
 					{/each}
 				</div>
 			{/if}
+		{/if}
+
+		{#if !domain.cdn && !domain.wildcard}
+			{@render ownershipBlock()}
 		{/if}
 
 		{#if domain.cdn && domain.status === 'success'}

--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -24,13 +24,17 @@
 		}
 	})
 	function handleReload () {
-		if (!['pending', 'verify'].includes(domain.status)) {
+		const nonCdnAwaitingDns = !domain.cdn && domain.status !== 'success'
+		if (!['pending', 'verify'].includes(domain.status) && !nonCdnAwaitingDns) {
 			return
 		}
 		const f = async () => {
 			reloadTimeout = null
 			await api.invalidate('domain.get')
-			if (domain.status === 'pending') {
+			// Non-CDN DNS verification runs on a cron at minute-scale, no point polling faster.
+			if (!domain.cdn && domain.status !== 'success') {
+				reloadTimeout = setTimeout(f, 30000)
+			} else if (domain.status === 'pending') {
 				reloadTimeout = setTimeout(f, 3000)
 			} else if (domain.status === 'verify') {
 				reloadTimeout = setTimeout(f, 5000)
@@ -253,7 +257,7 @@
 			</div>
 		</div>
 
-		{#if domain.status === 'pending'}
+		{#if domain.cdn && domain.status === 'pending'}
 			<hr>
 			<p><strong>Domain Verification</strong></p>
 			<div class="text-2xl">
@@ -261,9 +265,68 @@
 			</div>
 		{/if}
 
+		{#if !domain.cdn && domain.status !== 'success'}
+			<hr>
+			<p><strong>DNS Verification</strong></p>
+			<p class="text-sm opacity-80">
+				{#if domain.wildcard}
+					Wildcard DNS can't resolve to a single IP, so verify ownership by
+					adding the TXT record below. We re-check every few minutes and
+					switch the domain to <strong>success</strong> once the record is
+					visible.
+				{:else}
+					Point your DNS at the records below. We re-check every few minutes
+					and switch the domain to <strong>success</strong> once it resolves
+					to this location. If your DNS is behind a CDN/proxy and the A/AAAA
+					records can't resolve to us directly, add the TXT record under
+					<em>Proxied DNS (alternative)</em> instead.
+				{/if}
+			</p>
+
+			{#if domain.status === 'error'}
+				<p class="text-negative text-content/80">
+					DNS verification has been failing for over 48 hours. The certificate
+					has been torn down. Re-point DNS and we'll re-verify automatically.
+				</p>
+			{/if}
+
+			{#if domain.verification?.dns?.verifiedAt}
+				<p class="text-sm opacity-80">
+					Last verified: {format.datetime(domain.verification.dns.verifiedAt)}
+				</p>
+			{/if}
+			{#if domain.verification?.dns?.lastCheckedAt}
+				<p class="text-sm opacity-80">
+					Last checked: {format.datetime(domain.verification.dns.lastCheckedAt)}
+				</p>
+			{/if}
+			{#if (domain.verification?.dns?.errors ?? []).length > 0}
+				{#each domain.verification.dns.errors as e, i (i)}
+					<p class="text-negative text-content/80">{e}</p>
+				{/each}
+			{/if}
+		{/if}
+
 		{#if domain.verification?.ownership?.type}
 			<hr>
-			<p><strong>Domain Verification</strong></p>
+			<p>
+				<strong>
+					{#if domain.cdn}
+						Domain Verification
+					{:else if domain.wildcard}
+						Ownership TXT Record
+					{:else}
+						Proxied DNS (alternative)
+					{/if}
+				</strong>
+			</p>
+			{#if !domain.cdn && !domain.wildcard}
+				<p class="text-sm opacity-80">
+					If your DNS sits behind a CDN/proxy (e.g. Cloudflare) so the A/AAAA
+					records can't resolve to this location directly, add this TXT record
+					to prove ownership and we'll accept the proxied setup.
+				</p>
+			{/if}
 			{#if (domain.verification.ownership.errors ?? []).length > 0}
 				{#each domain.verification.ownership.errors as e, i (i)}
 					<p class="text-negative text-content/80">{e}</p>
@@ -342,7 +405,7 @@
 			{/if}
 		{/if}
 
-		{#if domain.status === 'success' || domain.status === 'verify'}
+		{#if domain.status === 'success' || domain.status === 'verify' || (!domain.cdn && !domain.wildcard)}
 			<hr>
 			{#if (domain.dnsConfig.ipv4 ?? []).length > 0}
 				<div class="field">

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -136,6 +136,11 @@ declare namespace Api {
                 }[]
                 errors: string[]
             }
+            dns: {
+                verifiedAt?: string
+                lastCheckedAt?: string
+                errors?: string[]
+            }
         },
         dnsConfig: {
             ipv4: string[]


### PR DESCRIPTION
## Summary

Companion to [api#14](https://github.com/deploys-app/api/pull/14), [apiserver#34](https://github.com/deploys-app/apiserver/pull/34), and [deployer#4](https://github.com/deploys-app/deployer/pull/4): non-CDN domains no longer auto-success on create. They stay in `pending` until a background cron verifies DNS, and can flip to `error` if DNS is lost for >48h. The console needed UI to support that lifecycle — show the records to configure, the cron's last check/verify timestamps, and the TXT ownership fallback for proxied DNS.

## Changes

- **`src/types/api.d.ts`** — added `verification.dns` (`verifiedAt`, `lastCheckedAt`, `errors`) to `Api.Domain` to mirror the new field returned by the apiserver.
- **`src/routes/(auth)/(project)/domain/detail/+page.svelte`**:
  - New **DNS Verification** section for non-CDN domains in non-success state, with wildcard-aware copy explaining what to configure, plus the cron's last-verified / last-checked timestamps and any errors.
  - Re-labelled the ownership-TXT block so it reads as **Proxied DNS (alternative)** for non-wildcard non-CDN, **Ownership TXT Record** for wildcard non-CDN, and keeps the original **Domain Verification** label for CDN.
  - Show DNS records (A/AAAA/CNAME) for non-CDN non-wildcard regardless of status, so users can copy them while in `pending`/`error`.
  - Polling now also covers non-CDN `error` (so users see recovery), at a 30s cadence matching the cron's minute-scale schedule.

The list page didn't need changes — non-CDN pending already renders the spinner via `StatusIcon`, and the CDN+SSL `verify` override is untouched.

## Test plan

- [ ] Create a non-CDN domain on a project where the corresponding apiserver version is deployed; verify the detail page shows DNS Verification, both record sets (A/AAAA/CNAME + TXT), and the apiserver's `dns.lastCheckedAt` once the cron has run.
- [ ] Create a non-CDN **wildcard** domain; verify only the TXT block is shown (no A/AAAA), and the copy makes clear TXT is the only option.
- [ ] Point DNS correctly, wait for the cron; the page should auto-refresh (≤30s) and flip to `success` with the DNS records still visible.
- [ ] Remove DNS to drive an `error` state; verify the cert-torn-down notice appears and polling continues.
- [ ] Create a CDN domain; verify the original Domain Verification + SSL/TLS sections look unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)