### PR TITLE
feat: show status icon on domain detail header

### DIFF
--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -5,6 +5,7 @@
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
+	import StatusIcon from '$lib/components/StatusIcon.svelte'
 	import Swal from 'sweetalert2'
 
 	const { data } = $props()
@@ -13,6 +14,7 @@
 	const domain = $derived(data.domain)
 	const dnsErrors = $derived(domain.verification?.dns?.errors ?? [])
 	const hasDnsErrors = $derived(dnsErrors.length > 0)
+	const headerStatus = $derived(domain.cdn && domain.verification?.ssl?.pending ? 'verify' : domain.status)
 
 	onMount(() => {
 		return setupCopy('.copy')
@@ -214,8 +216,13 @@
 <br>
 <div class="panel is-level-300 grid gap-6">
 	<div class="grid grid-cols-1 gap-3">
-		<h3>
+		<h3 class="flex items-center">
+			<StatusIcon status={headerStatus} />
 			<strong>Domain: {domain.domain}</strong>
+			{#if hasDnsErrors}
+				<i class="fa-solid fa-triangle-exclamation text-warning ml-3"
+					title="DNS verification is failing. See details below."></i>
+			{/if}
 		</h3>
 	</div>
 


### PR DESCRIPTION
## Summary
- Add the same `StatusIcon` shown in the domain list to the domain detail header, so users can see at a glance whether the domain is `pending`, `verify`, `success`, or `error` without scrolling through the page.
- Reuse the listing's `cdn && ssl.pending → 'verify'` logic so CDN domains awaiting SSL display the warning icon, matching what users already see in the table.
- Render the DNS-error warning triangle next to the title when non-CDN DNS verification is failing (same icon and tooltip as the list).

## Test plan
- [ ] Open a pending CDN domain — header shows the spinner.
- [ ] Open a CDN domain with SSL still pending — header shows the warning/verify icon.
- [ ] Open a successful domain — header shows the green check.
- [ ] Open a non-CDN domain with DNS errors — header shows the success/verify icon plus the orange triangle next to the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)