### PR TITLE
fix: text copy for proxied-apex TXT-fallback after apiserver #45

### DIFF
--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -289,7 +289,9 @@
 						and switch the domain to <strong>success</strong> once it resolves
 						to this location. If your DNS is behind a CDN/proxy and the A/AAAA
 						records can't resolve to us directly, add the TXT record under
-						<em>Proxied DNS (alternative)</em> instead.
+						<em>Proxied DNS (alternative)</em>. That proves ownership but
+						doesn't enable certificate issuance — point DNS directly if you
+						need us to issue a TLS certificate.
 					{/if}
 				</p>
 
@@ -307,10 +309,9 @@
 					the CNAME resolves.
 				</p>
 			{:else}
-				<p class="text-negative text-content/80">
-					DNS verification is currently failing. If this isn't resolved within
-					48 hours, the certificate will be torn down. Re-check your DNS
-					configuration against the records below.
+				<p class="text-content/80">
+					We can't issue or renew a TLS certificate with your current DNS
+					setup. Re-check your DNS configuration against the records below.
 				</p>
 			{/if}
 


### PR DESCRIPTION
## Summary

Two small text-only edits in `domain/detail/+page.svelte` so the copy matches the new apiserver behavior in deploys-app/apiserver#45 (apex TXT-fallback now confirms ownership but holds `cert_status` — proxied-apex users get status=success without a cert via HTTP-01).

## Edit 1 — pre-success apex: clarify TXT-fallback caveat

Today's copy sells the Proxied DNS TXT as a working alternative path. After #45 it isn't — TXT-only confirms ownership but won't get a TLS cert. Users who follow this path reach status=Success and wonder why their domain has no TLS.

```diff
- … add the TXT record under <em>Proxied DNS (alternative)</em> instead.
+ … add the TXT record under <em>Proxied DNS (alternative)</em>. That
+ proves ownership but doesn't enable certificate issuance — point
+ DNS directly if you need us to issue a TLS certificate.
```

The record itself stays visible in the form below; this just sets expectations correctly.

## Edit 2 — post-success failure: drop the "48h tear-down" framing

Today's catch-all message:

```diff
- DNS verification is currently failing. If this isn't resolved within
- 48 hours, the certificate will be torn down. Re-check your DNS
- configuration against the records below.
+ We can't issue or renew a TLS certificate with your current DNS
+ setup. Re-check your DNS configuration against the records below.
```

This branch fires for two different scenarios. The old copy was correct for "direct apex that lost its A record" (there IS a cert, will be torn down). It's wrong for "proxied apex never had a cert" (nothing to tear down). The new neutral copy works for both — the apiserver's specific error string still renders below to tell the user the actual reason.

The terminal 48h-tear-down warning lives in the `status === 'error'` branch and stays untouched — when the cert really is torn down, that branch fires with its accurate message.

## Test plan

- [x] `bun lint` clean.
- [x] `bun check` clean.
- [ ] **Proxied apex (new, post #45)** — status=success, hasDnsErrors=true. Block renders with the new neutral copy. Apiserver's "DNS isn't pointing directly…" error appears below. No more red 48h alarm.
- [ ] **Direct apex that lost A record** — same branch, same neutral copy. Apiserver's "A/AAAA records … do not match" message appears below. (If failure persists, the row eventually flips to status=error and the existing terminal "cert has been torn down" message takes over.)
- [ ] **Apex in Pending** — new caveat sentence appears at the end of the "Point your DNS at the records below…" paragraph.
- [ ] **Wildcard branches** — completely unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)