### PR TITLE
fix: stop the per-row status-fetch storm on the deployment list

### DIFF
--- a/src/lib/components/DeploymentStatusIcon.svelte
+++ b/src/lib/components/DeploymentStatusIcon.svelte
@@ -28,8 +28,15 @@
 	/** @type {Api.PodStatus | null} */
 	let podStatus = $state(null)
 
-	/** @type {string} */
-	let iconClass = $state('')
+	/** @type {?HTMLElement} */
+	let el = $state(null)
+	let visible = $state(false)
+	let hasBeenVisible = $state(false)
+
+	// Pod readiness only changes the icon for a running (non-paused) success
+	// deployment; every other state is resolved from props alone, so there's no
+	// reason to hit statusUrl for it.
+	const needsPodStatus = $derived(status === 'success' && action !== 'pause')
 
 	/**
 	 * @returns {string}
@@ -44,7 +51,12 @@
 		}
 
 		if (!podStatus) {
-			return 'fa-solid fa-spin fa-spinner text-content/40'
+			// Readiness not loaded yet. Only spin while the row is on-screen;
+			// off-screen rows show a static placeholder so a long list doesn't
+			// animate hundreds of spinners at once.
+			return (visible || hasBeenVisible)
+				? 'fa-solid fa-spin fa-spinner text-content/40'
+				: 'fa-solid fa-spinner text-content/30'
 		}
 		if (type === 'CronJob' && podStatus.count === podStatus.succeeded + podStatus.ready) {
 			return 'fa-solid fa-check-circle text-positive/80'
@@ -55,17 +67,22 @@
 		return 'fa-solid fa-exclamation-triangle text-warning'
 	}
 
-	let fetchPodStatusTimeout
+	const iconClass = $derived(getIconClass())
+
+	let timer
 	let destroyed = false
 
-	async function fetchPodStatus () {
+	function clearTimer () {
+		if (timer) {
+			clearTimeout(timer)
+			timer = null
+		}
+	}
+
+	async function poll () {
+		clearTimer()
 		if (destroyed) {
 			return
-		}
-
-		if (fetchPodStatusTimeout) {
-			clearTimeout(fetchPodStatusTimeout)
-			fetchPodStatusTimeout = null
 		}
 
 		try {
@@ -78,24 +95,53 @@
 		} catch (err) {
 			console.error(err)
 		} finally {
-			fetchPodStatusTimeout = setTimeout(fetchPodStatus, 10000)
+			// The row may have scrolled out of view while the request was in
+			// flight — only keep polling rows that still need it, and jitter the
+			// interval so many rows don't re-fetch in lockstep.
+			if (!destroyed && visible && needsPodStatus) {
+				timer = setTimeout(poll, 10000 + Math.random() * 3000)
+			}
 		}
 	}
 
+	// Drop stale readiness if the deployment we're pointing at changes.
+	$effect(() => {
+		url
+		podStatus = null
+	})
+
+	// Track viewport visibility so only on-screen rows fetch their status. The
+	// margin starts polling slightly before a row scrolls into view.
+	$effect(() => {
+		if (!browser || !el) {
+			return
+		}
+		const io = new IntersectionObserver((entries) => {
+			visible = entries[entries.length - 1].isIntersecting
+			if (visible) {
+				hasBeenVisible = true
+			}
+		}, { rootMargin: '300px' })
+		io.observe(el)
+		return () => io.disconnect()
+	})
+
+	// Poll only while the row is visible and its icon depends on pod status.
+	// Toggling visibility (or changing the target) restarts/stops the loop.
+	$effect(() => {
+		const active = browser && visible && needsPodStatus
+		url
+		clearTimer()
+		if (active) {
+			poll()
+		}
+		return clearTimer
+	})
+
 	onDestroy(() => {
 		destroyed = true
-		fetchPodStatusTimeout && clearTimeout(fetchPodStatusTimeout)
-	})
-	$effect(() => {
-		status
-		url
-		action
-		browser && fetchPodStatus()
-	})
-	$effect(() => {
-		podStatus
-		iconClass = getIconClass()
+		clearTimer()
 	})
 </script>
 
-<i class={`${iconClass} fa-fw mx-3`}></i>
+<i bind:this={el} class={`${iconClass} fa-fw mx-3`}></i>


### PR DESCRIPTION
## Problem
The deployment list page lags in **Safari** (Chrome is fine) when a project has many deployments, immediately on entering the page.

## Investigation
I reproduced in **WebKit (Safari's engine) vs Chromium** via Playwright, rendering up to 300 deployments and measuring frame jank (headless and headed, both the initial 0–3s window and after settle).

Ruled out with evidence:
- **CSS `fa-spin` animation / compositor** — spinning ≈ static icons (WebKit 5 vs 4 long frames at 300 rows).
- **Row count / DOM size / table CSS** — 300 rows render at 50–70fps in both engines; no sticky header or `backdrop-filter`.
- **Main-thread/script blocking** — 300 simultaneous fetch resolutions produced 0 long frames.

The only behaviour that scales with deployment count *and* is network-bound: `DeploymentStatusIcon` (one per row) fired an independent `fetch(statusUrl)` on mount and polled every 10s — i.e. a burst of **N concurrent requests + N recurring timers** on page enter. (This is why it didn't repro against the offline mock, whose `statusUrl` is a `data:`/local URL that resolves instantly.) The pod-readiness data it fetches is genuinely absent from `deployment.list`, so the fetch can't simply be dropped.

## Fix
In `DeploymentStatusIcon.svelte`:
- **Viewport-gate** the polling with an `IntersectionObserver` (300px margin) — only on-screen rows fetch their status; off-screen rows pause.
- **Jitter** the 10s poll interval so re-polls don't fire in lockstep.
- **Skip** fetching entirely for rows whose icon doesn't depend on pod status (non-success or paused).
- Off-screen, not-yet-loaded rows render a **static** placeholder instead of an animated spinner (also hedges the compositor angle).

## Verification
Temporary Playwright spec (WebKit + Chromium), 300 deployments:
- Status fetches on enter: **16** (visible rows) — was 300.
- After scrolling down: rises to 43, confirming lazy load as rows appear.

`bun lint`, `bun check`, and the existing `tests/deployment.spec.js` (12 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)