### PR TITLE
feat: add search input to the project select modal

### DIFF
--- a/src/routes/(auth)/ModalSelectProject.svelte
+++ b/src/routes/(auth)/ModalSelectProject.svelte
@@ -63,6 +63,15 @@
 	function onBackdrop (e) {
 		if (e.target === e.currentTarget) close()
 	}
+
+	/**
+	 * @param {KeyboardEvent} e
+	 */
+	function onSearchKeydown (e) {
+		if (e.key === 'Enter' && filtered.length) {
+			setProject(filtered[0].project)
+		}
+	}
 </script>
 
 <div class="modal" onclick={onBackdrop} class:is-active={isActive} aria-hidden={!isActive}>
@@ -75,6 +84,7 @@
 			<input
 				bind:this={elSearch}
 				bind:value={search}
+				onkeydown={onSearchKeydown}
 				type="text"
 				placeholder="Search projects…"
 				autocomplete="off"

--- a/src/routes/(auth)/ModalSelectProject.svelte
+++ b/src/routes/(auth)/ModalSelectProject.svelte
@@ -1,7 +1,9 @@
 <script>
+	import { tick } from 'svelte'
 	import { page } from '$app/stores'
 	import { goto } from '$app/navigation'
 	import { SvelteURLSearchParams } from 'svelte/reactivity'
+	import NoDataRow from '$lib/components/NoDataRow.svelte'
 
 	/**
 	 * @typedef {Object} Props
@@ -13,6 +15,16 @@
 
 	const project = $derived($page.url.searchParams.get('project'))
 	let isActive = $state(false)
+	let search = $state('')
+	let elSearch = $state(/** @type {?HTMLInputElement} */ (null))
+
+	const filtered = $derived.by(() => {
+		const q = search.trim().toLowerCase()
+		if (!q) return projects
+		return projects.filter((it) =>
+			it.name.toLowerCase().includes(q) || it.project.toLowerCase().includes(q)
+		)
+	})
 
 	/**
 	 * @param {string} sid
@@ -31,19 +43,43 @@
 		goto(`/?${q.toString()}`)
 	}
 
-	export function open () {
+	export async function open () {
+		search = ''
 		isActive = true
+		await tick()
+		elSearch?.focus()
 	}
 
 	function close () {
 		isActive = false
 	}
+
+	/**
+	 * Close only when the backdrop itself is clicked, not when a click inside
+	 * the panel bubbles up — otherwise interacting with the search would dismiss
+	 * the modal.
+	 * @param {MouseEvent} e
+	 */
+	function onBackdrop (e) {
+		if (e.target === e.currentTarget) close()
+	}
 </script>
 
-<div class="modal" onclick={close} class:is-active={isActive} aria-hidden="true">
+<div class="modal" onclick={onBackdrop} class:is-active={isActive} aria-hidden={!isActive}>
 	<div class="modal-panel">
 		<div class="modal-close" onclick={close} onkeypress={close} tabindex="0" role="button">✕</div>
 		<h4>Projects</h4>
+
+		<div class="input -has-icon-left mt-4">
+			<span class="icon -is-left"><i class="fa-solid fa-magnifying-glass"></i></span>
+			<input
+				bind:this={elSearch}
+				bind:value={search}
+				type="text"
+				placeholder="Search projects…"
+				autocomplete="off"
+			>
+		</div>
 
 		<div class="table-container mt-4">
 			<table class="table is-variant-compact" style="--table-data-font-size: var(--fs-2)">
@@ -55,7 +91,7 @@
 					</tr>
 				</thead>
 				<tbody>
-					{#each projects as it (it.project)}
+					{#each filtered as it (it.project)}
 					<tr>
 						<td>
 							{#if project === it.project}
@@ -73,6 +109,7 @@
 						<td>{it.project}</td>
 					</tr>
 					{/each}
+					<NoDataRow span={3} list={filtered} icon="fa-magnifying-glass" message="No projects match your search" />
 				</tbody>
 			</table>
 		</div>


### PR DESCRIPTION
## Summary
- Add a search input to `ModalSelectProject` that filters the project list by **name** or **ID** (case-insensitive).
- Auto-focus the search input when the modal opens (`await tick()` then `elSearch.focus()`).
- Switch the backdrop close handler to `onBackdrop` so it only closes when the backdrop itself is clicked — clicks inside the panel (including the new search input) no longer dismiss the modal. This matches the pattern in `PayInvoiceModal.svelte`.
- Reset the search query on each open, and show a `NoDataRow` when no project matches.

## Test plan
- `bun lint` — passes, zero errors
- `bun check` — passes, zero errors
- Open the project modal: the search input is focused, typing filters the list by name/ID, and clicking inside the modal doesn't close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)