### PR TITLE
feat: hide WAF-unsupported locations from create firewall page

### DIFF
--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -77,7 +77,7 @@ const locations = [
 		cname: 'rcf2.deploys.app.',
 		cpuAllocatable: ['100m', '250m', '500m', '1000m', '2000m'],
 		memoryAllocatable: ['128Mi', '256Mi', '512Mi', '1Gi', '2Gi'],
-		features: { workloadIdentity: true, disk: {} },
+		features: { workloadIdentity: true, disk: {}, waf: {} },
 		createdAt: CREATED_AT
 	},
 	{
@@ -87,7 +87,7 @@ const locations = [
 		cname: 'sg1.deploys.app.',
 		cpuAllocatable: ['100m', '250m', '500m', '1000m', '2000m'],
 		memoryAllocatable: ['128Mi', '256Mi', '512Mi', '1Gi', '2Gi'],
-		features: { workloadIdentity: true, disk: {} },
+		features: { workloadIdentity: true, disk: {}, waf: {} },
 		createdAt: CREATED_AT
 	}
 ]

--- a/src/routes/(auth)/(project)/waf/create/+page.js
+++ b/src/routes/(auth)/(project)/waf/create/+page.js
@@ -3,10 +3,16 @@ import api from '$lib/api'
 export async function load ({ parent, fetch }) {
 	const { project, locations } = await parent()
 
+	// Only locations whose backend supports the WAF can host a firewall; drop the
+	// rest before the fan-out (also saves a waf.get per unsupported location).
+	const supported = locations.filter(
+		(/** @type {Api.Location} */ loc) => loc.features.waf
+	)
+
 	// No "list zones" endpoint — fan out waf.get to discover which locations are
 	// already configured, then offer only the unconfigured ones for create.
 	const configured = await Promise.all(
-		locations.map(async (/** @type {Api.Location} */ loc) => {
+		supported.map(async (/** @type {Api.Location} */ loc) => {
 			/** @type {Api.Response<Api.WafZone>} */
 			const res = await api.invoke('waf.get', { project, location: loc.id }, fetch)
 			return res.ok && res.result ? loc.id : null
@@ -14,7 +20,7 @@ export async function load ({ parent, fetch }) {
 	)
 	const configuredSet = configured.filter((id) => id != null)
 
-	const available = locations.filter(
+	const available = supported.filter(
 		(/** @type {Api.Location} */ loc) => !configuredSet.includes(loc.id)
 	)
 

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -108,6 +108,7 @@ declare namespace Api {
         features: {
             workloadIdentity?: boolean
             disk?: Record<string, never>
+            waf?: Record<string, never>
         }
         createdAt: string
     }


### PR DESCRIPTION
## What

Filter the create-firewall location picker to locations whose backend supports the WAF (`features.waf`).

Depends on the now-merged api + apiserver changes:
- api exposes `LocationFeatures.waf` (deploys-app/api#26).
- apiserver rejects `waf.set` on a location without `features.waf` → `ErrLocationNotSupport` (deploys-app/apiserver#61).

Without this, an unsupported location would still appear in the dropdown and the save would fail server-side. Now it's filtered out client-side.

## Changes

- **`waf/create/+page.js`** — filter to `loc.features.waf` before the existing already-configured fan-out (also skips a `waf.get` per unsupported location).
- **`types/api.d.ts`** — add `waf?: Record<string, never>` to `Location.features`.
- **`lib/server/mock.js`** — seed `waf: {}` on both mock locations so the mock create flow still surfaces a selectable location (faithful to the apiserver migration, which enables `features.waf` on all enabled locations).

Matches the existing `features.disk` / `features.workloadIdentity` filtering used on the disk- and workload-identity create pages.

## Verification

- `eslint` clean on changed files.
- `svelte-check` clean (0 errors / 0 warnings, 746 files).

## Note

The create page's empty-state copy ("Every location already has a firewall configured") is unchanged. Post-migration every enabled location supports the WAF, so an empty list still means "all configured"; left as-is to avoid weakening that message for the common case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)