### PR TITLE
feat: default theme to OS preference

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -2,6 +2,15 @@
 <html lang="en" class="%theme%">
 <head>
 	<meta charset="utf-8">
+	<script>
+		(function () {
+			try {
+				var m = document.cookie.match(/(?:^|;\s*)theme=(dark|light)/)
+				var dark = m ? m[1] === 'dark' : matchMedia('(prefers-color-scheme: dark)').matches
+				document.documentElement.classList.toggle('dark', dark)
+			} catch (e) {}
+		})()
+	</script>
 	<title>Console | Deploys.app</title>
 	<link rel="icon" type="image/webp" href="/favicon.webp">
 	<link rel="icon" type="image/png" href="/favicon.png">

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -1,17 +1,11 @@
 import { sequence } from '@sveltejs/kit/hooks'
 
-const allowTheme = {
-	dark: true,
-	light: true
-}
-
 /** @type {import('@sveltejs/kit').Handle} */
 async function theme ({ event, resolve }) {
-	let t = event.cookies.get('theme')
-	if (!allowTheme[t]) {
-		t = 'dark'
-	}
-	const cls = t === 'dark' ? 'dark' : ''
+	// Only force a class for an explicit choice. With no cookie the default is
+	// the OS preference, which is unknown server-side — the inline script in
+	// app.html applies it before first paint.
+	const cls = event.cookies.get('theme') === 'dark' ? 'dark' : ''
 	return resolve(event, {
 		transformPageChunk: ({ html }) => html.replace('%theme%', cls)
 	})

--- a/src/routes/(auth)/Navbar.svelte
+++ b/src/routes/(auth)/Navbar.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { onMount } from 'svelte'
 	import { scale } from 'svelte/transition'
 	import gravatarUrl from 'gravatar-url'
 	import Cookie from 'js-cookie'
@@ -38,10 +39,31 @@
 		signOut?.submit()
 	}
 
+	function applySystemTheme () {
+		document.documentElement.classList.toggle('dark', window.matchMedia('(prefers-color-scheme: dark)').matches)
+	}
+
 	function setTheme (value) {
+		if (value === 'system') {
+			Cookie.remove('theme')
+			applySystemTheme()
+			return
+		}
 		document.documentElement.classList.toggle('dark', value === 'dark')
 		Cookie.set('theme', value, { expires: 30 })
 	}
+
+	onMount(() => {
+		const mq = window.matchMedia('(prefers-color-scheme: dark)')
+		// Follow OS changes live only while no explicit choice is stored.
+		const onChange = (e) => {
+			if (!Cookie.get('theme')) {
+				document.documentElement.classList.toggle('dark', e.matches)
+			}
+		}
+		mq.addEventListener('change', onChange)
+		return () => mq.removeEventListener('change', onChange)
+	})
 </script>
 
 <nav class="navbar">
@@ -56,6 +78,7 @@
 				Theme
 			</div>
 			<ul class="menu is-card is-compact">
+				<li><div onclick={() => setTheme('system')} onkeypress={() => setTheme('system')} role="button" tabindex="0">System</div></li>
 				<li><div onclick={() => setTheme('dark')} onkeypress={() => setTheme('dark')} role="button" tabindex="0">Dark</div></li>
 				<li><div onclick={() => setTheme('light')} onkeypress={() => setTheme('light')} role="button" tabindex="0">Light</div></li>
 			</ul>

--- a/tests/theme.spec.js
+++ b/tests/theme.spec.js
@@ -1,0 +1,49 @@
+import { test, unauthedTest, expect } from './helpers.js'
+
+const tokenCookie = {
+	name: 'token',
+	value: 'test-token',
+	url: 'http://localhost:4173',
+	httpOnly: true,
+	sameSite: /** @type {const} */ ('Lax')
+}
+
+unauthedTest.describe('theme — default follows OS', () => {
+	unauthedTest('applies dark when OS prefers dark and no theme cookie', async ({ context, page }) => {
+		await context.addCookies([tokenCookie])
+		await page.emulateMedia({ colorScheme: 'dark' })
+		await page.goto('/project')
+		await expect(page.locator('html')).toHaveClass(/dark/)
+	})
+
+	unauthedTest('stays light when OS prefers light and no theme cookie', async ({ context, page }) => {
+		await context.addCookies([tokenCookie])
+		await page.emulateMedia({ colorScheme: 'light' })
+		await page.goto('/project')
+		await expect(page.locator('html')).not.toHaveClass(/dark/)
+	})
+
+	unauthedTest('explicit theme cookie overrides OS preference', async ({ context, page }) => {
+		await context.addCookies([
+			tokenCookie,
+			{ name: 'theme', value: 'light', url: 'http://localhost:4173', sameSite: 'Lax' }
+		])
+		await page.emulateMedia({ colorScheme: 'dark' })
+		await page.goto('/project')
+		await expect(page.locator('html')).not.toHaveClass(/dark/)
+	})
+})
+
+test.describe('theme — system toggle', () => {
+	test('System option clears the choice and follows the OS', async ({ page }) => {
+		// Signed-in fixture stores an explicit theme=dark cookie.
+		await page.emulateMedia({ colorScheme: 'light' })
+		await page.goto('/project')
+		await expect(page.locator('html')).toHaveClass(/dark/)
+
+		await page.getByRole('button', { name: 'Theme' }).hover()
+		await page.getByRole('button', { name: 'System' }).click()
+
+		await expect(page.locator('html')).not.toHaveClass(/dark/)
+	})
+})


### PR DESCRIPTION
## Summary
- New users (no `theme` cookie) now follow their **OS color scheme** instead of always getting dark.
- An inline `<head>` script in `app.html` resolves the effective theme before first paint — explicit cookie if present, otherwise `prefers-color-scheme` — so there's no flash.
- `hooks.server.js` no longer defaults to `dark`; it only forces the `dark` class for an explicit `dark` cookie (the OS preference is unknown server-side and handled by the inline script).
- The navbar Theme menu gains a **System** option that clears the stored choice and follows the OS, and the navbar tracks live OS changes while no explicit choice is set.

## Behavior
| Stored choice | OS prefers | Result |
| --- | --- | --- |
| none | dark | dark |
| none | light | light |
| dark / light | (any) | the explicit choice wins |

## Test plan
- [x] `bun lint` and `bun check` pass with zero errors
- [x] New `tests/theme.spec.js` (4 tests): OS-dark default, OS-light default, explicit cookie overrides OS, and the System toggle clearing the choice
- [x] Full Playwright suite passes (58 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)