### PR TITLE
feat: confirm before deleting a WAF rule

### DIFF
--- a/src/routes/(auth)/(project)/waf/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/manage/+page.svelte
@@ -83,10 +83,18 @@
 	}
 
 	/** @param {number} i */
-	async function removeRule (i) {
-		const next = rules.filter((_, k) => k !== i)
-		rules = next
-		await persistZone(next)
+	function removeRule (i) {
+		const rule = rules[i]
+		if (!rule) return
+		modal.confirm({
+			title: `Delete rule ${rule.id}?`,
+			yes: 'Delete',
+			callback: async () => {
+				const next = rules.filter((_, k) => k !== i)
+				rules = next
+				await persistZone(next)
+			}
+		})
 	}
 
 	/** @param {import('$lib/waf/rules').RuleForm} rule */


### PR DESCRIPTION
## Summary

Deleting an individual WAF rule on the firewall manage page previously removed it immediately on click, with no confirmation — inconsistent with the rest of the page (disabling a firewall already prompts via `modal.confirm`).

This wraps `removeRule` in a `modal.confirm` so deleting a rule now requires explicit confirmation, naming the rule by its ID. The actual filter + `persistZone` only runs in the confirm callback.

## Testing

- `bun lint` — pass
- `bun check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)