### PR TITLE
Show dropbox egress usage on dashboard

### DIFF
--- a/src/routes/(auth)/(project)/+page.svelte
+++ b/src/routes/(auth)/(project)/+page.svelte
@@ -99,6 +99,12 @@
 			...formatStorage(usage.registryEgress, '')
 		},
 		{
+			key: 'dropboxEgress',
+			icon: 'fa-box-open',
+			label: 'Dropbox Egress',
+			...formatStorage(usage.dropboxEgress, '')
+		},
+		{
 			key: 'replica',
 			icon: 'fa-clone',
 			label: 'Replica',

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -58,6 +58,7 @@ declare namespace Api {
         memory: number
         egress: number
         registryEgress: number
+        dropboxEgress: number
         disk: number
         replica: number
         domainCdn: number


### PR DESCRIPTION
## Summary
- Add `dropboxEgress` to the `ProjectUsage` type and a **Dropbox Egress** usage card to the project dashboard (icon `fa-box-open`, consistent with the Dropbox sidebar entry), fed by the new `project.Usage` field.

## Dependency / ordering
- Requires apiserver deploys-app/apiserver#49 (which adds `dropboxEgress` to `project.Usage`) and api deploys-app/api#18. Deploy apiserver before the console so the field is present; otherwise the card shows `NaN` transiently (same behavior as any newly added usage field).

## Test plan
- [x] `bun lint` — 0 errors
- [x] `bun check` — 0 errors
- [ ] Manual: dashboard shows Dropbox Egress card with usage once apiserver is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)