### PR TITLE
feat: show 24h WAF match sparkline + total on firewall list

### DIFF
--- a/src/lib/components/Sparkline.svelte
+++ b/src/lib/components/Sparkline.svelte
@@ -1,0 +1,56 @@
+<script>
+	// Tiny inline bar chart for sparse time-series (e.g. WAF matches per minute).
+	// Bars are positioned by timestamp across [from, to] so quiet periods read as
+	// gaps rather than being collapsed, and heights are normalized to the window's
+	// peak. Cheap enough to render one per table row (plain SVG, no chart lib).
+
+	/**
+	 * @typedef {Object} Props
+	 * @property {[number, number][]} points  // [unixSeconds, value], time-ordered
+	 * @property {number} [from]   // x-domain start (unix seconds); defaults to first point
+	 * @property {number} [to]     // x-domain end (unix seconds); defaults to last point
+	 * @property {number} [width]
+	 * @property {number} [height]
+	 */
+
+	/** @type {Props} */
+	const { points = [], from, to, width = 96, height = 28 } = $props()
+
+	const start = $derived(from ?? points[0]?.[0] ?? 0)
+	const end = $derived(to ?? points[points.length - 1]?.[0] ?? 1)
+	const span = $derived(Math.max(1, end - start))
+	const max = $derived(Math.max(1, ...points.map((p) => p[1])))
+
+	const barW = 2
+
+	const bars = $derived(
+		points.map(([ts, v]) => {
+			const x = Math.min(width - barW, Math.max(0, ((ts - start) / span) * (width - barW)))
+			const h = Math.max(1, (v / max) * (height - 1))
+			return { x, y: height - h, h }
+		})
+	)
+</script>
+
+<svg
+	class="sparkline"
+	viewBox={`0 0 ${width} ${height}`}
+	{width}
+	{height}
+	preserveAspectRatio="none"
+	role="img"
+	aria-hidden="true"
+>
+	{#each bars as b, i (i)}
+		<rect x={b.x} y={b.y} width={barW} height={b.h} rx="0.75" />
+	{/each}
+</svg>
+
+<style>
+	.sparkline {
+		display: block;
+	}
+	.sparkline rect {
+		fill: hsl(var(--hsl-primary));
+	}
+</style>

--- a/src/lib/format/index.js
+++ b/src/lib/format/index.js
@@ -45,6 +45,17 @@ export function storage (v) {
 	return (v / 1024 / 1024 / 1024).toLocaleString(undefined, { maximumFractionDigits: 2 }) + ' GiB'
 }
 
+const compactNumber = new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 })
+
+/**
+ * Compact count, e.g. 950, 1.2K, 3.4M. Used for hit/match totals.
+ * @param {number} v
+ * @returns {string}
+ */
+export function count (v) {
+	return compactNumber.format(v ?? 0)
+}
+
 /**
  * @param {string | undefined | null} v
  * @returns {string}

--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -260,6 +260,41 @@ const wafZone = {
 	createdBy: USER_EMAIL
 }
 
+// Synthetic 24h match metrics for the seed zone, so the firewall index sparkline
+// + total have something to draw. Scatters per-minute counts across the window
+// per (rule, action), mirroring waf.metrics' shape (sparse buckets, grand total).
+function wafMetrics () {
+	const now = Math.floor(Date.now() / 1000)
+	const minute = 60
+
+	/**
+	 * @param {string} ruleId
+	 * @param {Api.WafAction} action
+	 * @param {number} buckets  // how many active minutes
+	 * @param {number} scale    // max count per minute
+	 */
+	const makeSeries = (ruleId, action, buckets, scale) => {
+		/** @type {[number, number][]} */
+		const points = []
+		let total = 0
+		for (let i = 0; i < buckets; i++) {
+			const ts = now - Math.floor(Math.random() * 24 * 60) * minute
+			const v = 1 + Math.floor(Math.random() * scale)
+			points.push([ts, v])
+			total += v
+		}
+		points.sort((a, b) => a[0] - b[0])
+		return { ruleId, action, total, points }
+	}
+
+	const series = [
+		makeSeries('block-admin', 'block', 36, 6),
+		makeSeries('log-bots', 'log', 80, 3)
+	]
+	const total = series.reduce((acc, s) => acc + s.total, 0)
+	return { series, total }
+}
+
 // Locations (besides the seed LOCATION_ID) that have had a firewall created in
 // this dev session, mapped to { description, polls }. `polls` counts how many
 // times the zone has been read while pending; the deployer is simulated by
@@ -718,6 +753,13 @@ const handlers = {
 			wafConfigured.set(location, { description: args?.description ?? '', polls: 0 })
 		}
 		return ok({})
+	},
+	'waf.metrics': (args) => {
+		// Seed zone has activity; session-created zones read empty (shows the "—"
+		// no-traffic state on the index).
+		const location = args?.location ?? LOCATION_ID
+		if (location === LOCATION_ID) return ok(wafMetrics())
+		return ok({ series: [], total: 0 })
 	},
 	'waf.delete': (args) => {
 		if (args?.location) wafConfigured.delete(args.location)

--- a/src/routes/(auth)/(project)/waf/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/+page.svelte
@@ -1,8 +1,10 @@
 <script>
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import Sparkline from '$lib/components/Sparkline.svelte'
 	import { onMount } from 'svelte'
 	import api from '$lib/api'
+	import * as format from '$lib/format'
 
 	const { data } = $props()
 
@@ -19,6 +21,58 @@
 		if (!hasPending) return
 		await api.invalidate('waf.list')
 	}, 3000))
+
+	// Last 24h of match activity per location, shown as an inline sparkline +
+	// total. Fetched client-side (one waf.metrics per zone, in parallel) so the
+	// table renders immediately and the charts fill in.
+	/**
+	 * @typedef {Object} Metrics
+	 * @property {boolean} loading
+	 * @property {number} total
+	 * @property {[number, number][]} points
+	 */
+	/** @type {Record<string, Metrics>} */
+	const metrics = $state({})
+
+	// Fixed 24h x-domain so bars sit at the right time-of-day even when the zone
+	// only has a few active minutes.
+	const to = Math.floor(Date.now() / 1000)
+	const from = to - 24 * 60 * 60
+
+	onMount(() => {
+		Promise.all(firewalls.map(async (/** @type {Api.WafZone} */ fw) => {
+			metrics[fw.location] = { loading: true, total: 0, points: [] }
+
+			/** @type {Api.Response<Api.WafMetricsResult>} */
+			const res = await api.invoke('waf.metrics',
+				{ project, location: fw.location, timeRange: '1d' }, fetch)
+
+			metrics[fw.location] = {
+				loading: false,
+				total: res.result?.total ?? 0,
+				points: aggregate(res.result?.series ?? [])
+			}
+		}))
+	})
+
+	// Collapse the per-(rule, action) series into one total-matches line: sum
+	// every series' value at each timestamp, then sort by time.
+	/**
+	 * @param {Api.WafMetricsSeries[]} series
+	 * @returns {[number, number][]}
+	 */
+	function aggregate (series) {
+		/** @type {Record<number, number>} */
+		const byTs = {}
+		for (const s of series) {
+			for (const [ts, v] of s.points ?? []) {
+				byTs[ts] = (byTs[ts] ?? 0) + v
+			}
+		}
+		return Object.entries(byTs)
+			.map(([ts, v]) => /** @type {[number, number]} */ ([Number(ts), v]))
+			.sort((a, b) => a[0] - b[0])
+	}
 </script>
 
 <div class="page-head">
@@ -43,6 +97,7 @@
 					<th>Status</th>
 					<th>Description</th>
 					<th>Rules</th>
+					<th>Matches (24h)</th>
 					<th class="is-collapse is-align-right"></th>
 				</tr>
 			</thead>
@@ -79,6 +134,20 @@
 						</td>
 						<td>{fw.rules?.length ?? 0}</td>
 						<td>
+							{#if metrics[fw.location]?.loading}
+								<span class="text-content/30"><i class="fa-solid fa-spinner-third fa-spin"></i></span>
+							{:else if (metrics[fw.location]?.total ?? 0) > 0}
+								<div class="flex items-center gap-3">
+									<span class="font-mono text-sm tabular-nums" title={`${metrics[fw.location].total.toLocaleString()} matches in the last 24h`}>
+										{format.count(metrics[fw.location].total)}
+									</span>
+									<Sparkline points={metrics[fw.location].points} {from} {to} />
+								</div>
+							{:else}
+								<span class="text-content/40">—</span>
+							{/if}
+						</td>
+						<td>
 							<div class="flex gap-1 justify-end">
 								<a class="button is-variant-secondary is-size-small"
 									href={`/waf/manage?project=${project}&location=${encodeURIComponent(fw.location)}`}>
@@ -89,14 +158,14 @@
 					</tr>
 				{/each}
 				<NoDataRow
-					span={5}
+					span={6}
 					list={firewalls}
 					icon="fa-shield-halved"
 					message="No firewalls yet"
 					hint="Create a firewall to start filtering traffic in a location."
 					ctaLabel="Create firewall"
 					ctaHref={`/waf/create?project=${project}`} />
-				<ErrorRow span={5} {error} />
+				<ErrorRow span={6} {error} />
 			</tbody>
 		</table>
 	</div>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -495,6 +495,21 @@ declare namespace Api {
         items: WafZone[]
     }
 
+    export type WafMetricsTimeRange = '1h' | '6h' | '12h' | '1d' | '7d' | '30d'
+
+    export type WafMetricsSeries = {
+        ruleId: string
+        action: WafAction
+        total: number
+        // [unixSeconds, count], time-ordered
+        points: [number, number][]
+    }
+
+    export type WafMetricsResult = {
+        series: WafMetricsSeries[]
+        total: number
+    }
+
     export type DropboxItem = {
         downloadUrl: string
         filename: string


### PR DESCRIPTION
## Why

The WAF metrics backend (`waf.metrics` over `waf_usages`) is live but unused. This surfaces it on the firewall index so users get an at-a-glance read on how much each zone is matching — without leaving the list.

## What

A new **Matches (24h)** column on the firewall list. Per zone, the page fetches `waf.metrics` (`timeRange: '1d'`) client-side in parallel (table renders immediately, charts fill in) and shows the **total hit count next to a small bar sparkline** of matches over the last 24h. Zones with no traffic show `—`.

- **`Sparkline.svelte`** — tiny SVG bar chart for sparse time-series, positioned by timestamp over a fixed 24h domain (quiet periods read as gaps), normalized to the window peak. Plain SVG, cheap enough to render one per row (no Highcharts instance per cell).
- **`waf/+page.svelte`** — fetch + aggregate the per-`(rule, action)` series into one total-matches line; render total (`format.count`) + sparkline.
- **`format.count`** — compact totals (`1.2K`, `3.4M`).
- **`api.d.ts`** — `WafMetricsTimeRange` / `WafMetricsSeries` / `WafMetricsResult`.
- **mock** — `waf.metrics` returns synthetic activity for the seed zone and empty for session-created zones, so `dev:mock` exercises both the chart and the `—` state.

## Verification

`bun run check` (0 errors), `eslint` clean, `bun run build` OK, and visually confirmed in `dev:mock` — the total (e.g. `286`) sits left of a compact bar sparkline in the new column, with `—` for zones that have no traffic.

## Depends on

`waf.metrics` (api + apiserver) — shipped in the backend PRs. Backend must be deployed for real data; until then the column shows `—`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)