### PR TITLE
fix: WAF list sparkline layout shift + rule form Enter-to-save

### DIFF
--- a/src/routes/(auth)/(project)/waf/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/+page.svelte
@@ -134,20 +134,24 @@
 						</td>
 						<td>{fw.rules?.length ?? 0}</td>
 						<td>
-							{#if metrics[fw.location]?.loading}
-								<span class="text-content/30"><i class="fa-solid fa-spinner-third fa-spin"></i></span>
-							{:else if (metrics[fw.location]?.total ?? 0) > 0}
-								<a class="matches-link flex items-center gap-3"
-									href={`/waf/metrics?project=${project}&location=${encodeURIComponent(fw.location)}`}
-									title={`${metrics[fw.location].total.toLocaleString()} matches in the last 24h — view metrics`}>
-									<span class="font-mono text-sm tabular-nums">
-										{format.count(metrics[fw.location].total)}
-									</span>
-									<Sparkline points={metrics[fw.location].points} {from} {to} />
-								</a>
-							{:else}
-								<span class="text-content/40">—</span>
-							{/if}
+							<!-- Reserve the loaded size in every state so the row/column keeps
+							     its dimensions while the async sparkline fills in (no layout shift). -->
+							<div class="matches-cell">
+								{#if metrics[fw.location]?.loading}
+									<span class="text-content/30"><i class="fa-solid fa-spinner-third fa-spin"></i></span>
+								{:else if (metrics[fw.location]?.total ?? 0) > 0}
+									<a class="matches-link flex items-center gap-3"
+										href={`/waf/metrics?project=${project}&location=${encodeURIComponent(fw.location)}`}
+										title={`${metrics[fw.location].total.toLocaleString()} matches in the last 24h — view metrics`}>
+										<span class="font-mono text-sm tabular-nums">
+											{format.count(metrics[fw.location].total)}
+										</span>
+										<Sparkline points={metrics[fw.location].points} {from} {to} />
+									</a>
+								{:else}
+									<span class="text-content/40">—</span>
+								{/if}
+							</div>
 						</td>
 						<td>
 							<div class="flex gap-1 justify-end">
@@ -174,6 +178,16 @@
 </div>
 
 <style>
+	/* Hold a fixed box across the loading / loaded / empty states: min-height
+	   matches the Sparkline's height (28px) and min-width its count + chart, so
+	   the row doesn't grow taller or the column wider when the chart loads. */
+	.matches-cell {
+		display: flex;
+		align-items: center;
+		min-height: 28px;
+		min-width: 10rem;
+	}
+
 	/* The matches total + sparkline doubles as a shortcut into the metrics view. */
 	.matches-link {
 		width: fit-content;

--- a/src/routes/(auth)/(project)/waf/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/edit/+page.svelte
@@ -117,6 +117,21 @@
 	function cancel () {
 		backToManage()
 	}
+
+	// Enter inside a text field (the method value combobox, the plain value input,
+	// description/status/message) must not implicitly submit the rule — in the
+	// value widgets it means "pick/add this value", elsewhere nothing. Saving is
+	// deliberate, via the Save button. Enter still works on the button itself
+	// (a <button>, not an <input>) and in the raw-CEL <textarea>.
+	/** @param {HTMLFormElement} node */
+	function blockEnterSubmit (node) {
+		/** @param {KeyboardEvent} e */
+		function onKeydown (e) {
+			if (e.key === 'Enter' && e.target instanceof HTMLInputElement) e.preventDefault()
+		}
+		node.addEventListener('keydown', onKeydown)
+		return { destroy: () => node.removeEventListener('keydown', onKeydown) }
+	}
 </script>
 
 <div class="breadcrumb">
@@ -142,7 +157,7 @@
 
 	<hr>
 
-	<form class="grid gap-6 w-full" onsubmit={save}>
+	<form class="grid gap-6 w-full" onsubmit={save} use:blockEnterSubmit>
 		<div class="field">
 			<label for="rule-description">Description</label>
 			<div class="input">


### PR DESCRIPTION
Two small, independent WAF fixes.

## 1. Firewall list — no layout shift when the sparkline loads
`waf/+page.svelte`

The "Matches (24h)" cell renders one of three states: a loading spinner, a count + 28px-tall `Sparkline`, or a `—`. The sparkline data is fetched client-side per zone, so when it arrived the cell grew taller (and the column wider), shifting the whole table.

Fix: wrap all three states in a fixed `.matches-cell` box — `min-height: 28px` (the sparkline's height) and `min-width: 10rem` (count + chart) — so the row and column keep their size while the chart fills in.

**Verified:** row height (48px) and cell width (160px) are identical between the loading and loaded states (zero shift), via an intercepted/delayed `waf.metrics` response.

## 2. Rule add/edit — Enter no longer saves the form
`waf/edit/+page.svelte`

The Save button is an implicit `type="submit"`, and pressing Enter in the method value field (the editable `Select` combobox, whose close path doesn't `preventDefault`) or the plain value `<input>` bubbled up and submitted the form — saving the rule prematurely.

Fix: a `blockEnterSubmit` form action prevents Enter-driven implicit submission from `<input>` elements. The Enter-driven value widgets (`TagInput`, `OptionSelect`, the combobox) still add/pick values, the raw-CEL `<textarea>` is unaffected, and the Save button still submits.

**Verified:** typing "GET" + Enter in the method value → no `waf.set` call, stays on the page; clicking Save → `waf.set` called, navigates to manage.

`bun lint` and `bun check` pass clean (0 errors / 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)