### PR TITLE
feat: show deploy status on the Firewall index via waf.list

### DIFF
--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -254,14 +254,47 @@ const wafZone = {
 			priority: 20
 		}
 	],
+	status: 'success',
+	action: 'create',
 	createdAt: CREATED_AT,
 	createdBy: USER_EMAIL
 }
 
 // Locations (besides the seed LOCATION_ID) that have had a firewall created in
-// this dev session, mapped to their description. Lets create → manage flow work.
-/** @type {Map<string, string>} */
+// this dev session, mapped to { description, polls }. `polls` counts how many
+// times the zone has been read while pending; the deployer is simulated by
+// flipping the zone from pending → success after the first poll, so the index
+// spinner visibly resolves on its own. Lets create → manage flow work too.
+/** @type {Map<string, { description: string, polls: number }>} */
 const wafConfigured = new Map()
+
+/**
+ * Build a WAF zone for a session-created location. `advance` simulates the
+ * deployer: it's set on waf.list reads (the index poll) so the first list shows
+ * pending/create and the next list — after the page polls — settles to success,
+ * making the spinner resolve on its own. waf.get reads observe the same state
+ * without advancing it.
+ * @param {string} location
+ * @param {boolean} [advance]
+ */
+function wafConfiguredZone (location, advance = false) {
+	const entry = wafConfigured.get(location) ?? { description: '', polls: 0 }
+	const status = entry.polls > 0 ? 'success' : 'pending'
+	if (advance) {
+		entry.polls += 1
+		wafConfigured.set(location, entry)
+	}
+	return {
+		project: 'acme',
+		location,
+		description: entry.description,
+		rules: [],
+		status,
+		action: 'create',
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL
+	}
+}
 
 const pullSecrets = [
 	{
@@ -658,29 +691,31 @@ const handlers = {
 	'route.createV2': () => ok({}),
 	'route.delete': () => ok({}),
 
-	// The seed location starts configured; every other location is "firewall not
-	// configured yet" (not-found) until created. waf.set and waf.delete update
-	// the in-memory set so the index/create/manage flows are coherent within a
-	// session (set returns ok and the location then resolves on get).
+	// The seed location starts configured and live; every other location is
+	// "firewall not configured yet" (not-found) until created. A freshly created
+	// location starts as { status: 'pending', action: 'create' } and the
+	// simulated deployer flips it to 'success' after the first read (see
+	// wafConfiguredZone), so the index spinner resolves on its own. waf.set and
+	// waf.delete keep the index/create/manage flows coherent within a session.
+	'waf.list': () => {
+		const items = [{ ...wafZone, location: LOCATION_ID }]
+		for (const location of wafConfigured.keys()) {
+			items.push(wafConfiguredZone(location, true))
+		}
+		return ok({ project: 'acme', items })
+	},
 	'waf.get': (args) => {
 		const location = args?.location ?? LOCATION_ID
 		if (location === LOCATION_ID) return ok({ ...wafZone, location: LOCATION_ID })
 		if (wafConfigured.has(location)) {
-			return ok({
-				project: 'acme',
-				location,
-				description: wafConfigured.get(location) ?? '',
-				rules: [],
-				createdAt: CREATED_AT,
-				createdBy: USER_EMAIL
-			})
+			return ok(wafConfiguredZone(location))
 		}
 		return err('api: waf zone not found')
 	},
 	'waf.set': (args) => {
 		const location = args?.location
 		if (location && location !== LOCATION_ID) {
-			wafConfigured.set(location, args?.description ?? '')
+			wafConfigured.set(location, { description: args?.description ?? '', polls: 0 })
 		}
 		return ok({})
 	},

--- a/src/routes/(auth)/(project)/waf/+page.js
+++ b/src/routes/(auth)/(project)/waf/+page.js
@@ -1,25 +1,14 @@
 import api from '$lib/api'
 
 export async function load ({ parent, fetch }) {
-	const { project, locations } = await parent()
+	const { project } = await parent()
 
-	// There is no "list zones" endpoint, so we fan out waf.get per location and
-	// collect the ones that resolve. A not-found location simply isn't configured.
-	const results = await Promise.all(
-		locations.map(async (/** @type {Api.Location} */ loc) => {
-			/** @type {Api.Response<Api.WafZone>} */
-			const res = await api.invoke('waf.get', { project, location: loc.id }, fetch)
-			if (!res.ok || !res.result) return null
-			const zone = res.result
-			return {
-				location: zone.location ?? loc.id,
-				description: zone.description ?? '',
-				ruleCount: zone.rules?.length ?? 0
-			}
-		})
-	)
+	/** @type {Api.Response<Api.WafZoneList>} */
+	const res = await api.invoke('waf.list', { project }, fetch)
 
-	const firewalls = results.filter((it) => it != null)
-
-	return { project, firewalls }
+	return {
+		project,
+		firewalls: res.result?.items ?? [],
+		error: res.error
+	}
 }

--- a/src/routes/(auth)/(project)/waf/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/+page.svelte
@@ -1,10 +1,24 @@
 <script>
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import { onMount } from 'svelte'
+	import api from '$lib/api'
 
 	const { data } = $props()
 
 	const project = $derived(data.project)
 	const firewalls = $derived(data.firewalls)
+	const error = $derived(data.error)
+
+	const hasPending = $derived(firewalls.some((/** @type {Api.WafZone} */ fw) => fw.status === 'pending'))
+
+	// While any zone is still being applied/removed by the deployer, poll waf.list
+	// so the spinner resolves to its settled state on its own. Mirrors the
+	// deployment detail polling pattern (api.intervalInvalidate in onMount).
+	onMount(() => api.intervalInvalidate(async () => {
+		if (!hasPending) return
+		await api.invalidate('waf.list')
+	}, 3000))
 </script>
 
 <div class="page-head">
@@ -26,6 +40,7 @@
 			<thead>
 				<tr>
 					<th>Location</th>
+					<th>Status</th>
 					<th>Description</th>
 					<th>Rules</th>
 					<th class="is-collapse is-align-right"></th>
@@ -38,13 +53,31 @@
 							<a href={`/waf/manage?project=${project}&location=${encodeURIComponent(fw.location)}`} class="link font-mono">{fw.location}</a>
 						</td>
 						<td>
+							{#if fw.status === 'pending'}
+								<span class="inline-flex items-center gap-2 text-content/70">
+									<i class="fa-solid fa-spinner-third fa-spin"></i>
+									{fw.action === 'delete' ? 'Removing' : 'Deploying'}
+								</span>
+							{:else if fw.status === 'error'}
+								<span class="inline-flex items-center gap-2 text-negative/80">
+									<i class="fa-solid fa-times"></i>
+									Error
+								</span>
+							{:else}
+								<span class="inline-flex items-center gap-2 text-positive/80">
+									<i class="fa-solid fa-check-circle"></i>
+									Active
+								</span>
+							{/if}
+						</td>
+						<td>
 							{#if fw.description}
 								{fw.description}
 							{:else}
 								<span class="text-content/40">—</span>
 							{/if}
 						</td>
-						<td>{fw.ruleCount}</td>
+						<td>{fw.rules?.length ?? 0}</td>
 						<td>
 							<div class="flex gap-1 justify-end">
 								<a class="button is-variant-secondary is-size-small"
@@ -56,13 +89,14 @@
 					</tr>
 				{/each}
 				<NoDataRow
-					span={4}
+					span={5}
 					list={firewalls}
 					icon="fa-shield-halved"
 					message="No firewalls yet"
 					hint="Create a firewall to start filtering traffic in a location."
 					ctaLabel="Create firewall"
 					ctaHref={`/waf/create?project=${project}`} />
+				<ErrorRow span={5} {error} />
 			</tbody>
 		</table>
 	</div>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -484,8 +484,15 @@ declare namespace Api {
         location: string
         description: string
         rules: WafRule[]
+        status: 'pending' | 'success' | 'error'
+        action: 'create' | 'delete'
         createdAt: string
         createdBy: string
+    }
+
+    export type WafZoneList = {
+        project: string
+        items: WafZone[]
     }
 
     export type DropboxItem = {


### PR DESCRIPTION
## Summary
- Switch the Firewall index loader to a single `waf.list` call (replacing the per-location `waf.get` fan-out) and surface the deployer status.
- Add a **Status** column: pending zones show a `fa-spinner-third` spinner with "Deploying" (`action: create`) / "Removing" (`action: delete`); `success` shows a green "Active" check; `error` shows a red "Error" badge.
- Auto-refresh while any zone is pending — the index polls `waf.list` every 3s via `api.intervalInvalidate` (same pattern as deployment detail polling), so the spinner resolves on its own with no manual reload.
- Mock: add a `waf.list` handler, include `status`/`action` in `waf.get`, and simulate the deployer (a freshly created location starts `pending`/`create` and flips to `success` after the first list poll).
- Types: add `status`/`action` to `Api.WafZone` and a `WafZoneList` result type.

> Note: original PR #128 was already merged (its branch auto-deleted), so this follow-up branches off the up-to-date `main`.

## Test plan
- [x] `bun lint` — zero errors
- [x] `bun check` — zero errors
- [x] `bun dev:mock` + Playwright at `/waf?project=acme`: seed zone shows "Active"; creating a firewall for another location shows a spinner + "Deploying" that auto-resolves to "Active"; zero console errors; verified light + dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)