### PR TITLE
feat: project search — partial multi-word match + arrow-key navigation

### DIFF
--- a/src/routes/(auth)/ModalSelectProject.svelte
+++ b/src/routes/(auth)/ModalSelectProject.svelte
@@ -19,11 +19,12 @@
 	let elSearch = $state(/** @type {?HTMLInputElement} */ (null))
 
 	const filtered = $derived.by(() => {
-		const q = search.trim().toLowerCase()
-		if (!q) return projects
-		return projects.filter((it) =>
-			it.name.toLowerCase().includes(q) || it.project.toLowerCase().includes(q)
-		)
+		const tokens = search.trim().toLowerCase().split(/\s+/).filter(Boolean)
+		if (!tokens.length) return projects
+		return projects.filter((it) => {
+			const haystack = `${it.name} ${it.project}`.toLowerCase()
+			return tokens.every((t) => haystack.includes(t))
+		})
 	})
 
 	/**

--- a/src/routes/(auth)/ModalSelectProject.svelte
+++ b/src/routes/(auth)/ModalSelectProject.svelte
@@ -17,6 +17,8 @@
 	let isActive = $state(false)
 	let search = $state('')
 	let elSearch = $state(/** @type {?HTMLInputElement} */ (null))
+	let highlighted = $state(0)
+	const rowEls = $state(/** @type {HTMLElement[]} */ ([]))
 
 	const filtered = $derived.by(() => {
 		const tokens = search.trim().toLowerCase().split(/\s+/).filter(Boolean)
@@ -25,6 +27,11 @@
 			const haystack = `${it.name} ${it.project}`.toLowerCase()
 			return tokens.every((t) => haystack.includes(t))
 		})
+	})
+
+	// Keep the keyboard-highlighted row scrolled into view as it moves.
+	$effect(() => {
+		rowEls[highlighted]?.scrollIntoView({ block: 'nearest' })
 	})
 
 	/**
@@ -46,6 +53,7 @@
 
 	export async function open () {
 		search = ''
+		highlighted = 0
 		isActive = true
 		await tick()
 		elSearch?.focus()
@@ -66,11 +74,19 @@
 	}
 
 	/**
+	 * Arrow Up/Down move the highlighted row; Enter selects it.
 	 * @param {KeyboardEvent} e
 	 */
 	function onSearchKeydown (e) {
-		if (e.key === 'Enter' && filtered.length) {
-			setProject(filtered[0].project)
+		if (!filtered.length) return
+		if (e.key === 'ArrowDown') {
+			e.preventDefault()
+			highlighted = Math.min(highlighted + 1, filtered.length - 1)
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault()
+			highlighted = Math.max(highlighted - 1, 0)
+		} else if (e.key === 'Enter') {
+			setProject(filtered[highlighted].project)
 		}
 	}
 </script>
@@ -86,6 +102,7 @@
 				bind:this={elSearch}
 				bind:value={search}
 				onkeydown={onSearchKeydown}
+				oninput={() => highlighted = 0}
 				type="text"
 				placeholder="Search projects…"
 				autocomplete="off"
@@ -102,8 +119,8 @@
 					</tr>
 				</thead>
 				<tbody>
-					{#each filtered as it (it.project)}
-					<tr>
+					{#each filtered as it, i (it.project)}
+					<tr bind:this={rowEls[i]} class:is-highlighted={i === highlighted} onmouseenter={() => highlighted = i}>
 						<td>
 							{#if project === it.project}
 								<i class="fas fa-check text-primary text-xl"></i>
@@ -136,6 +153,10 @@
 	.table td {
 		padding-top: 0.5rem;
 		padding-bottom: 0.5rem;
+	}
+
+	.table tbody tr.is-highlighted td {
+		background-color: hsl(var(--hsl-primary) / 0.1);
 	}
 
 	.modal-panel {


### PR DESCRIPTION
Two related improvements to the project select modal's search.

## 1. Partial multi-word matching

Previously the whole query was looked up as one literal substring, so `test prod` could never match a project named **Test Project Prod**. The filter now splits the query into whitespace-separated tokens and requires **every** token to appear in the project's name or ID:

- `test prod` → matches **Test Project Prod**
- Token order doesn't matter (`prod test` works too)
- name + ID are searched as one haystack, so a query can span both

## 2. Arrow-key navigation (desktop / keyboard)

- **Arrow Down / Up** move a highlighted row (clamped to the filtered list)
- **Enter** selects the highlighted project (was: always the top match)
- Highlighted row gets a primary tint and scrolls into view as it moves
- Mouse hover keeps the highlight in sync; typing resets it to the top match

## Checks

- `bun lint` — pass
- `bun check` — pass (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)