### PR TITLE
feat: WAF metrics page — per-location activity dashboard

### DIFF
--- a/src/lib/components/WafActivityChart.svelte
+++ b/src/lib/components/WafActivityChart.svelte
@@ -1,0 +1,131 @@
+<script>
+	import { onMount } from 'svelte'
+	import Highcharts from 'highcharts'
+	import * as hc from '$lib/hc'
+	import { browser } from '$app/environment'
+
+	/**
+	 * A stacked-column view of WAF matches over time, one stack segment per
+	 * action (block / log / allow). Data arrives pre-bucketed onto a shared time
+	 * grid so the segments align cleanly.
+	 *
+	 * @typedef {Object} ActivitySeries
+	 * @property {Api.WafAction} action
+	 * @property {string} name
+	 * @property {[number, number][]} data  // [unixMs, count]
+	 */
+
+	/**
+	 * @typedef {Object} Props
+	 * @property {ActivitySeries[]} series
+	 * @property {number} from  // x-extreme start, unix ms
+	 * @property {number} to    // x-extreme end, unix ms
+	 */
+
+	/** @type {Props} */
+	const { series, from, to } = $props()
+
+	/** @type {HTMLDivElement} */
+	let el
+
+	/** @type {import('highcharts').Chart | undefined} */
+	let chart = $state.raw(undefined)
+
+	// Highcharts paints series colors onto SVG `fill` attributes, where CSS
+	// `var()` does NOT resolve — so read the theme's HSL triplet off the document
+	// and hand Highcharts a concrete color. Re-read on every sync so a theme
+	// toggle (followed by the next refresh) recolors correctly.
+	/** @type {Record<Api.WafAction, string>} */
+	const tokenByAction = {
+		block: '--hsl-negative',
+		log: '--hsl-warning',
+		allow: '--hsl-positive'
+	}
+
+	/** @param {Api.WafAction} action */
+	function actionColor (action) {
+		if (!browser) return undefined
+		const triplet = getComputedStyle(document.documentElement)
+			.getPropertyValue(tokenByAction[action]).trim()
+		return triplet ? `hsl(${triplet})` : undefined
+	}
+
+	onMount(() => {
+		hc.init()
+
+		chart = Highcharts.chart(el, {
+			chart: {
+				type: 'column',
+				height: 320,
+				spacingTop: 16,
+				spacingBottom: 8
+			},
+			title: { text: undefined },
+			legend: { enabled: false },
+			xAxis: {
+				type: 'datetime',
+				showEmpty: true,
+				gridLineWidth: 0
+			},
+			yAxis: {
+				min: 0,
+				title: { text: null },
+				allowDecimals: false,
+				showEmpty: true
+			},
+			plotOptions: {
+				column: {
+					stacking: 'normal',
+					borderWidth: 0,
+					pointPadding: 0.02,
+					groupPadding: 0.05,
+					crisp: false
+				}
+			},
+			tooltip: {
+				shared: true,
+				useHTML: true,
+				headerFormat: '<span style="font-size:0.75rem;opacity:0.7">{point.key}</span><br>',
+				pointFormat: '<span style="color:{series.color}">●</span> {series.name}: <b>{point.y}</b><br>'
+			},
+			series: []
+		})
+
+		return () => {
+			chart?.destroy()
+		}
+	})
+
+	// Sync incoming series into the chart: update existing stacks in place,
+	// add new ones, drop ones that no longer have data.
+	$effect(() => {
+		if (!browser || !chart) return
+		const c = chart
+		const names = new Set(series.map((s) => s.name))
+
+		;[...c.series].forEach((s) => {
+			if (!names.has(s.name)) s.remove(false)
+		})
+
+		series.forEach((s) => {
+			const color = actionColor(s.action)
+			const existing = c.series.find((it) => it.name === s.name)
+			if (existing) {
+				existing.update({ type: 'column', color }, false)
+				existing.setData(s.data, false)
+				return
+			}
+			c.addSeries({
+				type: 'column',
+				name: s.name,
+				data: s.data,
+				color
+			}, false)
+		})
+
+		c.xAxis[0].setExtremes(from, to, false)
+		c.redraw()
+	})
+</script>
+
+<div bind:this={el}></div>

--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -252,6 +252,13 @@ const wafZone = {
 			expression: "request.headers['user-agent'].contains('bot')",
 			action: 'log',
 			priority: 20
+		},
+		{
+			id: 'allow-office',
+			description: 'Always allow the office egress IP',
+			expression: "request.ip == '203.0.113.7'",
+			action: 'allow',
+			priority: 30
 		}
 	],
 	status: 'success',
@@ -260,25 +267,30 @@ const wafZone = {
 	createdBy: USER_EMAIL
 }
 
-// Synthetic 24h match metrics for the seed zone, so the firewall index sparkline
-// + total have something to draw. Scatters per-minute counts across the window
-// per (rule, action), mirroring waf.metrics' shape (sparse buckets, grand total).
-function wafMetrics () {
+/** @type {Record<string, number>} */
+const wafRangeSeconds = { '1h': 3600, '6h': 21600, '12h': 43200, '1d': 86400, '7d': 604800, '30d': 2592000 }
+
+// Synthetic match metrics for the seed zone, so the firewall index sparkline +
+// total and the metrics page have something to draw. Scatters counts across the
+// requested window per (rule, action), mirroring waf.metrics' shape (sparse
+// buckets, grand total).
+/** @param {string} [timeRange] */
+function wafMetrics (timeRange) {
 	const now = Math.floor(Date.now() / 1000)
-	const minute = 60
+	const windowSeconds = wafRangeSeconds[timeRange ?? '1d'] ?? wafRangeSeconds['1d']
 
 	/**
 	 * @param {string} ruleId
 	 * @param {Api.WafAction} action
-	 * @param {number} buckets  // how many active minutes
-	 * @param {number} scale    // max count per minute
+	 * @param {number} buckets  // how many active samples
+	 * @param {number} scale    // max count per sample
 	 */
 	const makeSeries = (ruleId, action, buckets, scale) => {
 		/** @type {[number, number][]} */
 		const points = []
 		let total = 0
 		for (let i = 0; i < buckets; i++) {
-			const ts = now - Math.floor(Math.random() * 24 * 60) * minute
+			const ts = now - Math.floor(Math.random() * windowSeconds)
 			const v = 1 + Math.floor(Math.random() * scale)
 			points.push([ts, v])
 			total += v
@@ -288,8 +300,9 @@ function wafMetrics () {
 	}
 
 	const series = [
-		makeSeries('block-admin', 'block', 36, 6),
-		makeSeries('log-bots', 'log', 80, 3)
+		makeSeries('block-admin', 'block', 60, 6),
+		makeSeries('log-bots', 'log', 90, 3),
+		makeSeries('allow-office', 'allow', 24, 2)
 	]
 	const total = series.reduce((acc, s) => acc + s.total, 0)
 	return { series, total }
@@ -758,7 +771,7 @@ const handlers = {
 		// Seed zone has activity; session-created zones read empty (shows the "—"
 		// no-traffic state on the index).
 		const location = args?.location ?? LOCATION_ID
-		if (location === LOCATION_ID) return ok(wafMetrics())
+		if (location === LOCATION_ID) return ok(wafMetrics(args?.timeRange))
 		return ok({ series: [], total: 0 })
 	},
 	'waf.delete': (args) => {

--- a/src/routes/(auth)/(project)/waf/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/+page.svelte
@@ -105,7 +105,7 @@
 				{#each firewalls as fw (fw.location)}
 					<tr>
 						<td>
-							<a href={`/waf/manage?project=${project}&location=${encodeURIComponent(fw.location)}`} class="link font-mono">{fw.location}</a>
+							<a href={`/waf/metrics?project=${project}&location=${encodeURIComponent(fw.location)}`} class="link font-mono">{fw.location}</a>
 						</td>
 						<td>
 							{#if fw.status === 'pending'}
@@ -151,11 +151,6 @@
 						</td>
 						<td>
 							<div class="flex gap-1 justify-end">
-								<a class="button is-variant-tertiary is-size-small is-icon-left"
-									href={`/waf/metrics?project=${project}&location=${encodeURIComponent(fw.location)}`}>
-									<i class="fa-solid fa-chart-simple"></i>
-									Metrics
-								</a>
 								<a class="button is-variant-secondary is-size-small"
 									href={`/waf/manage?project=${project}&location=${encodeURIComponent(fw.location)}`}>
 									Manage

--- a/src/routes/(auth)/(project)/waf/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/+page.svelte
@@ -137,18 +137,25 @@
 							{#if metrics[fw.location]?.loading}
 								<span class="text-content/30"><i class="fa-solid fa-spinner-third fa-spin"></i></span>
 							{:else if (metrics[fw.location]?.total ?? 0) > 0}
-								<div class="flex items-center gap-3">
-									<span class="font-mono text-sm tabular-nums" title={`${metrics[fw.location].total.toLocaleString()} matches in the last 24h`}>
+								<a class="matches-link flex items-center gap-3"
+									href={`/waf/metrics?project=${project}&location=${encodeURIComponent(fw.location)}`}
+									title={`${metrics[fw.location].total.toLocaleString()} matches in the last 24h — view metrics`}>
+									<span class="font-mono text-sm tabular-nums">
 										{format.count(metrics[fw.location].total)}
 									</span>
 									<Sparkline points={metrics[fw.location].points} {from} {to} />
-								</div>
+								</a>
 							{:else}
 								<span class="text-content/40">—</span>
 							{/if}
 						</td>
 						<td>
 							<div class="flex gap-1 justify-end">
+								<a class="button is-variant-tertiary is-size-small is-icon-left"
+									href={`/waf/metrics?project=${project}&location=${encodeURIComponent(fw.location)}`}>
+									<i class="fa-solid fa-chart-simple"></i>
+									Metrics
+								</a>
 								<a class="button is-variant-secondary is-size-small"
 									href={`/waf/manage?project=${project}&location=${encodeURIComponent(fw.location)}`}>
 									Manage
@@ -170,3 +177,17 @@
 		</table>
 	</div>
 </div>
+
+<style>
+	/* The matches total + sparkline doubles as a shortcut into the metrics view. */
+	.matches-link {
+		width: fit-content;
+		color: inherit;
+		border-radius: 0.375rem;
+		transition: color var(--timing-fastest) ease;
+	}
+
+	.matches-link:hover {
+		color: hsl(var(--hsl-primary));
+	}
+</style>

--- a/src/routes/(auth)/(project)/waf/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/manage/+page.svelte
@@ -142,6 +142,11 @@
 			Web application firewall rules in <span class="font-mono">{location}</span>
 		</p>
 	</div>
+	<a class="button is-variant-secondary is-icon-left"
+		href={`/waf/metrics?project=${project}&location=${encodeURIComponent(location)}`}>
+		<i class="fa-solid fa-chart-simple"></i>
+		View metrics
+	</a>
 </div>
 
 <div class="panel is-level-300 grid gap-6">

--- a/src/routes/(auth)/(project)/waf/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/manage/+page.svelte
@@ -129,7 +129,10 @@
 		<a href={`/waf?project=${project}`} class="link"><h6>Firewall</h6></a>
 	</div>
 	<div class="breadcrumb-item">
-		<h6 class="font-mono">{location}</h6>
+		<a href={`/waf/metrics?project=${project}&location=${encodeURIComponent(location)}`} class="link"><h6 class="font-mono">{location}</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<h6>Manage</h6>
 	</div>
 </div>
 

--- a/src/routes/(auth)/(project)/waf/metrics/+page.js
+++ b/src/routes/(auth)/(project)/waf/metrics/+page.js
@@ -1,0 +1,30 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+
+// Metrics are fetched client-side (per time range) so the range switcher is
+// snappy and the page can auto-refresh. The loader only resolves the zone so
+// the top-rules table can show rule descriptions and we can bail early when the
+// firewall doesn't exist.
+export async function load ({ url, parent, fetch }) {
+	const { project } = await parent()
+	const location = url.searchParams.get('location') ?? ''
+
+	if (!location) {
+		redirect(302, `/waf?project=${project}`)
+	}
+
+	/** @type {Api.Response<Api.WafZone>} */
+	const res = await api.invoke('waf.get', { project, location }, fetch)
+
+	if (!res.ok) {
+		if (res.error?.notFound) redirect(302, `/waf?project=${project}`)
+		error(500, res.error?.message)
+	}
+	if (!res.result) redirect(302, `/waf?project=${project}`)
+
+	return {
+		project,
+		location,
+		zone: res.result
+	}
+}

--- a/src/routes/(auth)/(project)/waf/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/metrics/+page.svelte
@@ -193,10 +193,7 @@
 		<a href={`/waf?project=${project}`} class="link"><h6>Firewall</h6></a>
 	</div>
 	<div class="breadcrumb-item">
-		<a href={managePath} class="link"><h6 class="font-mono">{location}</h6></a>
-	</div>
-	<div class="breadcrumb-item">
-		<h6>Metrics</h6>
+		<h6 class="font-mono">{location}</h6>
 	</div>
 </div>
 

--- a/src/routes/(auth)/(project)/waf/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/metrics/+page.svelte
@@ -1,0 +1,608 @@
+<script>
+	import { onMount } from 'svelte'
+	import { page } from '$app/stores'
+	import { replaceState } from '$app/navigation'
+	import api from '$lib/api'
+	import * as modal from '$lib/modal'
+	import * as format from '$lib/format'
+	import { actionLabels } from '$lib/waf/rules'
+	import WafActivityChart from '$lib/components/WafActivityChart.svelte'
+
+	const { data } = $props()
+
+	const project = $derived(data.project)
+	const location = $derived(data.location)
+	const managePath = $derived(`/waf/manage?project=${project}&location=${encodeURIComponent(location)}`)
+
+	// Rule id → its configured description/action, so the top-rules table reads
+	// in human terms rather than raw ids.
+	const ruleMeta = $derived(new Map(
+		(data.zone?.rules ?? []).map((/** @type {Api.WafRule} */ r) => [r.id, r])
+	))
+
+	// Stacks render block on top of log on top of allow — most-severe last so it
+	// sits at the top of the column.
+	/** @type {Api.WafAction[]} */
+	const ACTION_ORDER = ['allow', 'log', 'block']
+
+	const RANGE_OPTIONS = [
+		{ value: '1h', label: '1H' },
+		{ value: '6h', label: '6H' },
+		{ value: '12h', label: '12H' },
+		{ value: '1d', label: '24H' },
+		{ value: '7d', label: '7D' },
+		{ value: '30d', label: '30D' }
+	]
+	/** @type {Record<string, number>} */
+	const RANGE_SECONDS = { '1h': 3600, '6h': 21600, '12h': 43200, '1d': 86400, '7d': 604800, '30d': 2592000 }
+	/** @type {Record<string, string>} */
+	const RANGE_LABEL = {
+		'1h': 'last hour',
+		'6h': 'last 6 hours',
+		'12h': 'last 12 hours',
+		'1d': 'last 24 hours',
+		'7d': 'last 7 days',
+		'30d': 'last 30 days'
+	}
+	// Bucket width per range — kept around 48–72 columns so bars stay legible.
+	/** @type {Record<string, number>} */
+	const BUCKET_SECONDS = { '1h': 60, '6h': 300, '12h': 600, '1d': 1800, '7d': 10800, '30d': 43200 }
+
+	const initialRange = $page.url.searchParams.get('range')
+	let range = $state(initialRange && RANGE_SECONDS[initialRange] ? initialRange : '1d')
+
+	let loading = $state(true)
+	let result = $state(/** @type {Api.WafMetricsResult | null} */ (null))
+	// Anchor the time window to the moment of the latest fetch so the chart grid
+	// and "as of" line agree.
+	let fetchedAt = $state(Math.floor(Date.now() / 1000))
+
+	/** @type {ReturnType<typeof setTimeout> | undefined} */
+	let refreshTimer
+
+	async function fetchMetrics () {
+		loading = true
+		try {
+			/** @type {Api.Response<Api.WafMetricsResult>} */
+			const res = await api.invoke('waf.metrics', { project, location, timeRange: range }, fetch)
+			if (!res.ok) {
+				modal.error({ error: res.error })
+				return
+			}
+			result = res.result ?? { series: [], total: 0 }
+			fetchedAt = Math.floor(Date.now() / 1000)
+		} finally {
+			loading = false
+			scheduleRefresh()
+		}
+	}
+
+	// Live-refresh only short windows — minute-level polling is meaningless for a
+	// 7d/30d view and just churns the chart.
+	function scheduleRefresh () {
+		clearTimeout(refreshTimer)
+		if (RANGE_SECONDS[range] <= RANGE_SECONDS['1d']) {
+			refreshTimer = setTimeout(fetchMetrics, 60 * 1000)
+		}
+	}
+
+	/** @param {string} r */
+	function selectRange (r) {
+		if (r === range) return
+		range = r
+		const u = new URL($page.url)
+		u.searchParams.set('range', r)
+		replaceState(u, {})
+		result = null
+		fetchMetrics()
+	}
+
+	onMount(() => {
+		fetchMetrics()
+		return () => clearTimeout(refreshTimer)
+	})
+
+	const total = $derived(result?.total ?? 0)
+
+	// Totals per action, for the KPI tiles.
+	const byAction = $derived.by(() => {
+		/** @type {Record<Api.WafAction, number>} */
+		const acc = { block: 0, log: 0, allow: 0 }
+		for (const s of result?.series ?? []) {
+			acc[s.action] = (acc[s.action] ?? 0) + s.total
+		}
+		return acc
+	})
+
+	const tiles = $derived([
+		{ key: 'total', label: 'Total matches', value: total },
+		{ key: 'block', label: 'Blocked', value: byAction.block },
+		{ key: 'log', label: 'Logged', value: byAction.log },
+		{ key: 'allow', label: 'Allowed', value: byAction.allow }
+	])
+
+	const windowFrom = $derived(fetchedAt - RANGE_SECONDS[range])
+
+	// Bucket every series' sparse points onto a shared grid, summed per action,
+	// so the stacked columns line up. Actions with no traffic in the window are
+	// dropped from the chart.
+	const chartSeries = $derived.by(() => {
+		const bucket = BUCKET_SECONDS[range]
+		const from = windowFrom
+		const to = fetchedAt
+		const n = Math.max(1, Math.ceil((to - from) / bucket))
+
+		/** @type {Record<Api.WafAction, number[]>} */
+		const grids = { block: new Array(n).fill(0), log: new Array(n).fill(0), allow: new Array(n).fill(0) }
+		for (const s of result?.series ?? []) {
+			const g = grids[s.action]
+			if (!g) continue
+			for (const [ts, v] of s.points ?? []) {
+				const i = Math.floor((ts - from) / bucket)
+				if (i >= 0 && i < n) g[i] += v
+			}
+		}
+
+		return ACTION_ORDER
+			.filter((action) => byAction[action] > 0)
+			.map((action) => ({
+				action,
+				name: actionLabels[action] ?? action,
+				/** @type {[number, number][]} */
+				data: grids[action].map((v, i) => [(from + i * bucket) * 1000, v])
+			}))
+	})
+
+	// Rank rules by match volume. Each (rule, action) series collapses onto its
+	// rule; the action of its largest series wins the badge.
+	const topRules = $derived.by(() => {
+		/** @type {Record<string, { ruleId: string, total: number, action: Api.WafAction, top: number }>} */
+		const byRule = {}
+		for (const s of result?.series ?? []) {
+			const cur = byRule[s.ruleId]
+			if (cur) {
+				cur.total += s.total
+				if (s.total > cur.top) {
+					cur.top = s.total
+					cur.action = s.action
+				}
+			} else {
+				byRule[s.ruleId] = { ruleId: s.ruleId, total: s.total, action: s.action, top: s.total }
+			}
+		}
+		return Object.values(byRule)
+			.filter((r) => r.total > 0)
+			.sort((a, b) => b.total - a.total)
+	})
+
+	/** @param {number} v */
+	function share (v) {
+		return total > 0 ? v / total : 0
+	}
+	/** @param {number} v */
+	function pct (v) {
+		return total > 0 ? `${Math.round((v / total) * 100)}%` : '—'
+	}
+
+	const showSpinner = $derived(loading && !result)
+	const isEmpty = $derived(!loading && total === 0)
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/waf?project=${project}`} class="link"><h6>Firewall</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<a href={managePath} class="link"><h6 class="font-mono">{location}</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<h6>Metrics</h6>
+	</div>
+</div>
+
+<br>
+
+<div class="page-head">
+	<div>
+		<h4><strong>Firewall activity</strong></h4>
+		<p class="page-sub">
+			Matches in <span class="font-mono">{location}</span> · {RANGE_LABEL[range]}
+		</p>
+	</div>
+	<div class="head-actions">
+		<div class="range-switch" role="group" aria-label="Time range">
+			{#each RANGE_OPTIONS as opt (opt.value)}
+				<button
+					type="button"
+					class="range-btn"
+					class:is-active={range === opt.value}
+					aria-pressed={range === opt.value}
+					onclick={() => selectRange(opt.value)}>{opt.label}</button>
+			{/each}
+		</div>
+		<a class="button is-variant-secondary is-icon-left" href={managePath}>
+			<i class="fa-solid fa-sliders"></i>
+			Manage rules
+		</a>
+	</div>
+</div>
+
+<div class="stat-grid">
+	{#each tiles as tile (tile.key)}
+		<div class="stat-tile" data-accent={tile.key}>
+			<div class="stat-head">
+				{#if tile.key !== 'total'}<span class="dot"></span>{/if}
+				{tile.label}
+			</div>
+			<div class="stat-value">
+				{#if showSpinner}
+					<span class="text-content/25"><i class="fa-solid fa-spinner-third fa-spin"></i></span>
+				{:else}
+					{format.count(tile.value)}
+				{/if}
+			</div>
+			<div class="stat-foot">
+				{#if tile.key === 'total'}
+					<span>across {topRules.length} {topRules.length === 1 ? 'rule' : 'rules'}</span>
+				{:else}
+					<span class="share-bar"><span style={`width:${share(tile.value) * 100}%`}></span></span>
+					<span class="tabular-nums">{pct(tile.value)}</span>
+				{/if}
+			</div>
+		</div>
+	{/each}
+</div>
+
+<div class="panel is-level-300 chart-panel">
+	<div class="panel-head">
+		<h6><strong>Matches over time</strong></h6>
+		<div class="legend">
+			{#each ['block', 'log', 'allow'] as action (action)}
+				<span class="legend-item" data-action={action}>
+					<span class="legend-dot"></span>
+					{actionLabels[action]}
+				</span>
+			{/each}
+		</div>
+	</div>
+
+	<div class="chart-body">
+		{#if showSpinner}
+			<div class="chart-state text-content/40">
+				<i class="fa-solid fa-spinner-third fa-spin text-2xl"></i>
+			</div>
+		{:else if isEmpty}
+			<div class="chart-state">
+				<i class="fa-solid fa-shield-halved empty-icon"></i>
+				<p class="empty-title">No matches in this window</p>
+				<p class="empty-sub">Traffic is flowing clean — no rule has fired in the {RANGE_LABEL[range]}.</p>
+			</div>
+		{:else}
+			<WafActivityChart series={chartSeries} from={windowFrom * 1000} to={fetchedAt * 1000} />
+		{/if}
+	</div>
+</div>
+
+{#if !isEmpty}
+	<div class="panel is-level-300">
+		<div class="panel-head">
+			<h6><strong>Top rules</strong></h6>
+			<span class="page-sub">by match volume</span>
+		</div>
+		<div class="table-container">
+			<table class="table is-variant-compact">
+				<thead>
+					<tr>
+						<th>Rule</th>
+						<th>Action</th>
+						<th class="is-align-right">Matches</th>
+						<th class="share-col">Share</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each topRules as rule (rule.ruleId)}
+						{@const meta = ruleMeta.get(rule.ruleId)}
+						{@const action = meta?.action ?? rule.action}
+						<tr>
+							<td>
+								<div class="rule-cell">
+									{#if meta?.description}
+										<span class="rule-desc">{meta.description}</span>
+									{/if}
+									<span class="font-mono text-sm text-content/55">{rule.ruleId}</span>
+								</div>
+							</td>
+							<td>
+								<span class="act-badge" data-action={action}>{actionLabels[action] ?? action}</span>
+							</td>
+							<td class="is-align-right font-mono tabular-nums">{rule.total.toLocaleString()}</td>
+							<td class="share-col">
+								<div class="row-share">
+									<span class="share-bar" data-action={action}>
+										<span style={`width:${share(rule.total) * 100}%`}></span>
+									</span>
+									<span class="tabular-nums text-content/60">{pct(rule.total)}</span>
+								</div>
+							</td>
+						</tr>
+					{/each}
+					{#if showSpinner}
+						<tr><td colspan="4" class="text-center text-content/40">
+							<i class="fa-solid fa-spinner-third fa-spin"></i>
+						</td></tr>
+					{/if}
+				</tbody>
+			</table>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.head-actions {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+
+	/* Segmented time-range control. */
+	.range-switch {
+		display: inline-flex;
+		padding: 0.1875rem;
+		gap: 0.125rem;
+		border-radius: 0.625rem;
+		background: hsl(var(--hsl-base-200));
+		border: 1px solid hsl(var(--hsl-line) / 0.7);
+	}
+
+	.range-btn {
+		padding: 0.3125rem 0.6875rem;
+		border-radius: 0.4375rem;
+		font-size: 0.75rem;
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+		color: hsl(var(--hsl-content) / 0.6);
+		transition: color var(--timing-fastest) ease, background var(--timing-fastest) ease;
+	}
+
+	.range-btn:hover {
+		color: hsl(var(--hsl-content) / 0.9);
+	}
+
+	.range-btn.is-active {
+		color: hsl(var(--hsl-primary-content));
+		background: hsl(var(--hsl-primary));
+	}
+
+	/* KPI tiles — colored by what the firewall decided. */
+	.stat-grid {
+		display: grid;
+		gap: 1rem;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		margin-bottom: 1rem;
+	}
+
+	@media (min-width: 1024px) {
+		.stat-grid {
+			grid-template-columns: repeat(4, minmax(0, 1fr));
+		}
+	}
+
+	.stat-tile {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		gap: 0.55rem;
+		padding: 1rem 1.125rem;
+		border-radius: 0.75rem;
+		background: hsl(var(--hsl-base-200));
+		border: 1px solid hsl(var(--hsl-line) / 0.7);
+		overflow: hidden;
+	}
+
+	.stat-tile::before {
+		content: '';
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: 0;
+		width: 3px;
+		background: var(--accent, hsl(var(--hsl-content) / 0.2));
+	}
+
+	.stat-tile[data-accent='block'] { --accent: hsl(var(--hsl-negative)); }
+	.stat-tile[data-accent='log'] { --accent: hsl(var(--hsl-warning)); }
+	.stat-tile[data-accent='allow'] { --accent: hsl(var(--hsl-positive)); }
+
+	.stat-tile[data-accent='total'] {
+		background: linear-gradient(135deg, hsl(var(--hsl-primary) / 0.12) 0%, hsl(var(--hsl-accent) / 0.12) 100%);
+		border-color: hsl(var(--hsl-primary) / 0.2);
+	}
+
+	.stat-tile[data-accent='total']::before {
+		background: linear-gradient(hsl(var(--hsl-primary)), hsl(var(--hsl-accent)));
+	}
+
+	.stat-head {
+		display: flex;
+		align-items: center;
+		gap: 0.45rem;
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.6);
+	}
+
+	.stat-head .dot {
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 9999px;
+		background: var(--accent);
+	}
+
+	.stat-value {
+		font-size: 1.9rem;
+		font-weight: 700;
+		line-height: 1;
+		letter-spacing: -0.02em;
+		font-variant-numeric: tabular-nums;
+		color: hsl(var(--hsl-content));
+	}
+
+	.stat-tile[data-accent='total'] .stat-value {
+		color: hsl(var(--hsl-primary));
+	}
+
+	.stat-foot {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-content) / 0.55);
+	}
+
+	/* Shared mini bar — fill color follows the row/tile action accent. */
+	.share-bar {
+		flex: 1;
+		height: 0.3125rem;
+		min-width: 2rem;
+		border-radius: 9999px;
+		background: hsl(var(--hsl-content) / 0.08);
+		overflow: hidden;
+	}
+
+	.share-bar > span {
+		display: block;
+		height: 100%;
+		border-radius: inherit;
+		background: var(--accent, hsl(var(--hsl-primary)));
+		transition: width var(--timing-normal) ease;
+	}
+
+	.stat-tile[data-accent='block'] .share-bar > span { background: hsl(var(--hsl-negative)); }
+	.stat-tile[data-accent='log'] .share-bar > span { background: hsl(var(--hsl-warning)); }
+	.stat-tile[data-accent='allow'] .share-bar > span { background: hsl(var(--hsl-positive)); }
+
+	.share-bar[data-action='block'] > span { background: hsl(var(--hsl-negative)); }
+	.share-bar[data-action='log'] > span { background: hsl(var(--hsl-warning)); }
+	.share-bar[data-action='allow'] > span { background: hsl(var(--hsl-positive)); }
+
+	/* Panels */
+	.panel-head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+		flex-wrap: wrap;
+		margin-bottom: 0.5rem;
+	}
+
+	.chart-panel {
+		margin-bottom: 1rem;
+	}
+
+	.chart-body {
+		min-height: 320px;
+	}
+
+	.chart-state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		min-height: 320px;
+		text-align: center;
+	}
+
+	.chart-state .empty-icon {
+		font-size: 1.75rem;
+		color: hsl(var(--hsl-positive) / 0.6);
+	}
+
+	.chart-state .empty-title {
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.8);
+	}
+
+	.chart-state .empty-sub {
+		font-size: 0.8125rem;
+		color: hsl(var(--hsl-content) / 0.55);
+		max-width: 22rem;
+	}
+
+	/* Chart legend */
+	.legend {
+		display: flex;
+		gap: 1rem;
+		flex-wrap: wrap;
+	}
+
+	.legend-item {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.6);
+	}
+
+	.legend-dot {
+		width: 0.625rem;
+		height: 0.625rem;
+		border-radius: 0.25rem;
+	}
+
+	.legend-item[data-action='block'] .legend-dot { background: hsl(var(--hsl-negative)); }
+	.legend-item[data-action='log'] .legend-dot { background: hsl(var(--hsl-warning)); }
+	.legend-item[data-action='allow'] .legend-dot { background: hsl(var(--hsl-positive)); }
+
+	/* Top-rules table */
+	.rule-cell {
+		display: flex;
+		flex-direction: column;
+		gap: 0.1rem;
+	}
+
+	.rule-desc {
+		font-weight: 500;
+	}
+
+	.share-col {
+		width: 30%;
+		min-width: 9rem;
+	}
+
+	.row-share {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		font-size: 0.75rem;
+	}
+
+	.act-badge {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.125rem 0.625rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		line-height: 1.5;
+		color: hsl(var(--hsl-content) / 0.75);
+		background-color: hsl(var(--hsl-content) / 0.08);
+	}
+
+	.act-badge[data-action='block'] {
+		color: hsl(var(--hsl-negative));
+		background-color: hsl(var(--hsl-negative) / 0.12);
+	}
+
+	.act-badge[data-action='log'] {
+		color: hsl(var(--hsl-warning));
+		background-color: hsl(var(--hsl-warning) / 0.14);
+	}
+
+	.act-badge[data-action='allow'] {
+		color: hsl(var(--hsl-positive));
+		background-color: hsl(var(--hsl-positive) / 0.12);
+	}
+</style>


### PR DESCRIPTION
## Summary

Adds a **WAF metrics page** at `/waf/metrics?project=&location=` — a security-ops view of web-application-firewall match activity for a single location, built on the existing `waf.metrics` API. Until now that data only surfaced as a 24h sparkline on the firewall list; this gives it a full home.

The aesthetic is intentionally **action-coded**: every number, bar, badge, and chart stack is colored by what the firewall *decided* — block = red, log = amber, allow = green — so the page reads as a threat dashboard at a glance, while staying entirely within the console's existing token/component system (no new fonts or libraries).

### What's on the page
- **KPI tiles** — Total matches (primary/accent gradient) + Blocked / Logged / Allowed, each with a share bar and %.
- **Matches over time** — a stacked-column Highcharts chart (block/log/allow), with the sparse per-rule buckets re-bucketed onto a shared time grid so stacks align.
- **Top rules** — rules ranked by match volume, joined to their configured descriptions, with action badge + share bar.
- **Time-range switcher** (1H · 6H · 12H · 24H · 7D · 30D) — URL-synced (`?range=`), refetches on change, and auto-refreshes every 60s for short windows only.
- **Empty state** — a calm shield message when no rule has fired in the window (top-rules panel hidden).

### Entry points
- Firewall list: a new **Metrics** button per row, and the matches total/sparkline cell is now a link into the page.
- Manage page: a **View metrics** button in the head.

### Implementation note
`WafActivityChart.svelte` resolves action colors from the theme's `--hsl-*` tokens via `getComputedStyle` rather than passing `hsl(var(--…))` to Highcharts — `var()` doesn't resolve in the SVG `fill` presentation attributes Highcharts writes, so colors are read as concrete values (re-read on each sync, so a theme toggle recovers on the next refresh).

### Mock
`waf.metrics` now scatters samples across the requested `timeRange` and includes an `allow` series; the seed zone gains a matching `allow-office` rule so the top-rules table shows descriptions in `bun dev:mock`.

## Testing
- `bun lint` — pass
- `bun check` — pass
- Manually verified in `bun dev:mock` (Playwright): light + dark themes, range switch to 7D (axis re-buckets, URL + subtitle update), empty state, and both entry points. No console errors.

| Light | Dark | Empty |
|---|---|---|
| populated dashboard | colors resolve in dark | shield "no matches" state |

🤖 Generated with [Claude Code](https://claude.com/claude-code)