### PR TITLE
Fix off-center delete icon on firewall rule condition row

### DIFF
--- a/src/lib/components/WafConditionRow.svelte
+++ b/src/lib/components/WafConditionRow.svelte
@@ -161,7 +161,7 @@
 	</div>
 
 	{#if removable}
-		<button type="button" class="row-remove button is-variant-tertiary is-icon-left is-size-small"
+		<button type="button" class="row-remove button is-variant-tertiary is-size-small"
 			aria-label="Remove condition" onclick={onremove}>
 			<i class="fa-solid fa-trash-can"></i>
 		</button>


### PR DESCRIPTION
## Summary
- On the firewall rule add/edit page, the remove-condition button (`WafConditionRow.svelte`) is icon-only but carried the `is-icon-left` modifier, which is intended for icon **+ text** buttons.
- `is-icon-left` overrides `padding-left` to `0.75em` (vs the `1rem` right padding from `is-size-small`) and adds a `gap`, leaving the lone trash icon shifted left of center — most noticeable on Safari mobile.
- Dropped the `is-icon-left` modifier so horizontal padding is symmetric and the icon centers.

## Test plan
- [x] `bun lint` passes
- [x] `bun check` passes
- [ ] Open a firewall rule (add a condition) on Safari mobile and confirm the trash icon is centered in its button

https://claude.ai/code/session_01L4zfdN1ycLtVD7Hd5p2LBW

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4zfdN1ycLtVD7Hd5p2LBW)_