### PR TITLE
fix: clearer DNS-verification copy for wildcard awaiting DCV CNAME

### DIFF
--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -299,6 +299,13 @@
 						has been torn down. Re-point DNS and we'll re-verify automatically.
 					</p>
 				{/if}
+			{:else if domain.wildcard}
+				<p class="text-content/80">
+					Ownership is confirmed. The wildcard certificate can't be issued
+					until you also add the SSL/TLS CNAME record above. We re-check
+					every few minutes and issue the certificate automatically once
+					the CNAME resolves.
+				</p>
 			{:else}
 				<p class="text-negative text-content/80">
 					DNS verification is currently failing. If this isn't resolved within


### PR DESCRIPTION
## Summary

Adds a wildcard-specific message in the DNS Verification block so users understand the new "ownership OK, cert blocked on DCV CNAME" state introduced by deploys-app/apiserver#44.

## Why

Today's post-success branch reads:

> DNS verification is currently failing. If this isn't resolved within 48 hours, the certificate will be torn down. Re-check your DNS configuration against the records below.

That's correct for a previously-Success domain that lost its A/AAAA. It's **wrong** for the new case: a freshly-verified wildcard non-CDN domain where ownership TXT is confirmed, status flipped to Success, but `cert_status` is held at `none` because the `_acme-challenge.<domain>` CNAME isn't set yet. There's no cert to tear down, and the cert-at-risk warning is misleading.

The new third branch shows up only when `domain.wildcard && status === 'success' && hasDnsErrors`:

> Ownership is confirmed. The wildcard certificate can't be issued until you also add the SSL/TLS CNAME record above. We re-check every few minutes and issue the certificate automatically once the CNAME resolves.

Below it, the existing `{#each dnsErrors}` loop still renders the underlying error from the apiserver (e.g. `CNAME record _acme-challenge.example.com not found (expected 42.acme.deploys.app)`), so users see the exact missing or mismatched record.

## Diff

```diff
-				{:else}
+				{:else if domain.wildcard}
+					<p class="text-content/80">
+						Ownership is confirmed. The wildcard certificate can't be issued
+						until you also add the SSL/TLS CNAME record above. We re-check
+						every few minutes and issue the certificate automatically once
+						the CNAME resolves.
+					</p>
+				{:else}
 					<p class="text-negative text-content/80">
 						DNS verification is currently failing. If this isn't resolved within
 						48 hours, the certificate will be torn down. Re-check your DNS
 						configuration against the records below.
 					</p>
 				{/if}
```

## Test plan

- [x] `bun lint` clean.
- [x] `bun check` clean.
- [ ] **Wildcard non-CDN, ownership TXT set, DCV CNAME missing** — status=success, hasDnsErrors=true. The DNS Verification block renders with the new ownership-confirmed copy (not red), and the underlying "CNAME not found" message is listed below. The SSL/TLS Verification block above still shows the CNAME the user needs to add.
- [ ] **Wildcard non-CDN, both records set** — block hides (status=success && no errors).
- [ ] **Apex non-CDN that lost its A record** — still falls through to the existing red `text-negative` cert-at-risk copy. Unchanged.
- [ ] **Pending non-CDN (apex or wildcard)** — still hits the first branch with the "point your DNS … / wildcard ownership" copy. Unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)