### PR TITLE
feat: surface DNS errors on success domains before tear-down

### DIFF
--- a/src/routes/(auth)/(project)/domain/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/+page.svelte
@@ -56,10 +56,15 @@
 			</thead>
 			<tbody>
 				{#each domains as it (`${it.domain}-${it.location}`)}
+					{@const dnsHasErrors = !it.cdn && (it.verification?.dns?.errors?.length ?? 0) > 0}
 					<tr>
 						<td>
 							<StatusIcon status={it.cdn && it.verification.ssl.pending ? 'verify' : it.status} />
 							<a href={`/domain/detail?project=${project}&domain=${it.domain}`} class="link">{it.domain}</a>
+							{#if dnsHasErrors}
+								<i class="fa-solid fa-triangle-exclamation text-warning ml-2"
+									title="DNS verification is failing. Open the domain to see details."></i>
+							{/if}
 						</td>
 						<td>
 							{#if it.wildcard}

--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -11,6 +11,8 @@
 
 	const project = $derived(data.project)
 	const domain = $derived(data.domain)
+	const dnsErrors = $derived(domain.verification?.dns?.errors ?? [])
+	const hasDnsErrors = $derived(dnsErrors.length > 0)
 
 	onMount(() => {
 		return setupCopy('.copy')
@@ -24,15 +26,15 @@
 		}
 	})
 	function handleReload () {
-		const nonCdnAwaitingDns = !domain.cdn && domain.status !== 'success'
-		if (!['pending', 'verify'].includes(domain.status) && !nonCdnAwaitingDns) {
+		const nonCdnDnsNeedsAttention = !domain.cdn && (domain.status !== 'success' || hasDnsErrors)
+		if (!['pending', 'verify'].includes(domain.status) && !nonCdnDnsNeedsAttention) {
 			return
 		}
 		const f = async () => {
 			reloadTimeout = null
 			await api.invalidate('domain.get')
 			// Non-CDN DNS verification runs on a cron at minute-scale, no point polling faster.
-			if (!domain.cdn && domain.status !== 'success') {
+			if (!domain.cdn && (domain.status !== 'success' || hasDnsErrors)) {
 				reloadTimeout = setTimeout(f, 30000)
 			} else if (domain.status === 'pending') {
 				reloadTimeout = setTimeout(f, 3000)
@@ -265,28 +267,36 @@
 			</div>
 		{/if}
 
-		{#if !domain.cdn && domain.status !== 'success'}
+		{#if !domain.cdn && (domain.status !== 'success' || hasDnsErrors)}
 			<hr>
 			<p><strong>DNS Verification</strong></p>
-			<p class="text-sm opacity-80">
-				{#if domain.wildcard}
-					Wildcard DNS can't resolve to a single IP, so verify ownership by
-					adding the TXT record below. We re-check every few minutes and
-					switch the domain to <strong>success</strong> once the record is
-					visible.
-				{:else}
-					Point your DNS at the records below. We re-check every few minutes
-					and switch the domain to <strong>success</strong> once it resolves
-					to this location. If your DNS is behind a CDN/proxy and the A/AAAA
-					records can't resolve to us directly, add the TXT record under
-					<em>Proxied DNS (alternative)</em> instead.
-				{/if}
-			</p>
+			{#if domain.status !== 'success'}
+				<p class="text-sm opacity-80">
+					{#if domain.wildcard}
+						Wildcard DNS can't resolve to a single IP, so verify ownership by
+						adding the TXT record below. We re-check every few minutes and
+						switch the domain to <strong>success</strong> once the record is
+						visible.
+					{:else}
+						Point your DNS at the records below. We re-check every few minutes
+						and switch the domain to <strong>success</strong> once it resolves
+						to this location. If your DNS is behind a CDN/proxy and the A/AAAA
+						records can't resolve to us directly, add the TXT record under
+						<em>Proxied DNS (alternative)</em> instead.
+					{/if}
+				</p>
 
-			{#if domain.status === 'error'}
+				{#if domain.status === 'error'}
+					<p class="text-negative text-content/80">
+						DNS verification has been failing for over 48 hours. The certificate
+						has been torn down. Re-point DNS and we'll re-verify automatically.
+					</p>
+				{/if}
+			{:else}
 				<p class="text-negative text-content/80">
-					DNS verification has been failing for over 48 hours. The certificate
-					has been torn down. Re-point DNS and we'll re-verify automatically.
+					DNS verification is currently failing. If this isn't resolved within
+					48 hours, the certificate will be torn down. Re-check your DNS
+					configuration against the records below.
 				</p>
 			{/if}
 
@@ -296,8 +306,8 @@
 			<p class="text-sm opacity-80">
 				Last checked: {format.datetime(domain.verification?.dns?.lastCheckedAt) || '-'}
 			</p>
-			{#if (domain.verification?.dns?.errors ?? []).length > 0}
-				{#each domain.verification.dns.errors as e, i (i)}
+			{#if hasDnsErrors}
+				{#each dnsErrors as e, i (i)}
 					<p class="text-negative text-content/80">{e}</p>
 				{/each}
 			{/if}


### PR DESCRIPTION
## Summary

- Show the DNS Verification panel on the domain detail page when a non-CDN domain is at `status === 'success'` but `verification.dns.errors` is non-empty, so users see issues before the 48h tear-down clock runs out.
- In that state, replace the "we'll switch to success" copy with a warning that the certificate will be torn down within 48h if DNS isn't fixed; keep showing last-verified / last-checked timestamps and the raw error lines.
- Extend the existing 30s polling so the page keeps refreshing while DNS errors are present on a success domain, picking up the cron's next check.

## Why

DNS verification for non-CDN domains keeps running on a cron after a domain goes `success`. If subsequent checks fail, the domain silently accumulates errors for up to 48 hours, then the certificate is torn down. Previously the detail page hid all DNS info once status was `success`, so users had no signal until tear-down already happened.

## Test plan

- [ ] Open a non-CDN domain at `status === 'success'` with no DNS errors — DNS Verification panel stays hidden (existing behavior).
- [ ] Open a non-CDN domain at `status === 'success'` with `verification.dns.errors` populated — panel renders with the tear-down warning, timestamps, and the error lines; page polls every 30s.
- [ ] Open a non-CDN domain at `status === 'error'` — existing 48h tear-down message still shows.
- [ ] Open a non-CDN domain at `status === 'pending'` / `'verify'` — existing copy and faster polling unchanged.
- [ ] CDN domains — unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)