### PR TITLE
feat: view env group variables in a modal

### DIFF
--- a/src/lib/components/EnvGroupModal.svelte
+++ b/src/lib/components/EnvGroupModal.svelte
@@ -1,0 +1,59 @@
+<script>
+	import NoDataRow from '$lib/components/NoDataRow.svelte'
+
+	let group = $state(/** @type {?Api.EnvGroup} */ (null))
+	let isActive = $state(false)
+
+	const entries = $derived(Object.entries(group?.env ?? {}))
+
+	/**
+	 * @param {Api.EnvGroup} g
+	 */
+	export function open (g) {
+		group = g
+		isActive = true
+	}
+
+	function close () {
+		isActive = false
+	}
+</script>
+
+<div class="modal" onclick={close} class:is-active={isActive} aria-hidden={!isActive}>
+	<div class="modal-panel">
+		<div class="modal-close" onclick={close} onkeypress={close} tabindex="0" role="button">✕</div>
+		<h4><strong>{group?.name}</strong></h4>
+
+		<div class="table-container mt-4">
+			<table class="table is-variant-compact">
+				<thead>
+					<tr>
+						<th class="is-collapse" style="min-width: 256px">Key</th>
+						<th>Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each entries as [k, v] (k)}
+						<tr>
+							<td>{k}</td>
+							<td>{v}</td>
+						</tr>
+					{/each}
+					<NoDataRow span={2} list={entries} />
+				</tbody>
+			</table>
+		</div>
+	</div>
+</div>
+
+<style>
+	.table-container {
+		max-height: 405px;
+		overflow: auto;
+	}
+
+	.modal-panel {
+		width: 100%;
+		max-width: 48rem;
+	}
+</style>

--- a/src/lib/modal/index.js
+++ b/src/lib/modal/index.js
@@ -104,3 +104,27 @@ export async function success ({ content }) {
 		}
 	})
 }
+
+/**
+ * @typedef {Object} ModalInfoOptions
+ * @property {string} [title]
+ * @property {string} [html]
+ */
+
+/**
+ * @param {ModalInfoOptions} options
+ * @returns {Promise<void>}
+ */
+export async function info ({ title, html }) {
+	await Swal.fire({
+		title,
+		html,
+		background: 'var(--modal-panel-background)',
+		color: 'var(--modal-panel-color)',
+		buttonsStyling: false,
+		customClass: {
+			actions: 'mt-6',
+			confirmButton: 'button is-variant-secondary'
+		}
+	})
+}

--- a/src/lib/modal/index.js
+++ b/src/lib/modal/index.js
@@ -104,27 +104,3 @@ export async function success ({ content }) {
 		}
 	})
 }
-
-/**
- * @typedef {Object} ModalInfoOptions
- * @property {string} [title]
- * @property {string} [html]
- */
-
-/**
- * @param {ModalInfoOptions} options
- * @returns {Promise<void>}
- */
-export async function info ({ title, html }) {
-	await Swal.fire({
-		title,
-		html,
-		background: 'var(--modal-panel-background)',
-		color: 'var(--modal-panel-color)',
-		buttonsStyling: false,
-		customClass: {
-			actions: 'mt-6',
-			confirmButton: 'button is-variant-secondary'
-		}
-	})
-}

--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -8,11 +8,27 @@
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import Secret from '$lib/components/Secret.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import EnvGroupModal from '$lib/components/EnvGroupModal.svelte'
 
 	const { data } = $props()
 
 	const deployment = $derived(data.deployment)
 	const location = $derived(data.location)
+
+	/** @type {?EnvGroupModal} */
+	let envGroupModal = $state(null)
+
+	/**
+	 * @param {string} name
+	 */
+	async function viewEnvGroup (name) {
+		const resp = await api.invoke('envGroup.get', { project: deployment.project, name }, fetch)
+		if (!resp.ok) {
+			modal.error({ error: resp.error })
+			return
+		}
+		envGroupModal?.open(resp.result)
+	}
 
 	const hasExternalTCPAddress = $derived(['TCPService'].includes(deployment.type))
 	const hasInternalTCPAddress = $derived(['WebService', 'TCPService', 'InternalTCPService'].includes(deployment.type))
@@ -260,9 +276,9 @@
 		{#each deployment.envGroups || [] as name (name)}
 			<tr>
 				<td>
-					<a class="link" href={`/env-group/create?project=${deployment.project}&name=${name}`}>
+					<button type="button" class="button is-variant-underline" onclick={() => viewEnvGroup(name)}>
 						{name}
-					</a>
+					</button>
 				</td>
 			</tr>
 		{:else}
@@ -317,3 +333,5 @@
 		</tbody>
 	</table>
 </div>
+
+<EnvGroupModal bind:this={envGroupModal} />

--- a/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
@@ -4,6 +4,7 @@
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
+	import EnvGroupModal from '$lib/components/EnvGroupModal.svelte'
 
 	const { data } = $props()
 
@@ -258,17 +259,8 @@
 
 	const envGroupByName = $derived(new Map(envGroups.map((g) => [g.name, g])))
 
-	/**
-	 * @param {string} s
-	 */
-	function escapeHtml (s) {
-		return String(s)
-			.replaceAll('&', '&amp;')
-			.replaceAll('<', '&lt;')
-			.replaceAll('>', '&gt;')
-			.replaceAll('"', '&quot;')
-			.replaceAll("'", '&#39;')
-	}
+	/** @type {?EnvGroupModal} */
+	let envGroupModal = $state(null)
 
 	/**
 	 * @param {string} name
@@ -276,15 +268,7 @@
 	function viewEnvGroup (name) {
 		const g = envGroupByName.get(name)
 		if (!g) return
-		const env = g.env ?? {}
-		const keys = Object.keys(env)
-		const body = keys.length
-			? keys.map((k) => `<tr><td>${escapeHtml(k)}</td><td>${escapeHtml(env[k])}</td></tr>`).join('')
-			: '<tr><td colspan="2" class="text-content/50">No variables</td></tr>'
-		modal.info({
-			title: `Env Group: ${name}`,
-			html: `<table class="table is-variant-compact"><thead><tr><th>Key</th><th>Value</th></tr></thead><tbody>${body}</tbody></table>`
-		})
+		envGroupModal?.open(g)
 	}
 
 	function convertSidecars () {
@@ -979,3 +963,5 @@
 	{/if}
 	</form>
 </div>
+
+<EnvGroupModal bind:this={envGroupModal} />

--- a/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
@@ -256,6 +256,37 @@
 		form.envGroups = form.envGroups.filter((g) => g !== name)
 	}
 
+	const envGroupByName = $derived(new Map(envGroups.map((g) => [g.name, g])))
+
+	/**
+	 * @param {string} s
+	 */
+	function escapeHtml (s) {
+		return String(s)
+			.replaceAll('&', '&amp;')
+			.replaceAll('<', '&lt;')
+			.replaceAll('>', '&gt;')
+			.replaceAll('"', '&quot;')
+			.replaceAll("'", '&#39;')
+	}
+
+	/**
+	 * @param {string} name
+	 */
+	function viewEnvGroup (name) {
+		const g = envGroupByName.get(name)
+		if (!g) return
+		const env = g.env ?? {}
+		const keys = Object.keys(env)
+		const body = keys.length
+			? keys.map((k) => `<tr><td>${escapeHtml(k)}</td><td>${escapeHtml(env[k])}</td></tr>`).join('')
+			: '<tr><td colspan="2" class="text-content/50">No variables</td></tr>'
+		modal.info({
+			title: `Env Group: ${name}`,
+			html: `<table class="table is-variant-compact"><thead><tr><th>Key</th><th>Value</th></tr></thead><tbody>${body}</tbody></table>`
+		})
+	}
+
 	function convertSidecars () {
 		return form.sidecars
 			.filter((s) => s.type)
@@ -752,10 +783,18 @@
 						<tr>
 							<td>{name}</td>
 							<td>
-								<button class="icon-button" type="button" aria-label="Remove env group"
-									onclick={() => removeEnvGroup(name)}>
-									<i class="fa-solid fa-trash-alt"></i>
-								</button>
+								<div class="flex gap-2 justify-end">
+									{#if envGroupByName.has(name)}
+										<button class="icon-button" type="button" aria-label="View env group"
+											onclick={() => viewEnvGroup(name)}>
+											<i class="fa-solid fa-eye"></i>
+										</button>
+									{/if}
+									<button class="icon-button" type="button" aria-label="Remove env group"
+										onclick={() => removeEnvGroup(name)}>
+										<i class="fa-solid fa-trash-alt"></i>
+									</button>
+								</div>
 							</td>
 						</tr>
 					{:else}

--- a/tests/deployment.spec.js
+++ b/tests/deployment.spec.js
@@ -226,4 +226,42 @@ test.describe('deployment deploy — env groups', () => {
 		await expect(main.getByRole('heading', { name: 'Env Groups' })).toBeVisible()
 		await expect(main.getByRole('cell', { name: 'shared-config' })).toBeVisible()
 	})
+
+	test('views env group variables in a popup', async ({ page }) => {
+		await setMocks({
+			'deployment.get': {
+				ok: true,
+				result: { ...sampleDeployment, envGroups: ['shared-config'] }
+			},
+			'location.get': { ok: true, result: defaultLocation },
+			'envGroup.list': {
+				ok: true,
+				result: {
+					items: [
+						{
+							project: 'test-project',
+							name: 'shared-config',
+							env: { LOG_LEVEL: 'info', REGION: 'apac' },
+							createdAt: '2024-01-01T00:00:00Z',
+							createdBy: '[email protected]'
+						}
+					]
+				}
+			}
+		})
+
+		await page.goto('/deployment/deploy?project=test-project&location=gke&name=web')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('cell', { name: 'shared-config' })).toBeVisible()
+
+		await main.getByRole('button', { name: 'View env group' }).click()
+
+		const dialog = page.getByRole('dialog')
+		await expect(dialog.getByText('Env Group: shared-config')).toBeVisible()
+		await expect(dialog.getByText('LOG_LEVEL')).toBeVisible()
+		await expect(dialog.getByText('info')).toBeVisible()
+		await expect(dialog.getByText('REGION')).toBeVisible()
+		await expect(dialog.getByText('apac')).toBeVisible()
+	})
 })

--- a/tests/deployment.spec.js
+++ b/tests/deployment.spec.js
@@ -153,23 +153,38 @@ test.describe('deployment deploy — sidecars', () => {
 })
 
 test.describe('deployment detail — env groups', () => {
-	test('lists attached env groups with links to their edit page', async ({ page }) => {
+	test('views attached env group variables in a popup', async ({ page }) => {
 		await setMocks({
 			'deployment.get': {
 				ok: true,
 				result: { ...sampleDeployment, envGroups: ['shared-config', 'secrets'] }
 			},
-			'location.get': { ok: true, result: defaultLocation }
+			'location.get': { ok: true, result: defaultLocation },
+			'envGroup.get': {
+				ok: true,
+				result: {
+					project: 'test-project',
+					name: 'shared-config',
+					env: { LOG_LEVEL: 'info', REGION: 'apac' },
+					createdAt: '2024-01-01T00:00:00Z',
+					createdBy: '[email protected]'
+				}
+			}
 		})
 
 		await page.goto('/deployment/detail?project=test-project&location=gke&name=web')
 
 		const main = page.locator('.content-wrapper')
 		await expect(main.getByRole('heading', { name: 'Env Groups' })).toBeVisible()
-		await expect(main.getByRole('link', { name: 'shared-config' }))
-			.toHaveAttribute('href', '/env-group/create?project=test-project&name=shared-config')
-		await expect(main.getByRole('link', { name: 'secrets' }))
-			.toHaveAttribute('href', '/env-group/create?project=test-project&name=secrets')
+
+		await main.getByRole('button', { name: 'shared-config' }).click()
+
+		const dialog = page.locator('.modal-panel')
+		await expect(dialog.getByRole('heading', { name: 'shared-config' })).toBeVisible()
+		await expect(dialog.getByText('LOG_LEVEL')).toBeVisible()
+		await expect(dialog.getByText('info')).toBeVisible()
+		await expect(dialog.getByText('REGION')).toBeVisible()
+		await expect(dialog.getByText('apac')).toBeVisible()
 	})
 
 	test('shows no data when deployment has no env groups', async ({ page }) => {
@@ -257,8 +272,8 @@ test.describe('deployment deploy — env groups', () => {
 
 		await main.getByRole('button', { name: 'View env group' }).click()
 
-		const dialog = page.getByRole('dialog')
-		await expect(dialog.getByText('Env Group: shared-config')).toBeVisible()
+		const dialog = page.locator('.modal-panel')
+		await expect(dialog.getByRole('heading', { name: 'shared-config' })).toBeVisible()
 		await expect(dialog.getByText('LOG_LEVEL')).toBeVisible()
 		await expect(dialog.getByText('info')).toBeVisible()
 		await expect(dialog.getByText('REGION')).toBeVisible()


### PR DESCRIPTION
## Summary
- Add a way to view an env group's variables in a modal popup from two places:
  - **Deployment deploy page** — an eye-icon **View** button on each attached env group row. It only renders when the group's data is available (`envGroupByName.has(name)`), so it's hidden when the user lacks env-group list permission.
  - **Deployment detail page** — clicking an attached env group name opens the same modal (the group is fetched on demand via `envGroup.get`; errors surface through `modal.error`). This replaces the previous link to the env-group edit page.
- Introduce a reusable `EnvGroupModal.svelte` component (modeled on `ModalSelectProject.svelte`) that renders the variables as a table via Svelte interpolation — values are auto-escaped, so there's no hand-built HTML string or manual escaping.
- The modal's `aria-hidden` is bound to its open state so the dialog is exposed to screen readers only while open.

## Notes
- The detail page now opens the modal instead of linking to the env-group edit page. Happy to re-add an edit link alongside it if that's still wanted.

## Test plan
- [x] `bun lint` passes with zero errors
- [x] `bun check` passes with zero errors
- [x] Playwright (`tests/deployment.spec.js`, 11 tests pass), including:
  - `deployment deploy — env groups › views env group variables in a popup`
  - `deployment detail — env groups › views attached env group variables in a popup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)