### PR TITLE
Hide CPU Allocated card on dashboard

### DIFF
--- a/src/routes/(auth)/(project)/+page.svelte
+++ b/src/routes/(auth)/(project)/+page.svelte
@@ -67,12 +67,6 @@
 			...formatAvgCount(usage.cpuUsage, 'vCPUs', 'vCPU-s')
 		},
 		{
-			key: 'cpu',
-			icon: 'fa-gauge-high',
-			label: 'CPU Allocated',
-			...formatAvgCount(usage.cpu, 'vCPUs', 'vCPU-s')
-		},
-		{
 			key: 'memory',
 			icon: 'fa-memory',
 			label: 'Memory',


### PR DESCRIPTION
## Summary
- Remove the **CPU Allocated** (`cpu`) card from the project dashboard usage panel. CPU allocation is not billed — the `cpu` SKU is disabled (commented out) in the billing cron — so the card was showing a non-billable metric.

## Notes
- The `cpu` field on `ProjectUsage` is left intact (the API still returns it); only the dashboard card is removed.

## Test plan
- [x] `bun lint` — clean
- [x] `bun check` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)