### PR TITLE
feat: replace native select dropdowns with custom Select component

### DIFF
--- a/src/lib/components/Select.svelte
+++ b/src/lib/components/Select.svelte
@@ -227,6 +227,8 @@
 						{/if}
 					</div>
 				{/if}
+			{:else}
+				<div class="select-empty">No options</div>
 			{/each}
 		</div>
 	{/if}
@@ -373,6 +375,13 @@
 		height: 1px;
 		margin: 0.25rem 0.4rem;
 		background: hsl(var(--hsl-line) / 0.7);
+	}
+
+	.select-empty {
+		padding: 0.75rem 0.65rem;
+		text-align: center;
+		font-size: 0.875rem;
+		color: hsl(var(--hsl-content) / 0.6);
 	}
 
 	/* Visually hidden but still focusable so native constraint validation

--- a/src/lib/components/Select.svelte
+++ b/src/lib/components/Select.svelte
@@ -1,0 +1,392 @@
+<script>
+	/**
+	 * @typedef {Object} Option
+	 * @property {string | number} [value]
+	 * @property {string} [label]
+	 * @property {boolean} [disabled]
+	 * @property {boolean} [separator]
+	 */
+
+	/**
+	 * @typedef {Object} Props
+	 * @property {string | number} [value]
+	 * @property {Option[]} options
+	 * @property {string} [placeholder]
+	 * @property {boolean} [required]
+	 * @property {boolean} [disabled]
+	 * @property {string} [id]
+	 * @property {string} [name]
+	 * @property {(value: string | number) => void} [onchange]
+	 * @property {boolean} [resetOnSelect]
+	 * @property {string} [class]
+	 */
+
+	/** @type {Props} */
+	let {
+		value = $bindable(''),
+		options,
+		placeholder = '',
+		required = false,
+		disabled = false,
+		id,
+		name,
+		onchange,
+		resetOnSelect = false,
+		class: className = ''
+	} = $props()
+
+	const uid = $props.id()
+	const listboxId = `${uid}-listbox`
+	const optionId = (/** @type {number} */ i) => `${uid}-opt-${i}`
+
+	let open = $state(false)
+	let activeIndex = $state(-1)
+
+	/** @type {HTMLButtonElement} */
+	let triggerEl
+	/** @type {HTMLDivElement | undefined} */
+	let listEl = $state()
+
+	let typeahead = ''
+	/** @type {ReturnType<typeof setTimeout> | undefined} */
+	let typeaheadTimer
+
+	const selectedOption = $derived(
+		options.find((o) => !o.separator && (o.value ?? '') === value)
+	)
+	const displayLabel = $derived(selectedOption ? selectedOption.label : placeholder)
+	const hasSelection = $derived(!!selectedOption)
+
+	/** @param {number} i */
+	function isSelectable (i) {
+		const o = options[i]
+		return !!o && !o.separator && !o.disabled
+	}
+
+	/** @param {Option} opt */
+	function commit (opt) {
+		if (opt.separator || opt.disabled) return
+		const v = opt.value ?? ''
+		value = v
+		close()
+		triggerEl?.focus()
+		onchange?.(v)
+		if (resetOnSelect) value = ''
+	}
+
+	function openMenu () {
+		if (disabled) return
+		open = true
+		const sel = options.findIndex((o) => !o.separator && (o.value ?? '') === value)
+		activeIndex = sel >= 0 && isSelectable(sel) ? sel : firstSelectable()
+	}
+
+	function close () {
+		open = false
+		activeIndex = -1
+	}
+
+	function firstSelectable () {
+		for (let i = 0; i < options.length; i++) if (isSelectable(i)) return i
+		return -1
+	}
+
+	function lastSelectable () {
+		for (let i = options.length - 1; i >= 0; i--) if (isSelectable(i)) return i
+		return -1
+	}
+
+	/** @param {number} dir */
+	function moveActive (dir) {
+		let i = activeIndex
+		for (let step = 0; step < options.length; step++) {
+			i += dir
+			if (i < 0) i = options.length - 1
+			if (i >= options.length) i = 0
+			if (isSelectable(i)) {
+				activeIndex = i
+				return
+			}
+		}
+	}
+
+	/** @param {string} char */
+	function typeaheadSearch (char) {
+		clearTimeout(typeaheadTimer)
+		typeahead += char.toLowerCase()
+		typeaheadTimer = setTimeout(() => { typeahead = '' }, 500)
+		const match = options.findIndex(
+			(o, i) => isSelectable(i) && (o.label ?? '').toLowerCase().startsWith(typeahead)
+		)
+		if (match >= 0) activeIndex = match
+	}
+
+	/** @param {KeyboardEvent} e */
+	function onKeydown (e) {
+		if (disabled) return
+		switch (e.key) {
+		case 'ArrowDown':
+			e.preventDefault()
+			open ? moveActive(1) : openMenu()
+			break
+		case 'ArrowUp':
+			e.preventDefault()
+			open ? moveActive(-1) : openMenu()
+			break
+		case 'Home':
+			if (open) { e.preventDefault(); activeIndex = firstSelectable() }
+			break
+		case 'End':
+			if (open) { e.preventDefault(); activeIndex = lastSelectable() }
+			break
+		case 'Enter':
+			e.preventDefault()
+			if (open && activeIndex >= 0) commit(options[activeIndex])
+			else openMenu()
+			break
+		case ' ':
+			e.preventDefault()
+			if (open && activeIndex >= 0) commit(options[activeIndex])
+			else openMenu()
+			break
+		case 'Escape':
+			if (open) { e.preventDefault(); close() }
+			break
+		case 'Tab':
+			if (open) close()
+			break
+		default:
+			if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+				if (!open) openMenu()
+				typeaheadSearch(e.key)
+			}
+		}
+	}
+
+	/** @type {(node: HTMLElement, handler: () => void) => { destroy(): void }} */
+	function clickOutside (node, handler) {
+		/** @param {MouseEvent} e */
+		function onDown (e) {
+			if (e.target instanceof Node && !node.contains(e.target)) handler()
+		}
+		document.addEventListener('mousedown', onDown)
+		return {
+			destroy () { document.removeEventListener('mousedown', onDown) }
+		}
+	}
+
+	// Keep the active option scrolled into view while navigating by keyboard.
+	$effect(() => {
+		if (!open || activeIndex < 0 || !listEl) return
+		const el = listEl.querySelector(`#${CSS.escape(optionId(activeIndex))}`)
+		if (el instanceof HTMLElement) el.scrollIntoView({ block: 'nearest' })
+	})
+</script>
+
+<div class="select-box {className}" class:is-disabled={disabled} use:clickOutside={close}>
+	<button
+		bind:this={triggerEl}
+		{id}
+		type="button"
+		class="select-trigger"
+		role="combobox"
+		aria-haspopup="listbox"
+		aria-expanded={open}
+		aria-controls={listboxId}
+		aria-activedescendant={open && activeIndex >= 0 ? optionId(activeIndex) : undefined}
+		{disabled}
+		onclick={() => (open ? close() : openMenu())}
+		onkeydown={onKeydown}>
+		<span class="select-value" class:is-placeholder={!hasSelection}>{displayLabel}</span>
+		<i class="fa-solid fa-chevron-down select-chevron" class:is-open={open}></i>
+	</button>
+
+	{#if open}
+		<div bind:this={listEl} id={listboxId} class="select-menu" role="listbox" tabindex="-1">
+			{#each options as opt, i (i)}
+				{#if opt.separator}
+					<div class="select-sep" role="separator"></div>
+				{:else}
+					<!-- Keyboard handling lives on the combobox trigger via aria-activedescendant. -->
+					<!-- svelte-ignore a11y_click_events_have_key_events -->
+					<div
+						id={optionId(i)}
+						role="option"
+						tabindex="-1"
+						aria-selected={(opt.value ?? '') === value}
+						aria-disabled={opt.disabled || undefined}
+						class="select-option"
+						class:is-active={i === activeIndex}
+						class:is-selected={(opt.value ?? '') === value}
+						class:is-disabled={opt.disabled}
+						onmouseenter={() => { if (isSelectable(i)) activeIndex = i }}
+						onclick={() => commit(opt)}>
+						<span class="truncate">{opt.label}</span>
+						{#if (opt.value ?? '') === value}
+							<i class="fa-solid fa-check select-check"></i>
+						{/if}
+					</div>
+				{/if}
+			{/each}
+		</div>
+	{/if}
+
+	<!-- Hidden mirror keeps native form constraint validation (`required`) working. -->
+	<select
+		class="select-validity"
+		bind:value
+		{name}
+		{required}
+		{disabled}
+		tabindex="-1"
+		aria-hidden="true">
+		{#if placeholder}<option value="">{placeholder}</option>{/if}
+		{#each options as opt, i (i)}
+			{#if !opt.separator}<option value={opt.value ?? ''}>{opt.label}</option>{/if}
+		{/each}
+	</select>
+</div>
+
+<style>
+	.select-box {
+		position: relative;
+		width: 100%;
+	}
+
+	.select-trigger {
+		appearance: none;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		width: 100%;
+		min-height: 2.5rem;
+		padding: 0.5rem 0.75rem;
+		font: inherit;
+		font-size: 0.875rem;
+		text-align: left;
+		color: inherit;
+		cursor: pointer;
+		background-color: hsl(var(--hsl-base-400) / 0.2);
+		border: 1px solid hsl(var(--hsl-base-400) / 0.3);
+		border-radius: var(--radius-md);
+		transition: border-color var(--timing-faster) ease,
+			box-shadow var(--timing-faster) ease,
+			background-color var(--timing-faster) ease;
+	}
+
+	:root:not(.dark) .select-trigger {
+		border-color: hsl(var(--hsl-line));
+		background-color: hsl(var(--hsl-base-100));
+	}
+
+	.select-trigger:hover:not(:disabled) {
+		border-color: hsl(var(--hsl-primary) / 0.45);
+	}
+
+	.select-trigger:focus-visible,
+	.select-box:focus-within .select-trigger {
+		outline: 0;
+		border-color: hsl(var(--hsl-primary));
+		box-shadow: 0 0 0 3px hsl(var(--hsl-primary) / 0.16);
+	}
+
+	.select-box.is-disabled .select-trigger,
+	.select-trigger:disabled {
+		cursor: not-allowed;
+		background-color: hsl(var(--hsl-content) / 0.05);
+		color: hsl(var(--hsl-content) / 0.6);
+	}
+
+	.select-value {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+	}
+
+	.select-value.is-placeholder {
+		color: hsl(var(--hsl-content) / 0.5);
+	}
+
+	.select-chevron {
+		flex-shrink: 0;
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-content) / 0.6);
+		transition: transform 0.15s ease;
+	}
+
+	.select-chevron.is-open {
+		transform: rotate(180deg);
+	}
+
+	.select-menu {
+		position: absolute;
+		top: calc(100% + 0.35rem);
+		left: 0;
+		z-index: 20;
+		width: 100%;
+		max-height: 18rem;
+		overflow-y: auto;
+		padding: 0.25rem;
+		background: hsl(var(--hsl-base-300));
+		border: 1px solid hsl(var(--hsl-line));
+		border-radius: 0.625rem;
+		box-shadow:
+			0 4px 12px hsl(220 20% 10% / 0.12),
+			0 12px 32px hsl(220 20% 10% / 0.18);
+	}
+
+	.select-option {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.65rem;
+		padding: 0.5rem 0.65rem;
+		border-radius: 0.4rem;
+		font-size: 0.875rem;
+		cursor: pointer;
+		color: hsl(var(--hsl-content));
+	}
+
+	.select-option.is-active {
+		background: hsl(var(--hsl-primary) / 0.1);
+	}
+
+	.select-option.is-selected {
+		font-weight: 600;
+	}
+
+	.select-option.is-disabled {
+		color: hsl(var(--hsl-content) / 0.4);
+		cursor: not-allowed;
+	}
+
+	.select-check {
+		flex-shrink: 0;
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-primary));
+	}
+
+	.select-sep {
+		height: 1px;
+		margin: 0.25rem 0.4rem;
+		background: hsl(var(--hsl-line) / 0.7);
+	}
+
+	/* Visually hidden but still focusable so native constraint validation
+	 * (the `required` bubble) anchors to the control's position. */
+	.select-validity {
+		position: absolute;
+		left: 0;
+		bottom: 0;
+		width: 100%;
+		height: 0;
+		padding: 0;
+		margin: 0;
+		border: 0;
+		opacity: 0;
+		pointer-events: none;
+	}
+</style>

--- a/src/routes/(auth)/(project)/audit-log/+page.svelte
+++ b/src/routes/(auth)/(project)/audit-log/+page.svelte
@@ -7,6 +7,7 @@
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import OutcomeBadge from '$lib/components/OutcomeBadge.svelte'
+	import Select from '$lib/components/Select.svelte'
 	import * as format from '$lib/format'
 
 	const { data } = $props()
@@ -281,24 +282,21 @@
 		<div class="filter-row">
 			<div class="field">
 				<label class="label" for="filter-resource-type">Resource type</label>
-				<div class="select">
-					<select id="filter-resource-type" bind:value={form.resourceType}>
-						<option value="">All</option>
-						{#each RESOURCE_TYPES as t (t.value)}
-							<option value={t.value}>{t.label}</option>
-						{/each}
-					</select>
-				</div>
+				<Select
+					id="filter-resource-type"
+					bind:value={form.resourceType}
+					options={[{ value: '', label: 'All' }, ...RESOURCE_TYPES.map((t) => ({ value: t.value, label: t.label }))]} />
 			</div>
 			<div class="field">
 				<label class="label" for="filter-outcome">Outcome</label>
-				<div class="select">
-					<select id="filter-outcome" bind:value={form.outcome}>
-						<option value="">All</option>
-						<option value="success">Success</option>
-						<option value="failure">Failure</option>
-					</select>
-				</div>
+				<Select
+					id="filter-outcome"
+					bind:value={form.outcome}
+					options={[
+						{ value: '', label: 'All' },
+						{ value: 'success', label: 'Success' },
+						{ value: 'failure', label: 'Failure' }
+					]} />
 			</div>
 			<div class="field">
 				<span class="label">Date range</span>

--- a/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
@@ -3,8 +3,24 @@
 	import api from '$lib/api'
 	import { onMount, tick } from 'svelte'
 	import Chart from '$lib/components/Chart.svelte'
+	import Select from '$lib/components/Select.svelte'
 
 	const { data } = $props()
+
+	const rangeOptions = [
+		{ value: '1h', label: '1 Hour' },
+		{ value: '6h', label: '6 Hours' },
+		{ value: '12h', label: '12 Hours' },
+		{ value: '1d', label: '1 Day' },
+		{ separator: true },
+		{ value: '1hagg', label: '1 Hour (Aggregate)' },
+		{ value: '6hagg', label: '6 Hours (Aggregate)' },
+		{ value: '12hagg', label: '12 Hours (Aggregate)' },
+		{ value: '1dagg', label: '1 Day (Aggregate)' },
+		{ value: '2dagg', label: '2 Days (Aggregate)' },
+		{ value: '7dagg', label: '7 Days (Aggregate)' },
+		{ value: '30dagg', label: '30 Days (Aggregate)' }
+	]
 
 	const deployment = $derived(data.deployment)
 
@@ -79,22 +95,10 @@
 <h6><strong>Metric</strong></h6>
 
 <div class="grid gap-4 justify-start">
-	<div class="select">
-		<select bind:value={filter.range} onchange={() => fetchMetrics(true)}>
-			<option value="1h">1 Hour</option>
-			<option value="6h">6 Hours</option>
-			<option value="12h">12 Hours</option>
-			<option value="1d">1 Day</option>
-			<option disabled>----------</option>
-			<option value="1hagg">1 Hour (Aggregate)</option>
-			<option value="6hagg">6 Hours (Aggregate)</option>
-			<option value="12hagg">12 Hours (Aggregate)</option>
-			<option value="1dagg">1 Day (Aggregate)</option>
-			<option value="2dagg">2 Days (Aggregate)</option>
-			<option value="7dagg">7 Days (Aggregate)</option>
-			<option value="30dagg">30 Days (Aggregate)</option>
-		</select>
-	</div>
+	<Select
+		bind:value={filter.range}
+		options={rangeOptions}
+		onchange={() => fetchMetrics(true)} />
 </div>
 
 <Chart title="vCPU (second)" unit="seconds" series={cpu} range={filter.range} />

--- a/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
@@ -5,6 +5,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import EnvGroupModal from '$lib/components/EnvGroupModal.svelte'
+	import Select from '$lib/components/Select.svelte'
 
 	const { data } = $props()
 
@@ -240,11 +241,6 @@
 		form.envGroups = [...form.envGroups, n]
 	}
 
-	function selectEnvGroupChanged (e) {
-		addEnvGroup(e.target.value)
-		e.target.value = ''
-	}
-
 	function addEnvGroupFromInput () {
 		addEnvGroup(envGroupInput)
 		envGroupInput = ''
@@ -392,16 +388,13 @@
 		{:else}
 			<div class="field">
 				<label for="input-location">Location</label>
-				<div class="select">
-					<select id="input-location" bind:value={form.location} onchange={changeLocation} required>
-						<option value="" selected disabled>Select Location</option>
-						{#each locations as it (it.id)}
-							<option value={it.id}>
-								{it.id}
-							</option>
-						{/each}
-					</select>
-				</div>
+				<Select
+					id="input-location"
+					bind:value={form.location}
+					onchange={changeLocation}
+					required
+					placeholder="Select Location"
+					options={locations.map((it) => ({ value: it.id, label: it.id }))} />
 			</div>
 		{/if}
 
@@ -423,14 +416,15 @@
 			{:else}
 				<div class="field">
 					<label for="input-type">Type</label>
-					<div class="select">
-						<select id="input-type" class="js-type" bind:value={form.type}>
-							<option value="WebService">Web Service</option>
-							<option value="InternalTCPService">Internal TCP Service</option>
-							<option value="Worker">Worker</option>
-							<option value="CronJob">CronJob</option>
-						</select>
-					</div>
+					<Select
+						id="input-type"
+						bind:value={form.type}
+						options={[
+							{ value: 'WebService', label: 'Web Service' },
+							{ value: 'InternalTCPService', label: 'Internal TCP Service' },
+							{ value: 'Worker', label: 'Worker' },
+							{ value: 'CronJob', label: 'CronJob' }
+						]} />
 				</div>
 			{/if}
 
@@ -444,16 +438,12 @@
 		{#if permission.pullSecrets}
 			<div class="field">
 				<label for="input-pull_secret">Pull Secret</label>
-				<div class="select">
-					{#key pullSecrets}
-						<select id="input-pull_secret" bind:value={form.pullSecret}>
-							<option value="">No Pull Secret</option>
-							{#each pullSecrets as it (it.name)}
-								<option value={it.name}>{it.name}</option>
-							{/each}
-						</select>
-					{/key}
-				</div>
+				{#key pullSecrets}
+					<Select
+						id="input-pull_secret"
+						bind:value={form.pullSecret}
+						options={[{ value: '', label: 'No Pull Secret' }, ...pullSecrets.map((it) => ({ value: it.name, label: it.name }))]} />
+				{/key}
 			</div>
 		{:else}
 			<div class="field">
@@ -469,16 +459,12 @@
 			{#if permission.workloadIdentities}
 				<div class="field">
 					<label for="input-workload_identity">Workload Identity</label>
-					<div class="select">
-						{#key workloadIdentities}
-							<select id="input-workload_identity" bind:value={form.workloadIdentity}>
-								<option value="">No Workload Identity</option>
-								{#each workloadIdentities as it (it.name)}
-									<option value={it.name}>{it.name}</option>
-								{/each}
-							</select>
-						{/key}
-					</div>
+					{#key workloadIdentities}
+						<Select
+							id="input-workload_identity"
+							bind:value={form.workloadIdentity}
+							options={[{ value: '', label: 'No Workload Identity' }, ...workloadIdentities.map((it) => ({ value: it.name, label: it.name }))]} />
+					{/key}
 				</div>
 			{:else}
 				<div class="field">
@@ -503,13 +489,14 @@
 		{#if form.type === 'WebService'}
 			<div class="field">
 				<label for="input-protocol">Protocol</label>
-				<div class="select">
-					<select id="input-protocol" bind:value={form.protocol}>
-						<option value="http">http</option>
-						<option value="https">https</option>
-						<option value="h2c">h2c</option>
-					</select>
-				</div>
+				<Select
+					id="input-protocol"
+					bind:value={form.protocol}
+					options={[
+						{ value: 'http', label: 'http' },
+						{ value: 'https', label: 'https' },
+						{ value: 'h2c', label: 'h2c' }
+					]} />
 			</div>
 			<div class="field">
 				<div class="checkbox">
@@ -577,16 +564,12 @@
 				{#if permission.disks}
 					<div class="field">
 						<label for="input-disk_name">Name</label>
-						<div class="select">
-							{#key disks}
-								<select id="input-disk_name" bind:value={form.disk.name}>
-									<option value="">No Disk</option>
-									{#each disks as it (it.name)}
-										<option value={it.name}>{it.name}</option>
-									{/each}
-								</select>
-							{/key}
-						</div>
+						{#key disks}
+							<Select
+								id="input-disk_name"
+								bind:value={form.disk.name}
+								options={[{ value: '', label: 'No Disk' }, ...disks.map((it) => ({ value: it.name, label: it.name }))]} />
+						{/key}
 					</div>
 				{:else}
 					<div class="field">
@@ -621,14 +604,15 @@
 		<div class="grid grid-cols-2 gap-4">
 			<div class="field">
 				<label for="input-ttl_unit">Unit</label>
-				<div class="select">
-					<select id="input-ttl_unit" bind:value={form.ttlUnit}>
-						<option value="0">No auto-delete</option>
-						<option value="60">Minutes</option>
-						<option value="3600">Hours</option>
-						<option value="86400">Days</option>
-					</select>
-				</div>
+				<Select
+					id="input-ttl_unit"
+					bind:value={form.ttlUnit}
+					options={[
+						{ value: '0', label: 'No auto-delete' },
+						{ value: '60', label: 'Minutes' },
+						{ value: '3600', label: 'Hours' },
+						{ value: '86400', label: 'Days' }
+					]} />
 			</div>
 
 			{#if form.ttlUnit !== '0'}
@@ -698,28 +682,27 @@
 
 		<div class="field">
 			<label for="input-cpu-limit">CPU limited</label>
-            <div class="select">
-                <select id="input-cpu-limit" name="cpu" bind:value={form.resources.limits.cpu}>
-                    <option value="0">Cluster Default</option>
-                    <option value="1">1</option>
-                    <option value="2">2</option>
-                    <option value="4">4</option>
-                </select>
-            </div>
-            <small class="helper">
-                Number of vCPUs limited to each container instance. Autoscaling triggers when CPU usage reaches 80% of the limit.
-            </small>
-        </div>
+			<Select
+				id="input-cpu-limit"
+				name="cpu"
+				bind:value={form.resources.limits.cpu}
+				options={[
+					{ value: '0', label: 'Cluster Default' },
+					{ value: '1', label: '1' },
+					{ value: '2', label: '2' },
+					{ value: '4', label: '4' }
+				]} />
+			<small class="helper">
+				Number of vCPUs limited to each container instance. Autoscaling triggers when CPU usage reaches 80% of the limit.
+			</small>
+		</div>
 
 		<div class="field">
 			<label for="input-memory">Memory allocated</label>
-			<div class="select">
-				<select id="input-memory" bind:value={form.resources.requests.memory}>
-					{#each selectedLocation.memoryAllocatable as it, i (i)}
-						<option value={it}>{format.memory(it)}</option>
-					{/each}
-				</select>
-			</div>
+			<Select
+				id="input-memory"
+				bind:value={form.resources.requests.memory}
+				options={selectedLocation.memoryAllocatable.map((it) => ({ value: it, label: format.memory(it) }))} />
 			<small class="helper">
 				Memory to allocate to each container instance.
 			</small>
@@ -734,16 +717,13 @@
 		</div>
 		{#if permission.envGroups}
 			<div class="field flex">
-				<div class="select">
-					{#key envGroups}
-						<select onchange={selectEnvGroupChanged}>
-							<option value="" disabled selected>Select Env Group</option>
-							{#each envGroups.filter((g) => !form.envGroups.includes(g.name)) as it (it.name)}
-								<option value={it.name}>{it.name}</option>
-							{/each}
-						</select>
-					{/key}
-				</div>
+				{#key envGroups}
+					<Select
+						placeholder="Select Env Group"
+						resetOnSelect
+						onchange={(v) => addEnvGroup(String(v))}
+						options={envGroups.filter((g) => !form.envGroups.includes(g.name)).map((it) => ({ value: it.name, label: it.name }))} />
+				{/key}
 			</div>
 		{:else}
 			<div class="field flex gap-3">
@@ -918,12 +898,11 @@
 					</div>
 					<div class="field">
 						<label for="input-sidecar-type-{i}">Type</label>
-						<div class="select">
-							<select id="input-sidecar-type-{i}" bind:value={sidecar.type}>
-								<option value="" disabled>Select Type</option>
-								<option value="cloudSqlProxy">Cloud SQL Proxy</option>
-							</select>
-						</div>
+						<Select
+							id="input-sidecar-type-{i}"
+							bind:value={sidecar.type}
+							placeholder="Select Type"
+							options={[{ value: 'cloudSqlProxy', label: 'Cloud SQL Proxy' }]} />
 					</div>
 					{#if sidecar.type === 'cloudSqlProxy'}
 						<div class="field">

--- a/src/routes/(auth)/(project)/disk/(detail)/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/disk/(detail)/metrics/+page.svelte
@@ -3,10 +3,21 @@
 	import api from '$lib/api'
 	import { onMount, tick } from 'svelte'
 	import Chart from '$lib/components/Chart.svelte'
+	import Select from '$lib/components/Select.svelte'
 
 	const { data } = $props()
 
 	const disk = $derived(data.disk)
+
+	const rangeOptions = [
+		{ value: '1h', label: '1 Hour' },
+		{ value: '6h', label: '6 Hours' },
+		{ value: '12h', label: '12 Hours' },
+		{ value: '1d', label: '1 Day' },
+		{ value: '2d', label: '2 Days' },
+		{ value: '7d', label: '7 Days' },
+		{ value: '30d', label: '30 Days' }
+	]
 
 	const reloadInterval = 60 * 1000 // 1m
 
@@ -60,17 +71,10 @@
 <h6><strong>Metric</strong></h6>
 
 <div class="grid gap-4 justify-start">
-	<div class="select">
-		<select bind:value={filter.range} onchange={() => fetchMetrics(true)}>
-			<option value="1h">1 Hour</option>
-			<option value="6h">6 Hours</option>
-			<option value="12h">12 Hours</option>
-			<option value="1d">1 Day</option>
-			<option value="2d">2 Days</option>
-			<option value="7d">7 Days</option>
-			<option value="30d">30 Days</option>
-		</select>
-	</div>
+	<Select
+		bind:value={filter.range}
+		options={rangeOptions}
+		onchange={() => fetchMetrics(true)} />
 </div>
 
 <Chart title="Disk (bytes)" unit="bytes" series={chart} />

--- a/src/routes/(auth)/(project)/disk/create/+page.svelte
+++ b/src/routes/(auth)/(project)/disk/create/+page.svelte
@@ -3,6 +3,7 @@
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
 
 	const { data } = $props()
 	const locations = $derived(data.locations)
@@ -97,18 +98,12 @@
 					<input id="input-location" value={form.location} readonly>
 				</div>
 			{:else}
-				<div class="select">
-					<select id="input-location" bind:value={form.location} required>
-						<option value="">Select Location</option>
-						{#each locations as it (it.id)}
-							{#if it.features.disk}
-								<option value={it.id}>
-									{it.id}
-								</option>
-							{/if}
-						{/each}
-					</select>
-				</div>
+				<Select
+					id="input-location"
+					bind:value={form.location}
+					required
+					placeholder="Select Location"
+					options={locations.filter((it) => it.features.disk).map((it) => ({ value: it.id, label: it.id }))} />
 			{/if}
 		</div>
 		<div class="field">

--- a/src/routes/(auth)/(project)/domain/create/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/create/+page.svelte
@@ -2,6 +2,7 @@
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
 
 	const { data } = $props()
 	const project = $derived(data.project)
@@ -73,14 +74,12 @@
 		</div>
 		<div class="field">
 			<label for="input-location">Location</label>
-			<div class="select">
-				<select id="input-location" bind:value={form.location} required>
-					<option value="" selected disabled>Select Location</option>
-					{#each locations as it (it.id)}
-						<option value={it.id}>{it.id}</option>
-					{/each}
-				</select>
-			</div>
+			<Select
+				id="input-location"
+				bind:value={form.location}
+				required
+				placeholder="Select Location"
+				options={locations.map((it) => ({ value: it.id, label: it.id }))} />
 		</div>
 
 		<div class="field mt-3">

--- a/src/routes/(auth)/(project)/pull-secret/create/+page.svelte
+++ b/src/routes/(auth)/(project)/pull-secret/create/+page.svelte
@@ -3,6 +3,7 @@
 	import validUrl from 'valid-url'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
 
 	const { data } = $props()
 
@@ -86,14 +87,12 @@
 		</div>
 		<div class="field">
 			<label for="input-location">Location</label>
-			<div class="select">
-				<select id="input-location" bind:value={form.location} required>
-					<option value="" disabled selected>Select Location</option>
-					{#each locations as it (it.id)}
-						<option value={it.id}>{it.id}</option>
-					{/each}
-				</select>
-			</div>
+			<Select
+				id="input-location"
+				bind:value={form.location}
+				required
+				placeholder="Select Location"
+				options={locations.map((it) => ({ value: it.id, label: it.id }))} />
 		</div>
 		<div class="field">
 			<label for="input-server">Server</label>

--- a/src/routes/(auth)/(project)/role/bind/+page.svelte
+++ b/src/routes/(auth)/(project)/role/bind/+page.svelte
@@ -4,6 +4,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import Select from '$lib/components/Select.svelte'
 
 	const { data } = $props()
 	const roles = $derived(data.roles)
@@ -27,11 +28,6 @@
 
 	function removeRole (role) {
 		form.roles = form.roles.filter((x) => x !== role)
-	}
-
-	function selectRoleChanged (e) {
-		addRole(e.target.value)
-		e.target.value = ''
 	}
 
 	let saving = $state(false)
@@ -97,16 +93,11 @@
 			</datalist>
 		</div>
 		<div class="field">
-			<div class="select">
-				<select onchange={selectRoleChanged}>
-					<option value="" disabled selected>Select Role</option>
-					{#each roles as it (it.role)}
-						{#if !form.roles.includes(it.role)}
-							<option value={it.role}>{it.name} ({it.role})</option>
-						{/if}
-					{/each}
-				</select>
-			</div>
+			<Select
+				placeholder="Select Role"
+				resetOnSelect
+				onchange={(v) => addRole(String(v))}
+				options={roles.filter((it) => !form.roles.includes(it.role)).map((it) => ({ value: it.role, label: `${it.name} (${it.role})` }))} />
 		</div>
 
 		<div class="table-container">

--- a/src/routes/(auth)/(project)/role/create/+page.svelte
+++ b/src/routes/(auth)/(project)/role/create/+page.svelte
@@ -5,6 +5,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
+	import Select from '$lib/components/Select.svelte'
 
 	const { data } = $props()
 	const role = $derived(data.role)
@@ -46,11 +47,6 @@
 			...form.permissions,
 			permission
 		]
-	}
-
-	function selectPermissionChanged (e) {
-		addPermission(e.target.value)
-		e.target.value = ''
 	}
 
 	function removePermission (permission) {
@@ -142,14 +138,11 @@
 			<h6><strong>Permissions</strong></h6>
 
 			<div class="field flex mb-3">
-				<div class="select">
-					<select onchange={selectPermissionChanged}>
-						<option value="" disabled selected>Select Permission</option>
-						{#each permissions.filter((x) => !form.permissions.includes(x)) as it (it)}
-							<option value={it}>{it}</option>
-						{/each}
-					</select>
-				</div>
+				<Select
+					placeholder="Select Permission"
+					resetOnSelect
+					onchange={(v) => addPermission(String(v))}
+					options={permissions.filter((x) => !form.permissions.includes(x)).map((it) => ({ value: it, label: it }))} />
 			</div>
 
 			<div class="table-container">

--- a/src/routes/(auth)/(project)/route/create/+page.svelte
+++ b/src/routes/(auth)/(project)/route/create/+page.svelte
@@ -2,6 +2,7 @@
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
 
 	const { data } = $props()
 
@@ -140,27 +141,24 @@
 	<form class="grid gap-4 w-full" onsubmit={save}>
 		<div class="field">
 			<label for="input-location">Location</label>
-			<div class="select">
-				<select id="input-location" bind:value={form.location} onchange={fetchLocationData} required>
-					<option value="" selected disabled>Select Location</option>
-					{#each locations as it (it.id)}
-						<option value={it.id}>{it.id}</option>
-					{/each}
-				</select>
-			</div>
+			<Select
+				id="input-location"
+				bind:value={form.location}
+				onchange={fetchLocationData}
+				required
+				placeholder="Select Location"
+				options={locations.map((it) => ({ value: it.id, label: it.id }))} />
 		</div>
 
 		{#if form.location}
 			<div class="field">
 				<label for="input-domain">Domain</label>
-				<div class="select">
-					<select id="input-domain" bind:value={form.domain} required>
-						<option value="" selected disabled>Select Domain</option>
-						{#each domains as it (it.domain)}
-							<option value={it.domain}>{#if it.wildcard}*.{/if}{it.domain}</option>
-						{/each}
-					</select>
-				</div>
+				<Select
+					id="input-domain"
+					bind:value={form.domain}
+					required
+					placeholder="Select Domain"
+					options={domains.map((it) => ({ value: it.domain, label: (it.wildcard ? '*.' : '') + it.domain }))} />
 			</div>
 
 			{#if selectedDomain?.wildcard}
@@ -182,26 +180,27 @@
 
 			<div class="field">
 				<label for="input-target_prefix">Type</label>
-				<div class="select">
-					<select id="input-target_prefix" bind:value={form.targetPrefix} onchange={() => form.targetValue = ''} required>
-						<option value="" selected disabled>Select Type</option>
-						<option value="deployment://">Deployment</option>
-						<option value="redirect://">Redirect</option>
-					</select>
-				</div>
+				<Select
+					id="input-target_prefix"
+					bind:value={form.targetPrefix}
+					onchange={() => form.targetValue = ''}
+					required
+					placeholder="Select Type"
+					options={[
+						{ value: 'deployment://', label: 'Deployment' },
+						{ value: 'redirect://', label: 'Redirect' }
+					]} />
 			</div>
 
 			{#if form.targetPrefix === 'deployment://'}
 				<div class="field">
 					<label for="input-target_deployment">Deployments</label>
-					<div class="select">
-						<select id="input-target_deployment" bind:value={form.targetValue} required>
-							<option value="" selected disabled>Select Deployment</option>
-							{#each deployments as it (it)}
-								<option value={it}>{it}</option>
-							{/each}
-						</select>
-					</div>
+					<Select
+						id="input-target_deployment"
+						bind:value={form.targetValue}
+						required
+						placeholder="Select Deployment"
+						options={deployments.map((it) => ({ value: it, label: it }))} />
 				</div>
 			{:else if form.targetPrefix}
 				<div class="field">

--- a/src/routes/(auth)/(project)/workload-identity/create/+page.svelte
+++ b/src/routes/(auth)/(project)/workload-identity/create/+page.svelte
@@ -2,6 +2,7 @@
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
 
 	const { data } = $props()
 
@@ -72,16 +73,12 @@
 		</div>
 		<div class="field">
 			<label for="input-location">Location</label>
-			<div class="select">
-				<select id="input-location" bind:value={form.location} required>
-					<option value="" selected disabled>Select Location</option>
-					{#each locations as it (it.id)}
-						{#if it.features.workloadIdentity}
-							<option value={it.id}>{it.id}</option>
-						{/if}
-					{/each}
-				</select>
-			</div>
+			<Select
+				id="input-location"
+				bind:value={form.location}
+				required
+				placeholder="Select Location"
+				options={locations.filter((it) => it.features.workloadIdentity).map((it) => ({ value: it.id, label: it.id }))} />
 		</div>
 		<div class="field">
 			<label for="input-gsa">GSA</label>

--- a/src/routes/(auth)/project/create/+page.svelte
+++ b/src/routes/(auth)/project/create/+page.svelte
@@ -3,6 +3,7 @@
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
 
 	const { data } = $props()
 
@@ -95,14 +96,12 @@
 
 		<div class="field">
 			<label for="input-billing_account">Billing Account</label>
-			<div class="select">
-				<select id="input-billing_account" bind:value={form.billingAccount} required>
-					<option value="" selected disabled>Select Billing Account</option>
-					{#each billingAccounts as it (it.id)}
-						<option value={it.id}>{it.name} ({it.id})</option>
-					{/each}
-				</select>
-			</div>
+			<Select
+				id="input-billing_account"
+				bind:value={form.billingAccount}
+				required
+				placeholder="Select Billing Account"
+				options={billingAccounts.map((it) => ({ value: it.id, label: `${it.name} (${it.id})` }))} />
 		</div>
 
 		<button class="button mt-4 mr-auto" class:is-loading={saving}>

--- a/tests/audit-log.spec.js
+++ b/tests/audit-log.spec.js
@@ -37,9 +37,9 @@ test.describe('audit log', () => {
 		await page.goto('/audit-log?project=test-project&resourceType=deployment&actor=user@example.com&outcome=success')
 
 		const main = page.locator('.content-wrapper')
-		await expect(main.locator('#filter-resource-type')).toHaveValue('deployment')
+		await expect(main.locator('#filter-resource-type')).toContainText('Deployment')
 		await expect(main.locator('#filter-actor')).toHaveValue('user@example.com')
-		await expect(main.locator('#filter-outcome')).toHaveValue('success')
+		await expect(main.locator('#filter-outcome')).toContainText('Success')
 		await expect(main.getByText('deployment.deploy')).toBeVisible()
 	})
 })


### PR DESCRIPTION
## Summary
- Adds `src/lib/components/Select.svelte` — a styled custom dropdown (combobox/listbox) with an app-rendered option list, matching the billing-report popover aesthetic (chevron, selected check, hover/active states, dark-mode aware).
- Replaces every native `<select>` across the console with `<Select>` (12 pages). The **billing report page is intentionally excluded** — it keeps its own bespoke multi-select dropdown.
- The 3 "picker" selects (role bind/create, deploy env groups) now use `resetOnSelect` + `onchange`, dropping their `e.target.value = ''` wrapper handlers.

## Details
- Data-driven API: `options={[{ value, label, disabled?, separator? }]}`, plus `placeholder`, `required`, `disabled`, `id`, `name`, `onchange`, `resetOnSelect`, `bind:value`.
- Full keyboard support (arrows, Home/End, Enter/Space, Esc, Tab, type-ahead), `clickOutside`, and combobox/listbox ARIA via `aria-activedescendant`.
- **Native validation preserved**: a visually-hidden mirror `<select required>` stays in the DOM so the browser's constraint-validation bubble still blocks form submit on empty required selects.

## Test plan
- [x] `bun lint` — clean
- [x] `bun check` — 0 errors, 0 warnings
- [x] `bun run test` — 58/58 Playwright tests pass (updated one audit-log assertion from `toHaveValue` → `toContainText`, since the value now lives on the trigger label)
- [x] Temporary smoke test (since removed) confirmed open → mouse-select → keyboard-select and that empty `required` selects still block submit
- [ ] Manual pass over dropdowns in light/dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)