### PR TITLE
fix: make domain detail page responsive on narrow viewports

### DIFF
--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -323,7 +323,7 @@
 			</p>
 			{#if hasDnsErrors}
 				{#each dnsErrors as e, i (i)}
-					<p class="text-negative text-content/80">{e}</p>
+					<p class="text-negative text-content/80 break-all">{e}</p>
 				{/each}
 			{/if}
 		{/if}
@@ -351,7 +351,7 @@
 				{/if}
 				{#if (domain.verification.ownership.errors ?? []).length > 0}
 					{#each domain.verification.ownership.errors as e, i (i)}
-						<p class="text-negative text-content/80">{e}</p>
+						<p class="text-negative text-content/80 break-all">{e}</p>
 					{/each}
 				{/if}
 				<div class="field">

--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -208,17 +208,17 @@
 	<div class="breadcrumb-item">
 		<a href={`/domain?project=${project}`} class="link"><h6>Domains</h6></a>
 	</div>
-	<div class="breadcrumb-item">
-		<h6>{domain.domain}</h6>
+	<div class="breadcrumb-item min-w-0">
+		<h6 class="min-w-0 break-all">{domain.domain}</h6>
 	</div>
 </div>
 
 <br>
 <div class="panel is-level-300 grid gap-6">
 	<div class="grid grid-cols-1 gap-3">
-		<h3 class="flex items-center">
+		<h3 class="flex flex-wrap items-center gap-y-2 min-w-0">
 			<StatusIcon status={headerStatus} />
-			<strong>Domain: {domain.domain}</strong>
+			<strong class="min-w-0 break-all">Domain: {domain.domain}</strong>
 			{#if hasDnsErrors}
 				<i class="fa-solid fa-triangle-exclamation text-warning ml-3"
 					title="DNS verification is failing. See details below."></i>
@@ -488,8 +488,8 @@
 				<div class="mb-3">
 					<strong>Purge Cache</strong>
 				</div>
-				<div class="bg-base-100 p-6 border border-negative border-current/70 rounded-md">
-					<div class="flex lg:flex-row flex-col gap-6 lg:items-center">
+				<div class="bg-base-100 p-4 sm:p-6 border border-negative/70 rounded-md">
+					<div class="flex lg:flex-row flex-col gap-4 lg:gap-6 lg:items-center">
 						<div class="flex-1 grid grid-cols-1 gap-1">
 							<div><strong>Purge everything</strong></div>
 							<p class="text-sm opacity-80">Remove all cached resources</p>
@@ -498,8 +498,8 @@
 							Purge everything
 						</button>
 					</div>
-					<hr class="my-6">
-					<div class="flex lg:flex-row flex-col gap-6 lg:items-center">
+					<hr class="my-4 sm:my-6">
+					<div class="flex lg:flex-row flex-col gap-4 lg:gap-6 lg:items-center">
 						<div class="flex-1 grid grid-cols-1 gap-1">
 							<div><strong>Purge prefix</strong></div>
 							<p class="text-sm opacity-80">Remove cached resources at prefix path</p>
@@ -508,8 +508,8 @@
 							Purge prefix
 						</button>
 					</div>
-					<hr class="my-6">
-					<div class="flex lg:flex-row flex-col gap-6 lg:items-center">
+					<hr class="my-4 sm:my-6">
+					<div class="flex lg:flex-row flex-col gap-4 lg:gap-6 lg:items-center">
 						<div class="flex-1 grid grid-cols-1 gap-1">
 							<div><strong>Purge file</strong></div>
 							<p class="text-sm opacity-80">Remove cached resources at exact path</p>

--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -209,7 +209,7 @@
 		<a href={`/domain?project=${project}`} class="link"><h6>Domains</h6></a>
 	</div>
 	<div class="breadcrumb-item min-w-0">
-		<h6 class="min-w-0 break-all">{domain.domain}</h6>
+		<h6 class="min-w-0 wrap-anywhere">{domain.domain}</h6>
 	</div>
 </div>
 
@@ -218,7 +218,7 @@
 	<div class="grid grid-cols-1 gap-3">
 		<h3 class="flex flex-wrap items-center gap-y-2 min-w-0">
 			<StatusIcon status={headerStatus} />
-			<strong class="min-w-0 break-all">Domain: {domain.domain}</strong>
+			<strong class="min-w-0 wrap-anywhere">Domain: {domain.domain}</strong>
 			{#if hasDnsErrors}
 				<i class="fa-solid fa-triangle-exclamation text-warning ml-3"
 					title="DNS verification is failing. See details below."></i>
@@ -323,7 +323,7 @@
 			</p>
 			{#if hasDnsErrors}
 				{#each dnsErrors as e, i (i)}
-					<p class="text-negative text-content/80 break-all">{e}</p>
+					<p class="text-negative text-content/80 wrap-anywhere">{e}</p>
 				{/each}
 			{/if}
 		{/if}
@@ -351,7 +351,7 @@
 				{/if}
 				{#if (domain.verification.ownership.errors ?? []).length > 0}
 					{#each domain.verification.ownership.errors as e, i (i)}
-						<p class="text-negative text-content/80 break-all">{e}</p>
+						<p class="text-negative text-content/80 wrap-anywhere">{e}</p>
 					{/each}
 				{/if}
 				<div class="field">


### PR DESCRIPTION
## Summary

The domain detail page didn't degrade gracefully on narrow viewports:

- The header `<h3>` used `flex items-center` with no `flex-wrap`, and the `<strong>` containing the domain name had no `min-w-0`/`break-all`. A long domain (or one with a DNS-error icon trailing it) overflowed horizontally on mobile.
- The breadcrumb's domain item had no break rule either, so a long domain pushed beyond the viewport.
- The Purge Cache box used `p-6` and `my-6` on its dividers — fine on desktop, cramped on phones.
- The same Purge Cache box had `border border-negative border-current/70`, where `border-current/70` overrode `border-negative`, so the intended red danger outline never rendered.

## Changes

- Header h3: `flex-wrap`, `gap-y-2`, `min-w-0`; `<strong>` gets `min-w-0 break-all`.
- Breadcrumb domain item: `min-w-0 break-all` so long domain names wrap.
- Purge Cache panel: responsive padding (`p-4 sm:p-6`), responsive row gaps (`gap-4 lg:gap-6`), responsive dividers (`my-4 sm:my-6`).
- Purge Cache panel: collapse the two conflicting border-color utilities into a single `border-negative/70`.

## Test plan

- [ ] Open `/domain/detail` on a phone-width viewport — header, breadcrumb, and purge-cache box should all stay within the content column with no horizontal scroll.
- [ ] Visit a domain with a long name (e.g. a multi-label subdomain) — the name wraps in both the breadcrumb and the h3.
- [ ] Trigger a DNS error state — the warning icon sits next to the domain name on wide screens and wraps below on narrow ones.
- [ ] CDN domain in `success` state — the Purge Cache box renders with a red 70%-opacity border.
- [ ] Tablet/desktop layout (≥lg) unchanged — purge rows still align side-by-side with the button on the right.

---
_Generated by [Claude Code](https://claude.ai/code/session_017XRYSX1oogz3qvEfPvZzBJ)_