### PR TITLE
fix: align deployment name when status icon is a pause glyph

### DIFF
--- a/src/lib/components/DeploymentStatusIcon.svelte
+++ b/src/lib/components/DeploymentStatusIcon.svelte
@@ -98,4 +98,4 @@
 	})
 </script>
 
-<i class={`${iconClass} mx-3`}></i>
+<i class={`${iconClass} fa-fw mx-3`}></i>

--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -8,6 +8,13 @@ const LOCATION_ID = 'gke.cluster-rcf2'
 const DOMAIN_SUFFIX = 'rcf2.deploys.app'
 const USER_EMAIL = 'dev@deploys.app'
 
+// DeploymentStatusIcon fetches statusUrl directly (not via the API proxy) and
+// expects a PodStatus JSON. A data: URI lets a success deployment resolve to the
+// healthy check icon offline without standing up a real pod-status endpoint.
+const HEALTHY_STATUS_URL =
+	'data:application/json,' +
+	encodeURIComponent(JSON.stringify({ count: 1, ready: 1, succeeded: 0, failed: 0 }))
+
 /**
  * @template T
  * @param {T} [result]
@@ -114,7 +121,7 @@ function deployment (project = 'acme') {
 		logUrl: '',
 		eventUrl: '',
 		podsUrl: '',
-		statusUrl: '',
+		statusUrl: HEALTHY_STATUS_URL,
 		address: '203.0.113.10',
 		internalAddress: '10.0.0.10',
 		status: 'success',
@@ -129,6 +136,18 @@ function deployment (project = 'acme') {
 
 const deployments = [
 	deployment('acme'),
+	{
+		...deployment('acme'),
+		name: 'cron-cleanup',
+		type: 'CronJob',
+		schedule: '0 * * * *',
+		port: 0,
+		url: '',
+		internalUrl: '',
+		address: '',
+		status: 'success',
+		action: 'pause'
+	},
 	{
 		...deployment('acme'),
 		name: 'worker',


### PR DESCRIPTION
## Summary
- On the deployment list, the name column shifted out of alignment whenever a row's status icon was the pause glyph.
- Cause: `DeploymentStatusIcon.svelte` rendered the icon as `<i class="{iconClass} mx-3">`, and Font Awesome glyphs have different intrinsic widths (`fa-pause` is narrower than `fa-check-circle`), so the following name started at a different x-position per row.
- Fix: add `fa-fw` (fixed-width) so every status icon occupies a uniform box and names always start at the same column.

## Test plan
- [x] `bun lint` passes
- [x] `bun check` passes
- [x] Verified visually in mock mode: `web`, a paused cron, and `worker` rows all left-align in the name column

🤖 Generated with [Claude Code](https://claude.com/claude-code)