### PR TITLE
feat: add mock API server for offline dev frontend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ All API calls go through a single proxy: `POST /api/{fnName}`.
 - **Server side**: `src/routes/api/[fn]/+server.js` — reads token from cookies, forwards to `env.API_ENDPOINT` (https://api.deploys.app) with `Authorization: bearer {token}`.
 - **Cache invalidation**: `api.invalidate(fn)` / `api.intervalInvalidate(cb, interval)` for polling.
 - **Error handling**: `api: unauthorized` → reloads page; `api: forbidden` → `error.forbidden`; `api: validate error` → `error.validate[]`; `api: * not found` → `error.notFound`.
+- **Mock mode (offline dev)**: `bun dev:mock` (sets `MOCK_API=1`). Both proxies (`api/[fn]` and `api/registry/[fn]`) short-circuit to static fixtures in `src/lib/server/mock.js`, skipping the token check — no real backend or OAuth sign-in needed. Add/adjust a fixture in `mock.js` (`handlers` map) when adding a new API call; unknown functions log a warning and return an empty `ok` response.
 
 All API types are defined in `src/types/api.d.ts` using TypeScript namespaces (`Api.Profile`, `Api.Response<T>`, `Api.Deployment`, etc.).
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "vite dev",
+    "dev:mock": "MOCK_API=1 vite dev",
     "build": "vite build",
     "preview": "vite preview",
     "prepare": "svelte-kit sync",

--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -1,0 +1,524 @@
+// Static fixture responses for the dev frontend, enabled via MOCK_API.
+// Wired into the API proxies (src/routes/api/[fn]/+server.js and
+// src/routes/api/registry/[fn]/+server.js) so the console can run fully
+// offline without the real api.deploys.app backend or an OAuth token.
+
+const CREATED_AT = '2026-05-01T08:00:00Z'
+const LOCATION_ID = 'gke.cluster-rcf2'
+const DOMAIN_SUFFIX = 'rcf2.deploys.app'
+const USER_EMAIL = 'dev@deploys.app'
+
+/**
+ * @template T
+ * @param {T} [result]
+ * @returns {{ ok: true, result: T }}
+ */
+const ok = (result = /** @type {T} */ ({})) => ({ ok: true, result })
+
+/**
+ * @template T
+ * @param {T[]} items
+ */
+const list = (items) => ok({ items })
+
+/**
+ * Synthesize a metric line: a single named series of [unixSeconds, value] points.
+ * @param {string} name
+ * @param {number} base
+ */
+function metricLine (name, base) {
+	const now = Math.floor(Date.now() / 1000)
+	const points = Array.from({ length: 30 }, (_, i) => {
+		const wobble = Math.sin(i / 3) * base * 0.25
+		return [now - (29 - i) * 120, Math.max(0, Math.round((base + wobble) * 100) / 100)]
+	})
+	return [{ name, points }]
+}
+
+const projects = [
+	{
+		id: 'prj_mock_acme',
+		project: 'acme',
+		name: 'Acme Corp',
+		billingAccount: 'ba_mock_1',
+		quota: { deployments: 50, deploymentMaxReplicas: 10 },
+		config: { domainAllowDisableCdn: true },
+		createdAt: CREATED_AT
+	},
+	{
+		id: 'prj_mock_staging',
+		project: 'staging',
+		name: 'Staging',
+		billingAccount: 'ba_mock_1',
+		quota: { deployments: 20, deploymentMaxReplicas: 5 },
+		config: { domainAllowDisableCdn: false },
+		createdAt: CREATED_AT
+	}
+]
+
+const locations = [
+	{
+		id: LOCATION_ID,
+		domainSuffix: DOMAIN_SUFFIX,
+		endpoint: 'https://rcf2.deploys.app',
+		cname: 'rcf2.deploys.app.',
+		cpuAllocatable: ['100m', '250m', '500m', '1000m', '2000m'],
+		memoryAllocatable: ['128Mi', '256Mi', '512Mi', '1Gi', '2Gi'],
+		features: { workloadIdentity: true, disk: {} },
+		createdAt: CREATED_AT
+	}
+]
+
+const billingAccounts = [
+	{
+		id: 'ba_mock_1',
+		name: 'Acme Billing',
+		taxId: '0123456789012',
+		taxName: 'Acme Co., Ltd.',
+		taxAddress: '1 Mockingbird Lane, Bangkok 10110',
+		active: true
+	}
+]
+
+/** @param {string} [project] */
+function deployment (project = 'acme') {
+	return {
+		project,
+		location: LOCATION_ID,
+		name: 'web',
+		type: 'WebService',
+		revision: 7,
+		image: 'registry.deploys.app/acme/web:latest',
+		env: { NODE_ENV: 'production', PORT: '8080' },
+		envGroups: ['shared'],
+		command: [],
+		args: [],
+		workloadIdentity: '',
+		pullSecret: '',
+		mountData: {},
+		minReplicas: 1,
+		maxReplicas: 3,
+		schedule: '',
+		port: 8080,
+		protocol: 'http',
+		internal: false,
+		nodePort: 0,
+		annotations: {},
+		resources: {
+			requests: { cpu: '100m', memory: '128Mi' },
+			limits: { cpu: '500m', memory: '512Mi' }
+		},
+		sidecars: [],
+		url: 'https://web.acme.rcf2.deploys.app',
+		internalUrl: 'http://web.acme.svc.cluster.local',
+		logUrl: '',
+		eventUrl: '',
+		podsUrl: '',
+		statusUrl: '',
+		address: '203.0.113.10',
+		internalAddress: '10.0.0.10',
+		status: 'success',
+		action: 'deploy',
+		allocatedPrice: 120.5,
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL,
+		successAt: CREATED_AT,
+		ttl: 0
+	}
+}
+
+const deployments = [
+	deployment('acme'),
+	{
+		...deployment('acme'),
+		name: 'worker',
+		type: 'Worker',
+		port: 0,
+		url: '',
+		internalUrl: '',
+		address: '',
+		status: 'pending',
+		allocatedPrice: 60
+	}
+]
+
+const disks = [
+	{
+		project: 'acme',
+		location: LOCATION_ID,
+		name: 'data',
+		size: 10,
+		status: 'success',
+		action: 'create',
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL,
+		successAt: CREATED_AT
+	}
+]
+
+const domains = [
+	{
+		project: 'acme',
+		location: LOCATION_ID,
+		domain: 'acme.example.com',
+		wildcard: false,
+		cdn: true,
+		verification: {
+			ownership: { type: 'TXT', name: '_deploys.acme.example.com', value: 'verify=mock', errors: [] },
+			ssl: {
+				pending: false,
+				dcv: { name: '_acme-challenge.acme.example.com', value: 'mock-dcv' },
+				records: [],
+				errors: []
+			},
+			dns: { verifiedAt: CREATED_AT, lastCheckedAt: CREATED_AT, errors: [] }
+		},
+		dnsConfig: {
+			ipv4: ['203.0.113.10'],
+			ipv6: ['2001:db8::10'],
+			cname: ['rcf2.deploys.app.']
+		},
+		status: 'success',
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL
+	}
+]
+
+const routes = [
+	{
+		location: LOCATION_ID,
+		domain: 'acme.example.com',
+		path: '/',
+		target: 'web',
+		deployment: 'web',
+		config: {},
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL
+	}
+]
+
+const pullSecrets = [
+	{
+		name: 'dockerhub',
+		value: '',
+		spec: { server: 'https://index.docker.io/v1/', username: 'acme', password: '' },
+		location: LOCATION_ID,
+		action: 'create',
+		status: 'success',
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL
+	}
+]
+
+const workloadIdentities = [
+	{
+		project: 'acme',
+		location: LOCATION_ID,
+		name: 'gcs-reader',
+		gsa: 'gcs-reader@acme.iam.gserviceaccount.com',
+		status: 'success',
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL
+	}
+]
+
+const envGroups = [
+	{
+		project: 'acme',
+		name: 'shared',
+		env: { LOG_LEVEL: 'info', REGION: 'apac' },
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL
+	}
+]
+
+const roles = [
+	{
+		role: 'viewer',
+		name: 'Viewer',
+		permissions: ['project.get', 'deployment.list', 'deployment.get'],
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL
+	},
+	{
+		role: 'admin',
+		name: 'Administrator',
+		permissions: ['*'],
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL
+	}
+]
+
+const permissions = [
+	'project.get', 'project.update', 'project.delete',
+	'deployment.list', 'deployment.get', 'deployment.deploy', 'deployment.delete',
+	'domain.list', 'domain.get', 'domain.create', 'domain.delete',
+	'disk.list', 'disk.get', 'disk.create', 'disk.delete',
+	'role.list', 'role.get', 'role.create', 'role.delete', 'role.bind',
+	'serviceAccount.list', 'serviceAccount.get', 'serviceAccount.create'
+]
+
+const serviceAccounts = [
+	{
+		sid: 'sa_mock_ci',
+		email: 'ci@acme.deploys.app',
+		name: 'CI Deployer',
+		description: 'Used by CI to deploy services',
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL
+	}
+]
+
+const auditLogItems = [
+	{
+		id: 1042,
+		resource: { type: 'Deployment', id: 'web', name: 'web', locationId: LOCATION_ID },
+		actor: { email: USER_EMAIL, type: 'User' },
+		action: 'deployment.deploy',
+		outcome: 'success',
+		detail: 'Deployed revision 7',
+		createdAt: CREATED_AT
+	},
+	{
+		id: 1041,
+		resource: { type: 'Domain', id: 'acme.example.com', name: 'acme.example.com', locationId: LOCATION_ID },
+		actor: { email: USER_EMAIL, type: 'User' },
+		action: 'domain.create',
+		outcome: 'success',
+		detail: 'Added domain acme.example.com',
+		createdAt: CREATED_AT
+	}
+]
+
+const repositories = [
+	{ name: 'acme/web', size: 184320000, createdAt: CREATED_AT },
+	{ name: 'acme/worker', size: 92160000, createdAt: CREATED_AT }
+]
+
+const repositoryTags = [
+	{ tag: 'latest', digest: 'sha256:1111111111111111111111111111111111111111111111111111111111111111', createdAt: CREATED_AT },
+	{ tag: 'v1.2.0', digest: 'sha256:2222222222222222222222222222222222222222222222222222222222222222', createdAt: CREATED_AT }
+]
+
+const repositoryManifests = [
+	{ digest: 'sha256:1111111111111111111111111111111111111111111111111111111111111111', createdAt: CREATED_AT },
+	{ digest: 'sha256:2222222222222222222222222222222222222222222222222222222222222222', createdAt: CREATED_AT }
+]
+
+/** @param {string} id */
+function invoice (id) {
+	return {
+		id,
+		billingAccountId: 'ba_mock_1',
+		number: 'INV-2026-0007',
+		currency: 'THB',
+		periodStart: '2026-04-01T00:00:00Z',
+		periodEnd: '2026-04-30T23:59:59Z',
+		subtotal: 1500,
+		taxRate: 0.07,
+		taxAmount: 105,
+		total: 1605,
+		status: 'paid',
+		taxId: '0123456789012',
+		taxName: 'Acme Co., Ltd.',
+		taxAddress: '1 Mockingbird Lane, Bangkok 10110',
+		issuedAt: '2026-05-01T00:00:00Z',
+		paidAt: '2026-05-03T00:00:00Z',
+		voidedAt: '',
+		createdAt: '2026-05-01T00:00:00Z',
+		lineItems: [
+			{ sku: 'cpu', description: 'vCPU-hours', quantity: 720, unit: 'hour', unitPrice: 1.5, amount: 1080 },
+			{ sku: 'mem', description: 'GiB-hours', quantity: 720, unit: 'hour', unitPrice: 0.583, amount: 420 }
+		]
+	}
+}
+
+const dropboxItems = [
+	{
+		downloadUrl: 'https://dropbox.deploys.app/d/mock-build.tar.gz',
+		filename: 'build.tar.gz',
+		size: 5242880,
+		ttl: 86400,
+		createdAt: CREATED_AT,
+		expiresAt: '2026-05-02T08:00:00Z'
+	}
+]
+
+/** @type {Record<string, (args: any) => object>} */
+const handlers = {
+	'me.get': () => ok({ email: USER_EMAIL }),
+
+	'project.list': () => list(projects),
+	'project.get': (args) => ok(projects.find((p) => p.project === args?.project) ?? { ...projects[0], project: args?.project ?? 'acme' }),
+	'project.create': (args) => ok({ ...projects[0], project: args?.project ?? 'new-project', name: args?.name ?? 'New Project' }),
+	'project.update': () => ok({}),
+	'project.delete': () => ok({}),
+	'project.usage': () => ok({
+		cpuUsage: 0.42,
+		cpu: 1.5,
+		memory: 805306368,
+		egress: 1073741824,
+		registryEgress: 268435456,
+		dropboxEgress: 134217728,
+		disk: 10737418240,
+		replica: 4,
+		domainCdn: 2
+	}),
+
+	'billing.list': () => list(billingAccounts),
+	'billing.get': (args) => ok(billingAccounts.find((b) => b.id === args?.id) ?? { ...billingAccounts[0], id: args?.id ?? 'ba_mock_1' }),
+	'billing.create': (args) => ok({ ...billingAccounts[0], id: 'ba_mock_new', name: args?.name ?? 'New Billing' }),
+	'billing.update': () => ok({}),
+	'billing.delete': () => ok({}),
+	'billing.project': () => ok({ price: 180.5 }),
+	'billing.report': () => ok({
+		projectList: projects.map((p) => ({ sid: p.id, name: p.name })),
+		projectSids: projects.map((p) => p.id),
+		list: [
+			{ projectSid: projects[0].id, name: 'CPU', usageValue: 720, billingValue: 1080 },
+			{ projectSid: projects[0].id, name: 'Memory', usageValue: 720, billingValue: 420 },
+			{ projectSid: projects[1].id, name: 'CPU', usageValue: 240, billingValue: 360 }
+		],
+		chart: {
+			categories: ['Apr 01', 'Apr 08', 'Apr 15', 'Apr 22', 'Apr 30'],
+			series: [
+				{ name: 'Acme Corp', data: [40, 55, 48, 60, 52] },
+				{ name: 'Staging', data: [10, 12, 9, 14, 11] }
+			]
+		}
+	}),
+	'billing.listInvoices': () => list([
+		{
+			id: 'inv_mock_7',
+			number: 'INV-2026-0007',
+			currency: 'THB',
+			periodStart: '2026-04-01T00:00:00Z',
+			periodEnd: '2026-04-30T23:59:59Z',
+			subtotal: 1500,
+			taxAmount: 105,
+			total: 1605,
+			status: 'paid',
+			issuedAt: '2026-05-01T00:00:00Z',
+			paidAt: '2026-05-03T00:00:00Z',
+			voidedAt: '',
+			createdAt: '2026-05-01T00:00:00Z'
+		}
+	]),
+	'billing.getInvoice': (args) => ok(invoice(args?.id ?? 'inv_mock_7')),
+
+	'auditLog.list': (args) => list(auditLogItems.slice(0, args?.limit ?? auditLogItems.length)),
+
+	'location.list': () => list(locations),
+	'location.get': (args) => ok(locations.find((l) => l.id === args?.location) ?? locations[0]),
+
+	'deployment.list': () => list(deployments),
+	'deployment.get': (args) => ok({ ...deployment(args?.project), name: args?.name ?? 'web', location: args?.location ?? LOCATION_ID }),
+	'deployment.deploy': () => ok({}),
+	'deployment.delete': () => ok({}),
+	'deployment.pause': () => ok({}),
+	'deployment.resume': () => ok({}),
+	'deployment.rollback': () => ok({}),
+	'deployment.revisions': (args) => list([7, 6, 5].map((revision) => ({
+		...deployment(args?.project),
+		name: args?.name ?? 'web',
+		location: args?.location ?? LOCATION_ID,
+		revision
+	}))),
+	'deployment.metrics': () => ok({
+		cpuUsage: metricLine('web', 0.3),
+		cpuLimit: metricLine('limit', 0.5),
+		memoryUsage: metricLine('web', 268435456),
+		memory: metricLine('allocated', 402653184),
+		memoryLimit: metricLine('limit', 536870912),
+		requests: metricLine('web', 120),
+		egress: metricLine('web', 1048576)
+	}),
+
+	'disk.list': () => list(disks),
+	'disk.get': (args) => ok({ ...disks[0], name: args?.name ?? 'data', location: args?.location ?? LOCATION_ID }),
+	'disk.create': () => ok({}),
+	'disk.update': () => ok({}),
+	'disk.delete': () => ok({}),
+	'disk.metrics': () => ok({
+		usage: metricLine('used', 5368709120),
+		size: metricLine('size', 10737418240)
+	}),
+
+	'domain.list': () => list(domains),
+	'domain.get': (args) => ok({ ...domains[0], domain: args?.domain ?? 'acme.example.com', location: args?.location ?? LOCATION_ID }),
+	'domain.create': () => ok({}),
+	'domain.delete': () => ok({}),
+	'domain.purgeCache': () => ok({}),
+
+	'route.list': () => list(routes),
+	'route.createV2': () => ok({}),
+	'route.delete': () => ok({}),
+
+	'pullSecret.list': () => list(pullSecrets),
+	'pullSecret.get': (args) => ok({ ...pullSecrets[0], name: args?.name ?? 'dockerhub', location: args?.location ?? LOCATION_ID }),
+	'pullSecret.create': () => ok({}),
+	'pullSecret.delete': () => ok({}),
+
+	'workloadIdentity.list': () => list(workloadIdentities),
+	'workloadIdentity.get': (args) => ok({ ...workloadIdentities[0], name: args?.name ?? 'gcs-reader', location: args?.location ?? LOCATION_ID }),
+	'workloadIdentity.create': () => ok({}),
+	'workloadIdentity.delete': () => ok({}),
+
+	'envGroup.list': () => list(envGroups),
+	'envGroup.get': (args) => ok({ ...envGroups[0], name: args?.name ?? 'shared' }),
+	'envGroup.create': () => ok({}),
+	'envGroup.update': () => ok({}),
+	'envGroup.delete': () => ok({}),
+
+	'email.list': () => list([{ domain: 'mail.acme.example.com', createdAt: CREATED_AT }]),
+
+	'role.list': () => list(roles),
+	'role.get': (args) => ok(roles.find((r) => r.role === args?.role) ?? roles[0]),
+	'role.create': () => ok({}),
+	'role.delete': () => ok({}),
+	'role.bind': () => ok({}),
+	'role.permissions': () => ok(permissions),
+	'role.users': () => list([
+		{ email: USER_EMAIL, roles: ['admin'] },
+		{ email: 'teammate@acme.example.com', roles: ['viewer'] }
+	]),
+
+	'serviceAccount.list': () => list(serviceAccounts),
+	'serviceAccount.get': (args) => ok({
+		...serviceAccounts[0],
+		sid: args?.id ?? serviceAccounts[0].sid,
+		keys: [{ secret: 'sk_mock_0000000000000000' }]
+	}),
+	'serviceAccount.create': () => ok({}),
+	'serviceAccount.update': () => ok({}),
+	'serviceAccount.createKey': () => ok({}),
+	'serviceAccount.delete': () => ok({}),
+	'serviceAccount.deleteKey': () => ok({}),
+
+	'dropbox.list': () => list(dropboxItems),
+
+	'registry/list': () => list(repositories),
+	'registry/get': (args) => ok({ ...repositories[0], name: args?.repository ?? repositories[0].name }),
+	'registry/getProjectStorage': () => ok({ size: 276480000, updatedAt: CREATED_AT }),
+	'registry/getTags': (args) => ok({ name: args?.repository ?? repositories[0].name, items: repositoryTags }),
+	'registry/getManifests': (args) => ok({ name: args?.repository ?? repositories[0].name, items: repositoryManifests }),
+	'registry/delete': () => ok({}),
+	'registry/deleteManifest': () => ok({}),
+	'registry/untag': () => ok({})
+}
+
+/**
+ * Resolve a mock response for an API function. Unknown functions return an
+ * empty-but-ok payload so list/get callers degrade gracefully.
+ * @param {string} fn
+ * @param {object} [args]
+ * @returns {object}
+ */
+export function mockInvoke (fn, args = {}) {
+	const handler = handlers[fn]
+	if (!handler) {
+		console.warn(`[mock] no fixture for "${fn}" — returning empty ok response`)
+		return ok({})
+	}
+	return handler(args)
+}

--- a/src/routes/api/[fn]/+server.js
+++ b/src/routes/api/[fn]/+server.js
@@ -1,9 +1,16 @@
 import { env } from '$env/dynamic/private'
+import { mockInvoke } from '$lib/server/mock'
 
 const endpoint = env.API_ENDPOINT || 'https://api.deploys.app'
 
 /** @type {import('@sveltejs/kit').RequestHandler} */
 export async function POST ({ locals, params, request }) {
+	// dev mock: short-circuit to static fixtures, no token required
+	if (env.MOCK_API) {
+		const args = await request.json().catch(() => ({}))
+		return Response.json(mockInvoke(params.fn ?? '', args))
+	}
+
 	const token = locals.token
 
 	// fast-path to reject unauthorized requests

--- a/src/routes/api/registry/[fn]/+server.js
+++ b/src/routes/api/registry/[fn]/+server.js
@@ -1,9 +1,16 @@
 import { env } from '$env/dynamic/private'
+import { mockInvoke } from '$lib/server/mock'
 
 const endpoint = env.REGISTRY_ENDPOINT || 'https://registry.deploys.app/api'
 
 /** @type {import('./$types').RequestHandler} */
 export async function POST ({ locals, params, request }) {
+	// dev mock: short-circuit to static fixtures, no token required
+	if (env.MOCK_API) {
+		const args = await request.json().catch(() => ({}))
+		return Response.json(mockInvoke(`registry/${params.fn}`, args))
+	}
+
 	const token = locals.token
 
 	// fast-path to reject unauthorized requests


### PR DESCRIPTION
## Summary
- Add a `MOCK_API` dev mode so the console runs fully offline — no real `api.deploys.app` backend and no OAuth sign-in required.
- New `src/lib/server/mock.js` provides static fixtures for every API function the frontend calls (~70 across the main API and the `registry/*` namespace), returning `Api.Response`-shaped objects. Unknown functions log a warning and return an empty `ok` response.
- Both proxies (`api/[fn]` and `api/registry/[fn]`) short-circuit to the mock **before** the token check when `MOCK_API` is set, so auth is effectively bypassed (`me.get` returns a profile → no signin redirect).
- Added `bun dev:mock` (`MOCK_API=1 vite dev`) and documented the mode in `CLAUDE.md`.

`get` endpoints echo back the requested name/location so detail pages resolve; mutations return `ok` without persisting (static fixtures, reset-free).

## Test plan
- [ ] `bun dev:mock`, then load `/?project=acme` — dashboard renders without redirecting to signin
- [ ] `/project` lists both mock projects (Acme Corp, Staging)
- [ ] Navigate deployment / domain / disk / registry / billing pages and confirm they populate
- [ ] `bun lint` and `bun check` pass (verified locally: zero errors/warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)