### PR TITLE
feat: show invoices on the billing page

### DIFF
--- a/src/lib/components/InvoiceStatusBadge.svelte
+++ b/src/lib/components/InvoiceStatusBadge.svelte
@@ -1,0 +1,49 @@
+<script>
+	/**
+	 * @typedef {Object} Props
+	 * @property {Api.InvoiceStatus} status
+	 */
+
+	/** @type {Props} */
+	const { status } = $props()
+
+	const badge = $derived.by(() => {
+		if (status === 'paid') return { icon: 'fa-circle-check', cls: 'is-positive', label: 'Paid' }
+		if (status === 'open') return { icon: 'fa-clock', cls: 'is-warning', label: 'Open' }
+		if (status === 'void') return { icon: 'fa-ban', cls: 'is-muted', label: 'Void' }
+		if (status === 'draft') return { icon: 'fa-pen', cls: 'is-muted', label: 'Draft' }
+		return { icon: 'fa-circle', cls: '', label: status }
+	})
+</script>
+
+<style>
+	.invoice-badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		padding: 0.15rem 0.55rem;
+		border-radius: 999px;
+		font-size: 0.8125rem;
+		line-height: 1.25;
+		background: hsl(var(--hsl-content) / 0.08);
+	}
+
+	.invoice-badge.is-positive {
+		color: hsl(var(--hsl-positive));
+		background: hsl(var(--hsl-positive) / 0.12);
+	}
+
+	.invoice-badge.is-warning {
+		color: hsl(var(--hsl-warning, var(--hsl-primary)));
+		background: hsl(var(--hsl-warning, var(--hsl-primary)) / 0.14);
+	}
+
+	.invoice-badge.is-muted {
+		color: hsl(var(--hsl-content) / 0.65);
+	}
+</style>
+
+<span class="invoice-badge {badge.cls}" title={badge.label}>
+	<i class="fa-solid {badge.icon}"></i>
+	{badge.label}
+</span>

--- a/src/routes/(auth)/billing/detail/+page.svelte
+++ b/src/routes/(auth)/billing/detail/+page.svelte
@@ -68,6 +68,7 @@
 		<div class="flex gap-4">
 			<a class="button" href={`/billing/create?id=${billingAccount.id}`}>Edit</a>
 			<a class="button" href={`/billing/report?id=${billingAccount.id}`}>Report</a>
+			<a class="button" href={`/billing/invoices?id=${billingAccount.id}`}>Invoices</a>
 			<button class="button" type="button" onclick={deleteItem}>Delete account</button>
 		</div>
 	</div>

--- a/src/routes/(auth)/billing/invoice/+page.js
+++ b/src/routes/(auth)/billing/invoice/+page.js
@@ -1,0 +1,25 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+
+export async function load ({ url, fetch }) {
+	const id = url.searchParams.get('id')
+
+	/** @type {Api.Response<Api.Invoice>} */
+	const invoice = await api.invoke('billing.getInvoice', { id }, fetch)
+	if (!invoice.ok) {
+		if (invoice.error?.notFound) redirect(302, '/billing')
+		error(500, invoice.error?.message)
+	}
+	if (!invoice.result) redirect(302, '/billing')
+
+	/** @type {Api.Response<Api.BillingAccount>} */
+	const billingAccount = await api.invoke('billing.get', { id: invoice.result.billingAccountId }, fetch)
+	if (!billingAccount.ok || !billingAccount.result) {
+		redirect(302, '/billing')
+	}
+
+	return {
+		invoice: invoice.result,
+		billingAccount: billingAccount.result
+	}
+}

--- a/src/routes/(auth)/billing/invoice/+page.svelte
+++ b/src/routes/(auth)/billing/invoice/+page.svelte
@@ -1,0 +1,179 @@
+<script>
+	import dayjs from 'dayjs'
+	import InvoiceStatusBadge from '$lib/components/InvoiceStatusBadge.svelte'
+	import * as format from '$lib/format'
+
+	const { data } = $props()
+
+	const invoice = $derived(data.invoice)
+	const billingAccount = $derived(data.billingAccount)
+
+	const periodLabel = $derived.by(() => {
+		const s = dayjs(invoice.periodStart)
+		const e = dayjs(invoice.periodEnd).subtract(1, 'day')
+		if (s.isSame(e, 'month')) {
+			return s.format('MMMM YYYY')
+		}
+		return `${s.format('YYYY-MM-DD')} → ${e.format('YYYY-MM-DD')}`
+	})
+
+	/**
+	 * @param {number} v
+	 */
+	function money (v) {
+		return `${v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${invoice.currency}`
+	}
+
+	/**
+	 * @param {number} v
+	 */
+	function quantity (v) {
+		return v.toLocaleString(undefined, { maximumFractionDigits: 4 })
+	}
+
+	const taxRatePct = $derived(`${(invoice.taxRate * 100).toLocaleString(undefined, { maximumFractionDigits: 2 })}%`)
+</script>
+
+<style>
+	.totals {
+		display: grid;
+		grid-template-columns: max-content max-content;
+		justify-content: end;
+		column-gap: 2rem;
+		row-gap: 0.4rem;
+		margin-top: 1.5rem;
+	}
+
+	.totals .label {
+		color: hsl(var(--hsl-content) / 0.7);
+	}
+
+	.totals .value {
+		text-align: right;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.totals .grand.label,
+	.totals .grand.value {
+		font-weight: 600;
+		font-size: 1.05rem;
+		padding-top: 0.5rem;
+		border-top: 1px solid hsl(var(--hsl-content) / 0.15);
+	}
+
+	.meta {
+		display: grid;
+		grid-template-columns: max-content 1fr;
+		column-gap: 1.5rem;
+		row-gap: 0.4rem;
+	}
+
+	.meta .key {
+		color: hsl(var(--hsl-content) / 0.65);
+	}
+
+	.is-align-right {
+		text-align: right;
+	}
+</style>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href="/billing" class="link"><h6>Billing</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<a href={`/billing/detail?id=${billingAccount.id}`} class="link"><h6>{billingAccount.name}</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<a href={`/billing/invoices?id=${billingAccount.id}`} class="link"><h6>Invoices</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<h6>{invoice.number}</h6>
+	</div>
+</div>
+
+<br>
+
+<div class="panel is-level-300 grid gap-6">
+	<div class="flex flex-wrap items-center justify-between gap-3">
+		<div>
+			<h3 class="mb-1"><strong>{invoice.number}</strong></h3>
+			<div class="text-content/70">{periodLabel}</div>
+		</div>
+		<InvoiceStatusBadge status={invoice.status} />
+	</div>
+
+	<hr>
+
+	<div class="grid gap-6 lg:grid-cols-2">
+		<div>
+			<h6 class="mb-3"><strong>Bill to</strong></h6>
+			<div class="meta">
+				<div class="key">Name</div>
+				<div>{invoice.taxName}</div>
+				<div class="key">Tax ID</div>
+				<div>{invoice.taxId}</div>
+				<div class="key">Address</div>
+				<div class="whitespace-pre-line">{invoice.taxAddress}</div>
+			</div>
+		</div>
+		<div>
+			<h6 class="mb-3"><strong>Details</strong></h6>
+			<div class="meta">
+				<div class="key">Issued at</div>
+				<div>{format.datetime(invoice.issuedAt)}</div>
+				<div class="key">Paid at</div>
+				<div>{format.datetime(invoice.paidAt) || '—'}</div>
+				{#if invoice.voidedAt && !invoice.voidedAt.startsWith('0001-01-01')}
+					<div class="key">Voided at</div>
+					<div>{format.datetime(invoice.voidedAt)}</div>
+				{/if}
+				<div class="key">Currency</div>
+				<div>{invoice.currency}</div>
+			</div>
+		</div>
+	</div>
+
+	<hr>
+
+	<div>
+		<h6 class="mb-3"><strong>Line items</strong></h6>
+		<div class="table-container">
+			<table class="table">
+				<thead>
+					<tr>
+						<th>Description</th>
+						<th class="is-align-right">Quantity</th>
+						<th>Unit</th>
+						<th class="is-align-right">Unit price</th>
+						<th class="is-align-right">Amount</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each invoice.lineItems as it, i (i)}
+						<tr>
+							<td>{it.description || it.sku}</td>
+							<td class="is-align-right">{quantity(it.quantity)}</td>
+							<td>{it.unit}</td>
+							<td class="is-align-right">{money(it.unitPrice)}</td>
+							<td class="is-align-right">{money(it.amount)}</td>
+						</tr>
+					{:else}
+						<tr>
+							<td colspan="5" class="text-content/60">No line items</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+
+		<div class="totals">
+			<div class="label">Subtotal</div>
+			<div class="value">{money(invoice.subtotal)}</div>
+			<div class="label">Tax ({taxRatePct})</div>
+			<div class="value">{money(invoice.taxAmount)}</div>
+			<div class="grand label">Total</div>
+			<div class="grand value">{money(invoice.total)}</div>
+		</div>
+	</div>
+</div>

--- a/src/routes/(auth)/billing/invoices/+page.js
+++ b/src/routes/(auth)/billing/invoices/+page.js
@@ -1,0 +1,23 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+
+export async function load ({ url, fetch }) {
+	const id = url.searchParams.get('id')
+
+	/** @type {Api.Response<Api.BillingAccount>} */
+	const billingAccount = await api.invoke('billing.get', { id }, fetch)
+	if (!billingAccount.ok) {
+		if (billingAccount.error?.notFound) redirect(302, '/billing')
+		error(500, billingAccount.error?.message)
+	}
+	if (!billingAccount.result) redirect(302, '/billing')
+
+	/** @type {Api.Response<Api.List<Api.InvoiceListItem>>} */
+	const invoices = await api.invoke('billing.listInvoices', { billingAccountId: id }, fetch)
+
+	return {
+		billingAccount: billingAccount.result,
+		invoices: invoices.result?.items ?? [],
+		error: invoices.error
+	}
+}

--- a/src/routes/(auth)/billing/invoices/+page.svelte
+++ b/src/routes/(auth)/billing/invoices/+page.svelte
@@ -1,0 +1,79 @@
+<script>
+	import dayjs from 'dayjs'
+	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import InvoiceStatusBadge from '$lib/components/InvoiceStatusBadge.svelte'
+	import * as format from '$lib/format'
+
+	const { data } = $props()
+
+	const billingAccount = $derived(data.billingAccount)
+	const invoices = $derived(data.invoices)
+	const error = $derived(data.error)
+
+	/**
+	 * @param {string} periodStart
+	 * @param {string} periodEnd
+	 */
+	function period (periodStart, periodEnd) {
+		const s = dayjs(periodStart)
+		const e = dayjs(periodEnd).subtract(1, 'day')
+		if (s.isSame(e, 'month')) {
+			return s.format('MMM YYYY')
+		}
+		return `${s.format('YYYY-MM-DD')} → ${e.format('YYYY-MM-DD')}`
+	}
+
+	/**
+	 * @param {number} v
+	 * @param {string} currency
+	 */
+	function money (v, currency) {
+		return `${v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${currency}`
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href="/billing" class="link"><h6>Billing</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<a href={`/billing/detail?id=${billingAccount.id}`} class="link"><h6>{billingAccount.name}</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<h6>Invoices</h6>
+	</div>
+</div>
+
+<br>
+
+<div class="panel is-level-300">
+	<div class="table-container mt-4">
+		<table class="table">
+			<thead>
+				<tr>
+					<th>Number</th>
+					<th>Period</th>
+					<th class="is-align-right">Total</th>
+					<th>Status</th>
+					<th>Issued</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each invoices as it (it.id)}
+					<tr>
+						<td>
+							<a class="link" href={`/billing/invoice?id=${it.id}`}>{it.number}</a>
+						</td>
+						<td>{period(it.periodStart, it.periodEnd)}</td>
+						<td class="is-align-right">{money(it.total, it.currency)}</td>
+						<td><InvoiceStatusBadge status={it.status} /></td>
+						<td>{format.datetime(it.issuedAt)}</td>
+					</tr>
+				{/each}
+				<NoDataRow span={5} list={invoices} />
+				<ErrorRow span={5} {error} />
+			</tbody>
+		</table>
+	</div>
+</div>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -404,4 +404,53 @@ declare namespace Api {
         detail: string
         createdAt: string
     }
+
+    export type InvoiceStatus = 'draft' | 'open' | 'paid' | 'void'
+
+    export type InvoiceListItem = {
+        id: string
+        number: string
+        currency: string
+        periodStart: string
+        periodEnd: string
+        subtotal: number
+        taxAmount: number
+        total: number
+        status: InvoiceStatus
+        issuedAt: string
+        paidAt: string
+        voidedAt: string
+        createdAt: string
+    }
+
+    export type InvoiceLineItem = {
+        sku: string
+        description: string
+        quantity: number
+        unit: string
+        unitPrice: number
+        amount: number
+    }
+
+    export type Invoice = {
+        id: string
+        billingAccountId: string
+        number: string
+        currency: string
+        periodStart: string
+        periodEnd: string
+        subtotal: number
+        taxRate: number
+        taxAmount: number
+        total: number
+        status: InvoiceStatus
+        taxId: string
+        taxName: string
+        taxAddress: string
+        issuedAt: string
+        paidAt: string
+        voidedAt: string
+        createdAt: string
+        lineItems: InvoiceLineItem[]
+    }
 }


### PR DESCRIPTION
## Summary
- Adds an **Invoices** button on the billing detail page (`/billing/detail?id=…`) next to Edit / Report / Delete.
- New `/billing/invoices?id=…` lists invoices for the account — Number / Period / Total / Status / Issued.
- New `/billing/invoice?id=…` shows full invoice: status badge, bill-to (tax recipient), line items, and subtotal/tax/total.
- Adds an `InvoiceStatusBadge` component (open / paid / void / draft).
- API: `billing.listInvoices` and `billing.getInvoice` (deploys-app/apiserver#46).
- No **Pay** action — payment is the next feature.

## Test plan
- [ ] `bun lint`
- [ ] `bun check`
- [ ] On a billing account with at least one issued invoice, click **Invoices** → row → confirm detail renders with correct period, status, line items, totals.
- [ ] Visit `/billing/invoice?id=<other-user's-invoice>` and confirm it redirects to `/billing` (not-found surfaces no info).

🤖 Generated with [Claude Code](https://claude.com/claude-code)