### PR TITLE
feat: list uploaded files on the dropbox page via dropbox.list

### DIFF
--- a/src/routes/(auth)/(project)/dropbox/+page.js
+++ b/src/routes/(auth)/(project)/dropbox/+page.js
@@ -1,0 +1,14 @@
+import api from '$lib/api'
+
+const LIMIT = 100
+
+export async function load ({ parent, fetch }) {
+	const { project } = await parent()
+
+	/** @type {Api.Response<Api.List<Api.DropboxItem>>} */
+	const res = await api.invoke('dropbox.list', { project, limit: LIMIT }, fetch)
+	return {
+		items: res.result?.items ?? [],
+		error: res.error
+	}
+}

--- a/src/routes/(auth)/(project)/dropbox/+page.svelte
+++ b/src/routes/(auth)/(project)/dropbox/+page.svelte
@@ -358,7 +358,7 @@
 		{#if loadError}
 			<div class="error-banner">
 				<i class="fa-solid fa-circle-exclamation"></i>
-				<span>{loadError.message}</span>
+				<span>{loadError.message || 'Failed to load files. Please try again.'}</span>
 			</div>
 		{:else if items.length === 0}
 			<small class="text-content/60">No files yet. Upload one above to get a shareable download URL.</small>

--- a/src/routes/(auth)/(project)/dropbox/+page.svelte
+++ b/src/routes/(auth)/(project)/dropbox/+page.svelte
@@ -1,10 +1,14 @@
 <script>
 	import ClipboardJS from 'clipboard'
 	import { onMount } from 'svelte'
+	import api from '$lib/api'
+	import * as format from '$lib/format'
 
 	const { data } = $props()
 
 	const project = $derived(data.project)
+	const items = $derived(data.items)
+	const loadError = $derived(data.error)
 
 	/** @type {HTMLInputElement} */
 	let elFile
@@ -15,9 +19,6 @@
 
 	/** @type {File | null} */
 	let selectedFile = $state(null)
-
-	/** @type {Array<{ name: string, size: number, url: string, uploadedAt: Date }>} */
-	let uploads = $state([])
 
 	onMount(() => {
 		const clip = new ClipboardJS('.copy-url')
@@ -40,13 +41,6 @@
 		if (bytes < 1024 ** 2) return `${(bytes / 1024).toFixed(1)} KB`
 		if (bytes < 1024 ** 3) return `${(bytes / 1024 ** 2).toFixed(1)} MB`
 		return `${(bytes / 1024 ** 3).toFixed(2)} GB`
-	}
-
-	/**
-	 * @param {Date} d
-	 */
-	function formatTime (d) {
-		return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' })
 	}
 
 	function onFileChange () {
@@ -99,7 +93,7 @@
 		uploading = true
 		error = ''
 		try {
-			const resp = await fetch(`/api/dropbox?project=${project}`, {
+			const resp = await fetch(`/api/dropbox?project=${project}&filename=${encodeURIComponent(file.name)}`, {
 				method: 'POST',
 				body: file
 			})
@@ -108,14 +102,8 @@
 				error = res?.error?.message ?? `upload failed (${resp.status})`
 				return
 			}
-			const url = res?.result?.downloadUrl ?? ''
-			if (url) {
-				uploads = [
-					{ name: file.name, size: file.size, url, uploadedAt: new Date() },
-					...uploads
-				]
-			}
 			clearFile()
+			await api.invalidate('dropbox.list')
 		} catch (err) {
 			error = err instanceof Error ? err.message : String(err)
 		} finally {
@@ -360,33 +348,42 @@
 		</div>
 	</form>
 
-	{#if uploads.length > 0}
-		<hr>
-		<div>
-			<div class="flex justify-between items-center mb-3">
-				<strong>Recent uploads</strong>
-				<small class="text-content/60">cleared on page reload</small>
-			</div>
+	<hr>
+	<div>
+		<div class="flex justify-between items-center mb-3">
+			<strong>Files</strong>
+			<small class="text-content/60">expires automatically</small>
+		</div>
 
+		{#if loadError}
+			<div class="error-banner">
+				<i class="fa-solid fa-circle-exclamation"></i>
+				<span>{loadError.message}</span>
+			</div>
+		{:else if items.length === 0}
+			<small class="text-content/60">No files yet. Upload one above to get a shareable download URL.</small>
+		{:else}
 			<div class="uploads">
-				{#each uploads as it (it.url)}
+				{#each items as it (it.downloadUrl)}
 					<div class="upload-item">
 						<span class="upload-icon">
-							<i class="fa-solid fa-circle-check"></i>
+							<i class="fa-solid fa-file"></i>
 						</span>
 						<div class="upload-info">
-							<div class="upload-name">{it.name}</div>
-							<div class="upload-url" title={it.url}>{it.url}</div>
-							<div class="upload-sub">{formatSize(it.size)} · {formatTime(it.uploadedAt)}</div>
+							<div class="upload-name">{it.filename || '(no name)'}</div>
+							<div class="upload-url" title={it.downloadUrl}>{it.downloadUrl}</div>
+							<div class="upload-sub">
+								{formatSize(it.size)} · uploaded {format.datetime(it.createdAt)} · expires {format.datetime(it.expiresAt)}
+							</div>
 						</div>
 						<div class="upload-actions">
 							<button
 								class="icon-button copy-url"
-								class:is-copied={justCopied === it.url}
+								class:is-copied={justCopied === it.downloadUrl}
 								type="button"
-								data-clipboard-text={it.url}
+								data-clipboard-text={it.downloadUrl}
 								aria-label="Copy URL">
-								{#if justCopied === it.url}
+								{#if justCopied === it.downloadUrl}
 									<i class="fa-solid fa-check"></i>
 								{:else}
 									<i class="fa-light fa-copy"></i>
@@ -394,7 +391,7 @@
 							</button>
 							<a
 								class="icon-button"
-								href={it.url}
+								href={it.downloadUrl}
 								target="_blank"
 								rel="noopener noreferrer"
 								aria-label="Open URL">
@@ -404,6 +401,6 @@
 					</div>
 				{/each}
 			</div>
-		</div>
-	{/if}
+		{/if}
+	</div>
 </div>

--- a/src/routes/api/dropbox/+server.js
+++ b/src/routes/api/dropbox/+server.js
@@ -2,6 +2,7 @@
 export async function POST ({ locals, request, url }) {
 	const token = locals.token
 	const project = url.searchParams.get('project')
+	const filename = url.searchParams.get('filename') ?? ''
 
 	if (!token || !project) {
 		return new Response(JSON.stringify({
@@ -16,17 +17,23 @@ export async function POST ({ locals, request, url }) {
 		})
 	}
 
+	/** @type {Record<string, string>} */
+	const headers = {
+		accept: 'application/json',
+		'content-type': request.headers.get('content-type') ?? 'application/octet-stream',
+		'param-project': project,
+		authorization: `bearer ${token}`
+	}
+	if (filename) {
+		headers['param-filename'] = filename
+	}
+
 	const resp = await fetch('https://dropbox.deploys.app/', {
 		method: 'POST',
 		body: request.body,
 		// @ts-expect-error workaround for missing type
 		duplex: 'half',
-		headers: {
-			accept: 'application/json',
-			'content-type': request.headers.get('content-type') ?? 'application/octet-stream',
-			'param-project': project,
-			authorization: `bearer ${token}`
-		}
+		headers
 	})
 	return new Response(resp.body, {
 		status: resp.status,

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -453,4 +453,13 @@ declare namespace Api {
         createdAt: string
         lineItems: InvoiceLineItem[]
     }
+
+    export type DropboxItem = {
+        downloadUrl: string
+        filename: string
+        size: number
+        ttl: number
+        createdAt: string
+        expiresAt: string
+    }
 }

--- a/tests/dropbox.spec.js
+++ b/tests/dropbox.spec.js
@@ -59,4 +59,20 @@ test.describe('dropbox', () => {
 		const main = page.locator('.content-wrapper')
 		await expect(main.getByText('iam: forbidden')).toBeVisible()
 	})
+
+	test('shows a fallback message when the error has no message', async ({ page }) => {
+		// arpc returns {"ok":false,"error":{}} for internal (500) errors, so
+		// the message is empty — the UI must still say something useful.
+		await setMocks({
+			'dropbox.list': {
+				ok: false,
+				error: {}
+			}
+		})
+
+		await page.goto('/dropbox?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('Failed to load files. Please try again.')).toBeVisible()
+	})
 })

--- a/tests/dropbox.spec.js
+++ b/tests/dropbox.spec.js
@@ -1,0 +1,62 @@
+import { test, expect, setMocks } from './helpers.js'
+import { sampleDropboxItem } from './fixtures/mocks.js'
+
+test.describe('dropbox', () => {
+	test('shows empty state when no files', async ({ page }) => {
+		await page.goto('/dropbox?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Dropbox' })).toBeVisible()
+		await expect(main.getByText(/No files yet/)).toBeVisible()
+	})
+
+	test('renders uploaded files from dropbox.list', async ({ page }) => {
+		await setMocks({
+			'dropbox.list': {
+				ok: true,
+				result: { items: [sampleDropboxItem] }
+			}
+		})
+
+		await page.goto('/dropbox?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('report.pdf')).toBeVisible()
+		await expect(main.getByText(sampleDropboxItem.downloadUrl)).toBeVisible()
+		// size formatter prints KB for 2048 bytes.
+		await expect(main.getByText(/2\.0 KB/)).toBeVisible()
+		// the open link points at the download URL.
+		await expect(main.getByRole('link', { name: 'Open URL' }))
+			.toHaveAttribute('href', sampleDropboxItem.downloadUrl)
+	})
+
+	test('falls back to (no name) when filename is empty', async ({ page }) => {
+		await setMocks({
+			'dropbox.list': {
+				ok: true,
+				result: {
+					items: [{ ...sampleDropboxItem, filename: '' }]
+				}
+			}
+		})
+
+		await page.goto('/dropbox?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('(no name)')).toBeVisible()
+	})
+
+	test('surfaces a load error', async ({ page }) => {
+		await setMocks({
+			'dropbox.list': {
+				ok: false,
+				error: { message: 'iam: forbidden' }
+			}
+		})
+
+		await page.goto('/dropbox?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('iam: forbidden')).toBeVisible()
+	})
+})

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -123,6 +123,10 @@ export function defaultMocks () {
 		'/auditLog.list': {
 			ok: true,
 			result: { items: [] }
+		},
+		'/dropbox.list': {
+			ok: true,
+			result: { items: [] }
 		}
 	}
 }
@@ -285,6 +289,15 @@ export const sampleRepository = {
 	name: 'web',
 	size: 12345678,
 	createdAt: now
+}
+
+export const sampleDropboxItem = {
+	downloadUrl: 'https://dropbox.deploys.app/files/abc123',
+	filename: 'report.pdf',
+	size: 2048,
+	ttl: 1,
+	createdAt: now,
+	expiresAt: '2024-01-02T00:00:00Z'
 }
 
 export const sampleAuditLogItem = {


### PR DESCRIPTION
## Summary
- Loads uploaded files via the new `dropbox.list` RPC in `+page.js` and renders them on the dropbox page, replacing the in-memory recent-uploads array (which was cleared on every reload).
- After a successful upload, calls `api.invalidate('dropbox.list')` so the list refreshes from the server — no client/server drift.
- Forwards the picked `filename` through the `/api/dropbox` proxy as `param-filename`, so files actually persist a display name (the dropbox service then writes it to `files.filename`).
- Empty / load-error states surface inline; `(no name)` fallback when `filename` is empty.

## Test plan
- [x] `bun lint` and `bun check` pass
- [x] `bun run test tests/dropbox.spec.js` — empty state, populated list, `(no name)` fallback, load-error banner (4/4 pass)
- [ ] Upload a file end-to-end against the apiserver + dropbox stack and confirm it appears in the list after upload, with the correct filename, size, and expires-at

## Depends on
- apiserver PR https://github.com/deploys-app/apiserver/pull/47 (deploys `dropbox.list`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)