### PR TITLE
fix: show SSL/TLS verification block when only DCV CNAME is set

### DIFF
--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -373,7 +373,7 @@
 			{@render ownershipBlock()}
 		{/if}
 
-		{#if (domain.verification?.ssl?.records ?? []).length > 0}
+		{#if (domain.verification?.ssl?.records ?? []).length > 0 || domain.verification?.ssl?.dcv?.name}
 			<hr>
 			<p><strong>SSL/TLS Verification</strong></p>
 


### PR DESCRIPTION
## Summary

One-line gate change in the domain detail page so wildcard non-CDN domains see their `_acme-challenge.<domain>` CNAME.

## Why

The outer `{#if (domain.verification?.ssl?.records ?? []).length > 0}` at `domain/detail/+page.svelte:376` hid the entire **SSL/TLS Verification** block whenever the legacy `verification.ssl.records` array was empty. The apiserver's new wildcard non-CDN flow (deploys-app/apiserver#43) populates `verification.ssl.dcv` instead, leaving `records` empty — so users would never see the CNAME they need to add for the wildcard cert to issue via DNS-01.

The inner branch already knows how to render either shape:
```svelte
{#if domain.verification.ssl.dcv.name}
  <!-- DCV CNAME -->
{:else}
  {#each domain.verification.ssl.records as it … }
  <!-- legacy TXT records -->
{/each}
{/if}
```

Only the outer condition needed extending.

## Diff

```diff
- {#if (domain.verification?.ssl?.records ?? []).length > 0}
+ {#if (domain.verification?.ssl?.records ?? []).length > 0 || domain.verification?.ssl?.dcv?.name}
```

## Test plan

- [x] `bun lint` clean.
- [x] `bun check` clean.
- [ ] Open a wildcard non-CDN domain in the console — block now renders the CNAME Name + CNAME Value fields with copy-to-clipboard, matching the existing UX of the ownership TXT.
- [ ] Open a non-wildcard non-CDN domain — block stays hidden (no `dcv.name`, no `records`).
- [ ] Open a legacy-style CDN domain that uses `ssl.records` (Cloudflare custom hostname path) — still renders the legacy TXT records, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)