### PR TITLE
feat: invoice PDF download and pay-by-slip on the invoice page

### DIFF
--- a/src/lib/components/PayInvoiceModal.svelte
+++ b/src/lib/components/PayInvoiceModal.svelte
@@ -1,0 +1,193 @@
+<script>
+	// Max upload size, mirrors api.MaxTransferSlipSize (10 MiB). The server
+	// enforces this too; checking here gives instant feedback.
+	const MAX_SIZE = 10 * 1024 * 1024
+
+	/**
+	 * @typedef {Object} Props
+	 * @property {() => void} [onuploaded] called after a slip is accepted
+	 */
+
+	/** @type {Props} */
+	const { onuploaded } = $props()
+
+	let invoice = $state(/** @type {?Api.Invoice} */ (null))
+	let isActive = $state(false)
+	let uploading = $state(false)
+	let error = $state('')
+	let selectedFile = $state(/** @type {?File} */ (null))
+	let elFile = $state(/** @type {?HTMLInputElement} */ (null))
+
+	/**
+	 * @param {Api.Invoice} inv
+	 */
+	export function open (inv) {
+		invoice = inv
+		selectedFile = null
+		error = ''
+		if (elFile) elFile.value = ''
+		isActive = true
+	}
+
+	function close () {
+		if (uploading) return
+		isActive = false
+	}
+
+	/**
+	 * Close only when the backdrop itself is clicked, not when a click inside
+	 * the panel bubbles up — otherwise interacting with the form would dismiss
+	 * the modal.
+	 * @param {MouseEvent} e
+	 */
+	function onBackdrop (e) {
+		if (e.target === e.currentTarget) close()
+	}
+
+	/**
+	 * @param {Event} e
+	 */
+	function onFileChange (e) {
+		const input = /** @type {HTMLInputElement} */ (e.currentTarget)
+		const f = input.files?.[0] ?? null
+		error = ''
+		if (f && f.size > MAX_SIZE) {
+			error = 'Slip is too large (max 10 MB).'
+			selectedFile = null
+			input.value = ''
+			return
+		}
+		selectedFile = f
+	}
+
+	async function upload () {
+		if (uploading || !selectedFile || !invoice) return
+		uploading = true
+		error = ''
+		try {
+			const fd = new FormData()
+			fd.append('id', invoice.id)
+			fd.append('slip', selectedFile)
+			const resp = await fetch('/api/billing.uploadTransferSlip', {
+				method: 'POST',
+				body: fd
+			})
+			const res = await resp.json().catch(() => null)
+			if (!resp.ok || !res?.ok) {
+				error = res?.error?.message ?? `Upload failed (${resp.status}).`
+				return
+			}
+			isActive = false
+			onuploaded?.()
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err)
+		} finally {
+			uploading = false
+		}
+	}
+
+	/**
+	 * @param {number} n
+	 */
+	function fileSize (n) {
+		if (n < 1024) return `${n} B`
+		if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+		return `${(n / 1024 / 1024).toFixed(1)} MB`
+	}
+</script>
+
+<div class="modal" onclick={onBackdrop} class:is-active={isActive} aria-hidden={!isActive}>
+	<div class="modal-panel">
+		<div class="modal-close" onclick={close} onkeypress={close} tabindex="0" role="button">✕</div>
+		<h4><strong>Pay invoice {invoice?.number}</strong></h4>
+		<p class="mt-1 text-content/70">
+			Upload your bank transfer slip as proof of payment. We'll verify it and mark the invoice as paid.
+		</p>
+
+		<input
+			bind:this={elFile}
+			class="hidden-input"
+			type="file"
+			accept="image/*,application/pdf"
+			onchange={onFileChange}
+		>
+
+		<div class="mt-4 grid gap-3">
+			<button type="button" class="button is-variant-secondary is-icon-left" onclick={() => elFile?.click()}>
+				<i class="fa-solid fa-paperclip"></i>
+				Choose file
+			</button>
+
+			{#if selectedFile}
+				<div class="selected-file">
+					<i class="fa-solid fa-file-invoice file-icon"></i>
+					<div class="file-meta">
+						<div class="file-name">{selectedFile.name}</div>
+						<div class="file-size">{fileSize(selectedFile.size)}</div>
+					</div>
+				</div>
+			{/if}
+
+			{#if error}
+				<div class="text-negative">{error}</div>
+			{/if}
+
+			<button
+				class="button is-icon-left"
+				class:is-loading={uploading}
+				disabled={!selectedFile || uploading}
+				onclick={upload}
+			>
+				<i class="fa-solid fa-cloud-arrow-up"></i>
+				Upload slip
+			</button>
+		</div>
+	</div>
+</div>
+
+<style>
+	.modal-panel {
+		width: 100%;
+		max-width: 32rem;
+	}
+
+	.hidden-input {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		opacity: 0;
+		pointer-events: none;
+	}
+
+	.selected-file {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.75rem 1rem;
+		background-color: hsl(var(--hsl-content) / 0.06);
+		border: 1px solid hsl(var(--hsl-content) / 0.15);
+		border-radius: 6px;
+	}
+
+	.selected-file .file-icon {
+		font-size: 1.25rem;
+		color: hsl(var(--hsl-content) / 0.7);
+	}
+
+	.selected-file .file-meta {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.selected-file .file-name {
+		font-weight: 600;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.selected-file .file-size {
+		font-size: var(--fs-1);
+		color: hsl(var(--hsl-content) / 0.6);
+	}
+</style>

--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -324,15 +324,67 @@ const repositoryManifests = [
 	{ digest: 'sha256:2222222222222222222222222222222222222222222222222222222222222222', createdAt: CREATED_AT }
 ]
 
-/** @param {string} id */
-function invoice (id) {
-	return {
-		id,
+// Invoices covering every status the UI renders (paid / open / void / draft)
+// plus a foreign-currency + zero-tax case and a partial-period case, so the
+// status badge and detail layout can be exercised offline. period_end is the
+// exclusive first instant of the next period, matching the real backend.
+// NOTE: the real billing.listInvoices hides drafts; this mock lists the draft
+// too so its badge is visible during dev.
+const invoices = [
+	{
+		id: 'inv_mock_9',
+		billingAccountId: 'ba_mock_1',
+		number: 'INV-2026-0009',
+		currency: 'THB',
+		periodStart: '2026-05-01T00:00:00Z',
+		periodEnd: '2026-06-01T00:00:00Z',
+		subtotal: 1200,
+		taxRate: 0.07,
+		taxAmount: 84,
+		total: 1284,
+		status: 'open',
+		taxId: '0123456789012',
+		taxName: 'Acme Co., Ltd.',
+		taxAddress: '1 Mockingbird Lane, Bangkok 10110',
+		issuedAt: '2026-06-01T00:00:00Z',
+		paidAt: '',
+		voidedAt: '',
+		createdAt: '2026-06-01T00:00:00Z',
+		lineItems: [
+			{ sku: 'cpu', description: 'vCPU-hours', quantity: 600, unit: 'hour', unitPrice: 1.5, amount: 900 },
+			{ sku: 'mem', description: 'GiB-hours', quantity: 600, unit: 'hour', unitPrice: 0.5, amount: 300 }
+		]
+	},
+	{
+		id: 'inv_mock_8',
+		billingAccountId: 'ba_mock_1',
+		number: 'INV-2026-0008',
+		currency: 'THB',
+		periodStart: '2026-04-01T00:00:00Z',
+		periodEnd: '2026-05-01T00:00:00Z',
+		subtotal: 150,
+		taxRate: 0.07,
+		taxAmount: 10.5,
+		total: 160.5,
+		status: 'draft',
+		taxId: '0123456789012',
+		taxName: 'Acme Co., Ltd.',
+		taxAddress: '1 Mockingbird Lane, Bangkok 10110',
+		issuedAt: '',
+		paidAt: '',
+		voidedAt: '',
+		createdAt: '2026-05-01T00:00:00Z',
+		lineItems: [
+			{ sku: 'cpu', description: 'vCPU-hours', quantity: 100, unit: 'hour', unitPrice: 1.5, amount: 150 }
+		]
+	},
+	{
+		id: 'inv_mock_7',
 		billingAccountId: 'ba_mock_1',
 		number: 'INV-2026-0007',
 		currency: 'THB',
 		periodStart: '2026-04-01T00:00:00Z',
-		periodEnd: '2026-04-30T23:59:59Z',
+		periodEnd: '2026-05-01T00:00:00Z',
 		subtotal: 1500,
 		taxRate: 0.07,
 		taxAmount: 105,
@@ -349,6 +401,95 @@ function invoice (id) {
 			{ sku: 'cpu', description: 'vCPU-hours', quantity: 720, unit: 'hour', unitPrice: 1.5, amount: 1080 },
 			{ sku: 'mem', description: 'GiB-hours', quantity: 720, unit: 'hour', unitPrice: 0.583, amount: 420 }
 		]
+	},
+	{
+		id: 'inv_mock_6',
+		billingAccountId: 'ba_mock_1',
+		number: 'INV-2026-0006',
+		currency: 'THB',
+		periodStart: '2026-03-01T00:00:00Z',
+		periodEnd: '2026-04-01T00:00:00Z',
+		subtotal: 1080,
+		taxRate: 0.07,
+		taxAmount: 75.6,
+		total: 1155.6,
+		status: 'void',
+		taxId: '0123456789012',
+		taxName: 'Acme Co., Ltd.',
+		taxAddress: '1 Mockingbird Lane, Bangkok 10110',
+		issuedAt: '2026-04-01T00:00:00Z',
+		paidAt: '',
+		voidedAt: '2026-04-05T00:00:00Z',
+		createdAt: '2026-04-01T00:00:00Z',
+		lineItems: [
+			{ sku: 'cpu', description: 'vCPU-hours', quantity: 720, unit: 'hour', unitPrice: 1.5, amount: 1080 }
+		]
+	},
+	{
+		id: 'inv_mock_5',
+		billingAccountId: 'ba_mock_1',
+		number: 'INV-2026-0005',
+		currency: 'USD',
+		periodStart: '2026-02-01T00:00:00Z',
+		periodEnd: '2026-03-01T00:00:00Z',
+		subtotal: 11.2,
+		taxRate: 0,
+		taxAmount: 0,
+		total: 11.2,
+		status: 'paid',
+		taxId: '0123456789012',
+		taxName: 'Acme Co., Ltd.',
+		taxAddress: '1 Mockingbird Lane, Bangkok 10110',
+		issuedAt: '2026-03-01T00:00:00Z',
+		paidAt: '2026-03-02T00:00:00Z',
+		voidedAt: '',
+		createdAt: '2026-03-01T00:00:00Z',
+		lineItems: [
+			{ sku: 'cpu', description: 'vCPU-hours', quantity: 200, unit: 'hour', unitPrice: 0.04, amount: 8 },
+			{ sku: 'mem', description: 'GiB-hours', quantity: 200, unit: 'hour', unitPrice: 0.016, amount: 3.2 }
+		]
+	},
+	{
+		id: 'inv_mock_4',
+		billingAccountId: 'ba_mock_1',
+		number: 'INV-2026-0004',
+		currency: 'THB',
+		periodStart: '2026-01-10T00:00:00Z',
+		periodEnd: '2026-01-20T00:00:00Z',
+		subtotal: 75,
+		taxRate: 0.07,
+		taxAmount: 5.25,
+		total: 80.25,
+		status: 'paid',
+		taxId: '0123456789012',
+		taxName: 'Acme Co., Ltd.',
+		taxAddress: '1 Mockingbird Lane, Bangkok 10110',
+		issuedAt: '2026-01-21T00:00:00Z',
+		paidAt: '2026-01-22T00:00:00Z',
+		voidedAt: '',
+		createdAt: '2026-01-21T00:00:00Z',
+		lineItems: [
+			{ sku: 'cpu', description: 'vCPU-hours', quantity: 50, unit: 'hour', unitPrice: 1.5, amount: 75 }
+		]
+	}
+]
+
+/** @param {(typeof invoices)[number]} inv */
+function invoiceListItem (inv) {
+	return {
+		id: inv.id,
+		number: inv.number,
+		currency: inv.currency,
+		periodStart: inv.periodStart,
+		periodEnd: inv.periodEnd,
+		subtotal: inv.subtotal,
+		taxAmount: inv.taxAmount,
+		total: inv.total,
+		status: inv.status,
+		issuedAt: inv.issuedAt,
+		paidAt: inv.paidAt,
+		voidedAt: inv.voidedAt,
+		createdAt: inv.createdAt
 	}
 }
 
@@ -406,24 +547,21 @@ const handlers = {
 			]
 		}
 	}),
-	'billing.listInvoices': () => list([
-		{
-			id: 'inv_mock_7',
-			number: 'INV-2026-0007',
-			currency: 'THB',
-			periodStart: '2026-04-01T00:00:00Z',
-			periodEnd: '2026-04-30T23:59:59Z',
-			subtotal: 1500,
-			taxAmount: 105,
-			total: 1605,
-			status: 'paid',
-			issuedAt: '2026-05-01T00:00:00Z',
-			paidAt: '2026-05-03T00:00:00Z',
-			voidedAt: '',
-			createdAt: '2026-05-01T00:00:00Z'
-		}
-	]),
-	'billing.getInvoice': (args) => ok(invoice(args?.id ?? 'inv_mock_7')),
+	'billing.listInvoices': () => list(invoices.map(invoiceListItem)),
+	'billing.getInvoice': (args) => ok(invoices.find((i) => i.id === args?.invoiceId) ?? invoices[0]),
+	'billing.downloadInvoice': (args) => {
+		const inv = invoices.find((i) => i.id === args?.invoiceId) ?? invoices[0]
+		return ok({
+			downloadUrl: `https://dropbox.deploys.app/files/mock-${inv.id}.pdf`,
+			expiresAt: '2026-06-02T00:00:00Z'
+		})
+	},
+	// Multipart upload: the proxy can't JSON-parse the body in mock mode, so
+	// args is empty here — just acknowledge the upload.
+	'billing.uploadTransferSlip': () => ok({
+		downloadUrl: 'https://dropbox.deploys.app/files/mock-slip.jpg',
+		expiresAt: '2026-06-02T00:00:00Z'
+	}),
 
 	'auditLog.list': (args) => list(auditLogItems.slice(0, args?.limit ?? auditLogItems.length)),
 

--- a/src/routes/(auth)/billing/invoice/+page.js
+++ b/src/routes/(auth)/billing/invoice/+page.js
@@ -5,7 +5,7 @@ export async function load ({ url, fetch }) {
 	const id = url.searchParams.get('id')
 
 	/** @type {Api.Response<Api.Invoice>} */
-	const invoice = await api.invoke('billing.getInvoice', { id }, fetch)
+	const invoice = await api.invoke('billing.getInvoice', { invoiceId: id }, fetch)
 	if (!invoice.ok) {
 		if (invoice.error?.notFound) redirect(302, '/billing')
 		error(500, invoice.error?.message)

--- a/src/routes/(auth)/billing/invoice/+page.svelte
+++ b/src/routes/(auth)/billing/invoice/+page.svelte
@@ -1,12 +1,40 @@
 <script>
 	import dayjs from 'dayjs'
 	import InvoiceStatusBadge from '$lib/components/InvoiceStatusBadge.svelte'
+	import PayInvoiceModal from '$lib/components/PayInvoiceModal.svelte'
 	import * as format from '$lib/format'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
 
 	const { data } = $props()
 
 	const invoice = $derived(data.invoice)
 	const billingAccount = $derived(data.billingAccount)
+
+	let downloading = $state(false)
+	let payModal = $state(/** @type {?ReturnType<typeof PayInvoiceModal>} */ (null))
+
+	function onSlipUploaded () {
+		modal.success({ content: 'Payment slip uploaded. We\'ll verify it and mark the invoice as paid.' })
+	}
+
+	async function downloadPDF () {
+		if (downloading) return
+		downloading = true
+		try {
+			/** @type {Api.Response<Api.InvoiceDownloadResult>} */
+			const resp = await api.invoke('billing.downloadInvoice', { invoiceId: invoice.id }, fetch)
+			if (!resp.ok || !resp.result) {
+				modal.error({ error: resp.error })
+				return
+			}
+			// The dropbox link serves the file as an attachment, so navigating
+			// to it downloads rather than leaves the page.
+			window.location.href = resp.result.downloadUrl
+		} finally {
+			downloading = false
+		}
+	}
 
 	const periodLabel = $derived.by(() => {
 		const s = dayjs(invoice.periodStart)
@@ -100,7 +128,24 @@
 			<h3 class="mb-1"><strong>{invoice.number}</strong></h3>
 			<div class="text-content/70">{periodLabel}</div>
 		</div>
-		<InvoiceStatusBadge status={invoice.status} />
+		<div class="flex items-center gap-3">
+			<InvoiceStatusBadge status={invoice.status} />
+			<button
+				class="button is-variant-secondary is-icon-left"
+				class:is-loading={downloading}
+				disabled={downloading}
+				onclick={downloadPDF}
+			>
+				<i class="fa-solid fa-download"></i>
+				Download PDF
+			</button>
+			{#if invoice.status === 'open'}
+				<button class="button is-icon-left" onclick={() => payModal?.open(invoice)}>
+					<i class="fa-solid fa-receipt"></i>
+					Pay
+				</button>
+			{/if}
+		</div>
 	</div>
 
 	<hr>
@@ -177,3 +222,5 @@
 		</div>
 	</div>
 </div>
+
+<PayInvoiceModal bind:this={payModal} onuploaded={onSlipUploaded} />

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -455,6 +455,16 @@ declare namespace Api {
         lineItems: InvoiceLineItem[]
     }
 
+    export type InvoiceDownloadResult = {
+        downloadUrl: string
+        expiresAt: string
+    }
+
+    export type InvoiceUploadSlipResult = {
+        downloadUrl: string
+        expiresAt: string
+    }
+
     export type DropboxItem = {
         downloadUrl: string
         filename: string


### PR DESCRIPTION
## Summary
- **Download PDF** action on the invoice detail page — calls `billing.downloadInvoice` and navigates to the returned signed dropbox URL (served as an attachment).
- **Pay** action for `open` invoices — opens `PayInvoiceModal` to upload a bank-transfer slip as proof of payment (`billing.uploadTransferSlip`). File pick (image/PDF, 10 MiB cap mirroring `api.MaxTransferSlipSize`), loading/error states, success confirmation. The button is hidden for paid/void/draft invoices.
- Expanded the offline invoice fixtures to cover every status (paid / open / void / draft), a foreign currency (USD, zero-tax), and a partial billing period so the status badge and detail layout can be exercised in mock mode (`bun dev:mock`).
- Renamed the `getInvoice` / `downloadInvoice` arg to `invoiceId` to match the merged api contract.

## Notes
- **No proxy change needed**: the slip upload is `multipart/form-data`; the existing `/api/[fn]` proxy already streams `request.body` with the original content-type through to the backend.
- Backend support is already merged (api #19, apiserver #53). Requires the apiserver Chromium sidecar + dropbox service-account secrets to be live for the real (non-mock) actions to work.

## Test plan
- [x] `bun lint` (0 errors)
- [x] `bun check` (0 errors, 0 warnings)
- [x] Mock mode (Playwright): Pay button shows on an open invoice and is hidden on a paid one; choosing a file enables Upload; upload POSTs to `billing.uploadTransferSlip` and shows the success message; Download PDF calls `billing.downloadInvoice`.
- [ ] Manual against staging once the Chromium sidecar + secrets are live.