### PR TITLE
fix: WAF rule builder — reset value when field changes

### DIFF
--- a/src/lib/components/WafConditionRow.svelte
+++ b/src/lib/components/WafConditionRow.svelte
@@ -61,6 +61,16 @@
 		const valid = operators.some((o) => o.value === condition.operator)
 		if (!valid) condition.operator = operators[0]?.value ?? ''
 	})
+
+	// A value entered for one field rarely makes sense for another (an IP under a
+	// numeric field, a country code under a path), so clear it when the user picks
+	// a different field. Wired to the Select's onchange so it only fires on a real
+	// user selection — programmatic reseeds (raw CEL → Visual) keep their values.
+	function onFieldChange () {
+		condition.value = ''
+		condition.values = ''
+		valuesList = []
+	}
 </script>
 
 <div class="row">
@@ -68,7 +78,7 @@
 		<div class="grid gap-3 sm:grid-cols-2">
 			<div class="field">
 				<label for="waf-field">Field</label>
-				<Select id="waf-field" bind:value={condition.field} options={fieldOptions} />
+				<Select id="waf-field" bind:value={condition.field} options={fieldOptions} onchange={onFieldChange} />
 			</div>
 
 			{#if needsName}

--- a/tests/waf.spec.js
+++ b/tests/waf.spec.js
@@ -1,0 +1,31 @@
+import { test, expect } from './helpers.js'
+
+test.describe('firewall rule builder', () => {
+	// The add-rule page opens the visual condition builder. Changing a condition's
+	// field must clear any value already entered, since a value typed for one field
+	// rarely makes sense for another.
+	test('clears the value when the field changes', async ({ page }) => {
+		await page.goto('/waf/edit?project=acme&location=gke.cluster-rcf2')
+
+		// Visual builder starts with no rows — add a blank condition. Retry the
+		// click until a row appears so the test doesn't race page hydration (the
+		// server-rendered button exists before Svelte attaches its handler).
+		const addCondition = page.getByRole('button', { name: 'Add condition' })
+		const value = page.locator('#waf-value')
+		await expect(async () => {
+			await addCondition.click()
+			await expect(value).toBeVisible({ timeout: 1000 })
+		}).toPass()
+
+		// Enter a value for the default (Path) field.
+		await value.fill('/admin')
+		await expect(value).toHaveValue('/admin')
+
+		// Switch the field via the custom Select.
+		await page.locator('#waf-field').click()
+		await page.getByRole('option', { name: 'Host' }).click()
+
+		// The previously entered value is reset to empty.
+		await expect(page.locator('#waf-value')).toHaveValue('')
+	})
+})


### PR DESCRIPTION
## Summary
- On the firewall **Add rule** / **Edit rule** page, the condition builder now clears the entered value when the user picks a different **Field**.
- Previously the old value lingered after switching fields, even though it rarely makes sense for the new field (e.g. an IP value under a numeric field, a country code under a path).

## Details
- Added an `onFieldChange` handler in `WafConditionRow.svelte` that resets `condition.value`, `condition.values`, and the chip list (`valuesList`).
- Wired it to the Field `Select`'s `onchange` callback so it only fires on a real user selection — programmatic reseeds (e.g. switching from raw CEL back to the Visual builder) keep their parsed values intact.
- The existing operator-validity effect is unchanged, so switching field types continues to keep the operator valid.

## Test plan
- [ ] Open Firewall → a location → Add rule, Visual mode.
- [ ] Enter a value for a condition, then change the Field dropdown → value field is cleared.
- [ ] Verify multi-value (e.g. country/method list) and single-value inputs both reset.
- [ ] Edit raw CEL then switch back to Visual → existing values are preserved (not wiped).
- [ ] `bun lint` and `bun check` pass (verified locally: 0 errors).

https://claude.ai/code/session_01Q37tavKn5haqWMJBSELm5g

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q37tavKn5haqWMJBSELm5g)_