### PR TITLE
feat: standardize page headers across detail and create pages

### DIFF
--- a/src/lib/components/DeploymentStatusIcon.svelte
+++ b/src/lib/components/DeploymentStatusIcon.svelte
@@ -144,4 +144,4 @@
 	})
 </script>
 
-<i bind:this={el} class={`${iconClass} fa-fw mx-3`}></i>
+<i bind:this={el} class={`${iconClass} fa-fw mr-3`}></i>

--- a/src/lib/components/Select.svelte
+++ b/src/lib/components/Select.svelte
@@ -199,10 +199,11 @@
 			open ? moveActive(-1) : openMenu()
 			break
 		case 'Enter':
-			// Commit the active option if one is highlighted; otherwise keep the
-			// typed text as-is and just close the menu.
+			// Enter inside the combobox must never submit the surrounding form:
+			// commit the highlighted option if any, otherwise just close the menu
+			// and keep the typed text.
+			e.preventDefault()
 			if (open && activeIndex >= 0) {
-				e.preventDefault()
 				commit(visibleOptions[activeIndex])
 			} else if (open) {
 				close()

--- a/src/lib/components/Select.svelte
+++ b/src/lib/components/Select.svelte
@@ -44,6 +44,12 @@
 	let open = $state(false)
 	let activeIndex = $state(-1)
 
+	// Safari/iOS ignore autocomplete="off" and contact-autofill an editable text
+	// field. Keeping it readonly until focus means the field isn't an autofill
+	// target when the browser evaluates it; we drop readonly on focus so typing
+	// works, and re-arm on blur for the next focus.
+	let autofillGuard = $state(true)
+
 	/** @type {HTMLButtonElement | undefined} */
 	let triggerEl = $state()
 	/** @type {HTMLInputElement | undefined} */
@@ -245,7 +251,8 @@
 		<div class="select-trigger select-trigger-editable" class:is-open={open}>
 			<!-- A combobox, not a real text field — suppress browser and
 			     password-manager autofill (1Password / LastPass / Bitwarden /
-			     Dashlane), which ignore autocomplete="off". -->
+			     Dashlane). Safari/iOS ignore autocomplete="off", so the input is
+			     also kept readonly until focus (see autofillGuard). -->
 			<input
 				bind:this={inputEl}
 				bind:value
@@ -258,6 +265,7 @@
 				data-lpignore="true"
 				data-bwignore
 				data-form-type="other"
+				readonly={autofillGuard}
 				aria-autocomplete="list"
 				aria-haspopup="listbox"
 				aria-expanded={open}
@@ -265,6 +273,8 @@
 				aria-activedescendant={open && activeIndex >= 0 ? optionId(activeIndex) : undefined}
 				{placeholder}
 				{disabled}
+				onfocus={() => { autofillGuard = false }}
+				onblur={() => { autofillGuard = true }}
 				oninput={onInput}
 				onkeydown={onInputKeydown}
 				onclick={openMenu}>

--- a/src/lib/components/Select.svelte
+++ b/src/lib/components/Select.svelte
@@ -243,6 +243,9 @@
 <div class="select-box {className}" class:is-disabled={disabled} use:clickOutside={close}>
 	{#if editable}
 		<div class="select-trigger select-trigger-editable" class:is-open={open}>
+			<!-- A combobox, not a real text field — suppress browser and
+			     password-manager autofill (1Password / LastPass / Bitwarden /
+			     Dashlane), which ignore autocomplete="off". -->
 			<input
 				bind:this={inputEl}
 				bind:value
@@ -251,6 +254,10 @@
 				class="select-input"
 				role="combobox"
 				autocomplete="off"
+				data-1p-ignore
+				data-lpignore="true"
+				data-bwignore
+				data-form-type="other"
 				aria-autocomplete="list"
 				aria-haspopup="listbox"
 				aria-expanded={open}

--- a/src/lib/components/StatusIcon.svelte
+++ b/src/lib/components/StatusIcon.svelte
@@ -19,4 +19,4 @@
 	const iconClass = $derived(iconClassByStatus[status] || 'fa-solid fa-minus text-content/40')
 </script>
 
-<i class={`${iconClass} mx-3`}></i>
+<i class={`${iconClass} mr-3`}></i>

--- a/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
@@ -1,5 +1,6 @@
 <script>
 	import Header from '../_components/Header.svelte'
+	import { page } from '$app/stores'
 	import { onMount } from 'svelte'
 	import api from '$lib/api'
 
@@ -7,6 +8,19 @@
 
 	const project = $derived(data.project)
 	const deployment = $derived(data.deployment)
+
+	const tabs = [
+		{ label: 'Metric', path: '/deployment/metrics' },
+		{ label: 'Details', path: '/deployment/detail' },
+		{ label: 'Revision', path: '/deployment/revision' },
+		{ label: 'Logs', path: '/deployment/logs' },
+		{ label: 'Events', path: '/deployment/events' }
+	]
+
+	/** @param {string} path */
+	function tabHref (path) {
+		return `${path}?project=${project}&location=${deployment.location}&name=${deployment.name}`
+	}
 
 	let lastReload = Date.now()
 
@@ -30,8 +44,16 @@
 
 <br>
 
+<Header {deployment} invalidate={() => api.invalidate('deployment.get')} />
+
 <div class="panel is-level-300 grid gap-6">
-	<Header {deployment} invalidate={() => api.invalidate('deployment.get')} />
+	<div class="tabs is-variant-underline w-full flex-col lg:flex-row">
+		{#each tabs as t (t.path)}
+			<a class="tab-button" class:is-active={$page.url.pathname === t.path} href={tabHref(t.path)}>
+				{t.label}
+			</a>
+		{/each}
+	</div>
 
 	{@render children?.()}
 </div>

--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -262,10 +262,6 @@
 	</table>
 </div>
 
-<DangerZone description="Permanently delete this deployment. All running instances will be stopped and removed.">
-	<button class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</button>
-</DangerZone>
-
 <h6><strong>Env Groups</strong></h6>
 <div class="table-container">
 	<table class="table is-variant-compact" style="--table-data-border-color: none">
@@ -344,5 +340,9 @@
 		</tbody>
 	</table>
 </div>
+
+<DangerZone description="Permanently delete this deployment. All running instances will be stopped and removed.">
+	<button class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</button>
+</DangerZone>
 
 <EnvGroupModal bind:this={envGroupModal} />

--- a/src/routes/(auth)/(project)/deployment/_components/Header.svelte
+++ b/src/routes/(auth)/(project)/deployment/_components/Header.svelte
@@ -57,72 +57,30 @@
 	}
 </script>
 
-<div class="grid grid-cols-1 gap-3">
-	<div class="grid gap-3 grid-flow-row xl:grid-flow-col">
-		<h3 class="flex flex-wrap items-start mr-6 mb-4 xl:mb-0">
-			<div>
-				<DeploymentStatusIcon action={deployment.action} status={deployment.status} url={deployment.statusUrl} type={deployment.type} />
-			</div>
-			<div>
-				{deployment.name}
-				<div class="image text-base mt-1 break-all">{deployment.image}</div>
-			</div>
-		</h3>
-		<div class="flex items-center flex-wrap">
-			<a class="button xl:ml-auto mr-6 mb-4 xl:mb-0"
-				href={`/deployment/deploy?project=${project}&location=${deployment.location}&name=${deployment.name}`}>
-				Deploy New Revision
-			</a>
-			{#if canPause}
-				<div>
-					<button class="button is-variant-secondary xl:ml-auto mr-6 mb-4 xl:mb-0" type="button" onclick={pause}>
-						<i class="fa-solid fa-pause"></i>&nbsp;&nbsp;Pause
-					</button>
-				</div>
-			{/if}
-			{#if canResume}
-				<div>
-					<button class="button is-variant-secondary xl:ml-auto mr-6 mb-4 xl:mb-0" type="button" onclick={resume}>
-						<i class="fa-solid fa-play"></i>&nbsp;&nbsp;Resume
-					</button>
-				</div>
-			{/if}
-		</div>
+<div class="page-head">
+	<div class="min-w-0">
+		<h4 class="flex flex-wrap items-center gap-y-2 min-w-0">
+			<DeploymentStatusIcon action={deployment.action} status={deployment.status} url={deployment.statusUrl} type={deployment.type} />
+			<strong class="min-w-0 wrap-anywhere">{deployment.name}</strong>
+		</h4>
+		<p class="page-sub font-mono min-w-0 wrap-anywhere">{deployment.image}</p>
+	</div>
+	<div class="flex items-center gap-3 flex-wrap">
+		<a class="button"
+			href={`/deployment/deploy?project=${project}&location=${deployment.location}&name=${deployment.name}`}>
+			Deploy New Revision
+		</a>
+		{#if canPause}
+			<button class="button is-variant-secondary is-icon-left" type="button" onclick={pause}>
+				<i class="fa-solid fa-pause"></i>
+				Pause
+			</button>
+		{/if}
+		{#if canResume}
+			<button class="button is-variant-secondary is-icon-left" type="button" onclick={resume}>
+				<i class="fa-solid fa-play"></i>
+				Resume
+			</button>
+		{/if}
 	</div>
 </div>
-
-<hr>
-
-<div class="tabs is-variant-underline xl:mb-0 w-full flex-col lg:flex-row">
-	<a class="tab-button"
-		class:is-active={$page.url.pathname === '/deployment/metrics'}
-		href={`/deployment/metrics?project=${project}&location=${deployment.location}&name=${deployment.name}`}>
-		Metric
-	</a>
-	<a class="tab-button"
-		class:is-active={$page.url.pathname === '/deployment/detail'}
-		href={`/deployment/detail?project=${project}&location=${deployment.location}&name=${deployment.name}`}>
-		Details
-	</a>
-	<a class="tab-button"
-		class:is-active={$page.url.pathname === '/deployment/revision'}
-		href={`/deployment/revision?project=${project}&location=${deployment.location}&name=${deployment.name}`}>
-		Revision
-	</a>
-	<a class="tab-button"
-		class:is-active={$page.url.pathname === '/deployment/logs'}
-		href={`/deployment/logs?project=${project}&location=${deployment.location}&name=${deployment.name}`}>
-		Logs
-	</a>
-	<a class="tab-button"
-		class:is-active={$page.url.pathname === '/deployment/events'}
-		href={`/deployment/events?project=${project}&location=${deployment.location}&name=${deployment.name}`}>
-		Events
-	</a>
-</div>
-
-<style>
-	.image {
-		color: hsla(220, 10%, 47%, 0.95);
-	}
-</style>

--- a/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
@@ -364,16 +364,14 @@
 
 <br>
 
-<div class="panel is-level-300 grid gap-6">
-	<div class="grid grid-cols-1 justify-items-start gap-3">
-		{#if deployment}
-			<h5><strong>Deploy New Revision</strong></h5>
-		{:else}
-			<h5><strong>Deploy New Deployment</strong></h5>
-		{/if}
+<div class="page-head">
+	<div>
+		<h4><strong>{#if deployment}Deploy new revision{:else}Create deployment{/if}</strong></h4>
+		<p class="page-sub">Configure and roll out a container workload.</p>
 	</div>
-	<hr>
+</div>
 
+<div class="panel is-level-300 grid gap-6">
 	<form class="grid gap-4 w-full" onsubmit={save}>
 		<div class="form-section is-first">
 			<h6 class="form-section-title">General</h6>

--- a/src/routes/(auth)/(project)/disk/(detail)/+layout.svelte
+++ b/src/routes/(auth)/(project)/disk/(detail)/+layout.svelte
@@ -28,17 +28,18 @@
 
 <br>
 
-<div class="panel is-level-300 grid gap-6">
-	<div class="grid grid-cols-1 gap-3">
-		<h3>
+<div class="page-head">
+	<div class="min-w-0">
+		<h4 class="flex flex-wrap items-center gap-y-2 min-w-0">
 			<StatusIcon status={disk.status} />
-			<strong>Disk: {disk.name}</strong>
-		</h3>
+			<strong class="min-w-0 wrap-anywhere">{disk.name}</strong>
+		</h4>
+		<p class="page-sub">Persistent disk in <span class="font-mono">{disk.location}</span></p>
 	</div>
+</div>
 
-	<hr>
-
-	<div class="tabs is-variant-underline xl:mb-0 w-full flex-col lg:flex-row">
+<div class="panel is-level-300 grid gap-6">
+	<div class="tabs is-variant-underline w-full flex-col lg:flex-row">
 		<a class="tab-button"
 			class:is-active={$page.url.pathname === '/disk/metrics'}
 			href={`/disk/metrics?project=${project}&location=${disk.location}&name=${disk.name}`}>

--- a/src/routes/(auth)/(project)/disk/create/+page.svelte
+++ b/src/routes/(auth)/(project)/disk/create/+page.svelte
@@ -69,21 +69,14 @@
 
 <br>
 
-<div class="panel is-level-300 grid gap-6">
-	<div class="grid grid-cols-1 gap-3">
-		<div class="flex items-center">
-			<h3 class="mr-6 mb-4 xl:mb-0"><strong>
-				{#if disk}
-					Update Disk {disk.name}
-				{:else}
-					Create Disk
-				{/if}
-			</strong></h3>
-		</div>
+<div class="page-head">
+	<div>
+		<h4><strong>{#if disk}Edit disk{:else}Create disk{/if}</strong></h4>
+		<p class="page-sub">Persistent storage you can attach to deployments.</p>
 	</div>
+</div>
 
-	<hr>
-
+<div class="panel is-level-300 grid gap-6">
 	<form class="grid gap-4 w-full max-w-[512px]" onsubmit={save}>
 		<div class="field">
 			<label for="input-name">Disk name</label>

--- a/src/routes/(auth)/(project)/domain/create/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/create/+page.svelte
@@ -58,13 +58,14 @@
 
 <br>
 
-<div class="panel is-level-300 grid gap-6">
-	<div class="grid grid-cols-1 gap-3">
-		<div class="flex items-center">
-			<h3 class="mr-6 mb-4 xl:mb-0"><strong>Create domain</strong></h3>
-		</div>
+<div class="page-head">
+	<div>
+		<h4><strong>Create domain</strong></h4>
+		<p class="page-sub">Map a custom domain to your deployments, with optional CDN.</p>
 	</div>
-	<hr>
+</div>
+
+<div class="panel is-level-300 grid gap-6">
 	<form class="grid gap-4 w-full" onsubmit={save}>
 		<div class="field">
 			<label for="input-domain">Domain</label>

--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -215,21 +215,23 @@
 </div>
 
 <br>
-<div class="panel is-level-300 grid gap-6">
-	<div class="grid grid-cols-1 gap-3">
-		<h3 class="flex flex-wrap items-center gap-y-2 min-w-0">
+
+<div class="page-head">
+	<div class="min-w-0">
+		<h4 class="flex flex-wrap items-center gap-y-2 min-w-0">
 			<StatusIcon status={headerStatus} />
-			<strong class="min-w-0 wrap-anywhere">Domain: {domain.domain}</strong>
+			<strong>Domain</strong>
 			{#if hasDnsErrors}
 				<i class="fa-solid fa-triangle-exclamation text-warning ml-3"
 					title="DNS verification is failing. See details below."></i>
 			{/if}
-		</h3>
+		</h4>
+		<p class="page-sub font-mono min-w-0 wrap-anywhere">{domain.domain}</p>
 	</div>
+</div>
 
-	<hr>
-
-	<div class="content grid gap-4 w-full">
+<div class="panel is-level-300 grid gap-6">
+	<div class="grid gap-4 w-full">
 		<div class="field">
 			<label for="input-gsa">Domain</label>
 			<div class="input">

--- a/src/routes/(auth)/(project)/env-group/+page.svelte
+++ b/src/routes/(auth)/(project)/env-group/+page.svelte
@@ -36,7 +36,7 @@
 				{#each envGroups as it (it.name)}
 					<tr>
 						<td>
-							<a class="link" href="/env-group/create?project={project}&name={it.name}">
+							<a class="link" href="/env-group/detail?project={project}&name={it.name}">
 								<strong>{it.name}</strong>
 							</a>
 						</td>

--- a/src/routes/(auth)/(project)/env-group/create/+page.svelte
+++ b/src/routes/(auth)/(project)/env-group/create/+page.svelte
@@ -3,7 +3,6 @@
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
-	import DangerZone from '$lib/components/DangerZone.svelte'
 
 	const { data } = $props()
 
@@ -30,26 +29,6 @@
 		envText = form.env
 			.map(({ k, v }) => `${k}=${v}`)
 			.join('\n')
-	}
-
-	function deleteItem () {
-		if (!envGroup) return
-
-		modal.confirm({
-			title: `Delete "${envGroup.name}"?`,
-			yes: 'Delete',
-			callback: async () => {
-				const resp = await api.invoke('envGroup.delete', {
-					project,
-					name: envGroup.name
-				}, fetch)
-				if (!resp.ok) {
-					modal.error({ error: resp.error })
-					return
-				}
-				await goto(`/env-group?project=${project}`)
-			}
-		})
 	}
 
 	let saving = $state(false)
@@ -98,7 +77,7 @@
 	</div>
 	{#if envGroup}
 		<div class="breadcrumb-item">
-			<h6>{envGroup.name}</h6>
+			<a href={`/env-group/detail?project=${project}&name=${encodeURIComponent(envGroup.name)}`} class="link"><h6>{envGroup.name}</h6></a>
 		</div>
 		<div class="breadcrumb-item">
 			<h6>Update</h6>
@@ -112,19 +91,14 @@
 
 <br>
 
-<div class="panel is-level-300 grid gap-4">
-	<div class="grid grid-cols-1 gap-3">
-		<h3><strong>
-			{#if envGroup}
-				Update env group "{envGroup.name}"
-			{:else}
-				Create new env group
-			{/if}
-		</strong></h3>
+<div class="page-head">
+	<div>
+		<h4><strong>{#if envGroup}Edit env group{:else}Create env group{/if}</strong></h4>
+		<p class="page-sub">A reusable set of environment variables for deployments.</p>
 	</div>
+</div>
 
-	<hr>
-
+<div class="panel is-level-300 grid gap-4">
 	<form class="grid gap-4 w-full" onsubmit={save}>
 		<div class="field">
 			<label for="input-name">Name</label>
@@ -203,10 +177,5 @@
 				{#if envGroup}Update{:else}Create{/if}
 			</button>
 		</div>
-		{#if envGroup}
-			<DangerZone description="Permanently delete this env group. Deployments referencing it may fail to start.">
-				<button class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</button>
-			</DangerZone>
-		{/if}
 	</form>
 </div>

--- a/src/routes/(auth)/(project)/env-group/detail/+page.js
+++ b/src/routes/(auth)/(project)/env-group/detail/+page.js
@@ -1,0 +1,21 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+
+export async function load ({ url, parent, fetch }) {
+	const { project } = await parent()
+	const name = url.searchParams.get('name')
+	if (!name) redirect(302, `/env-group?project=${project}`)
+
+	/** @type {Api.Response<Api.EnvGroup>} */
+	const res = await api.invoke('envGroup.get', { project, name }, fetch)
+	if (!res.ok) {
+		if (res.error?.notFound) redirect(302, `/env-group?project=${project}`)
+		error(500, res.error?.message)
+	}
+	if (!res.result) redirect(302, `/env-group?project=${project}`)
+
+	return {
+		menu: 'env-group',
+		envGroup: res.result
+	}
+}

--- a/src/routes/(auth)/(project)/env-group/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/env-group/detail/+page.svelte
@@ -1,0 +1,122 @@
+<script>
+	import { goto } from '$app/navigation'
+	import * as format from '$lib/format'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import DangerZone from '$lib/components/DangerZone.svelte'
+	import Secret from '$lib/components/Secret.svelte'
+
+	const { data } = $props()
+
+	const project = $derived(data.project)
+	const envGroup = $derived(data.envGroup)
+	const entries = $derived(Object.entries(envGroup.env ?? {}))
+
+	let showAllEnv = $state(false)
+
+	function deleteItem () {
+		modal.confirm({
+			title: `Delete "${envGroup.name}"?`,
+			yes: 'Delete',
+			callback: async () => {
+				const resp = await api.invoke('envGroup.delete', { project, name: envGroup.name }, fetch)
+				if (!resp.ok) {
+					modal.error({ error: resp.error })
+					return
+				}
+				await goto(`/env-group?project=${project}`)
+			}
+		})
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/env-group?project=${project}`} class="link"><h6>Env Groups</h6></a>
+	</div>
+	<div class="breadcrumb-item min-w-0">
+		<h6 class="min-w-0 wrap-anywhere">{envGroup.name}</h6>
+	</div>
+</div>
+
+<br>
+
+<div class="page-head">
+	<div class="min-w-0">
+		<h4 class="min-w-0 wrap-anywhere"><strong>{envGroup.name}</strong></h4>
+		<p class="page-sub">{entries.length} {entries.length === 1 ? 'variable' : 'variables'}</p>
+	</div>
+	<a class="button is-variant-secondary is-icon-left"
+		href={`/env-group/create?project=${project}&name=${encodeURIComponent(envGroup.name)}`}>
+		<i class="fa-solid fa-pen"></i>
+		Edit
+	</a>
+</div>
+
+<div class="panel is-level-300 grid gap-6">
+	<div class="grid gap-4 w-full">
+		<div class="field">
+			<label for="input-name">Name</label>
+			<div class="input">
+				<input id="input-name" value={envGroup.name} readonly disabled>
+			</div>
+		</div>
+		<div class="field">
+			<label for="input-created_at">Created at</label>
+			<div class="input">
+				<input id="input-created_at" value={format.datetime(envGroup.createdAt)} readonly disabled>
+			</div>
+		</div>
+		<div class="field">
+			<label for="input-created_by">Created by</label>
+			<div class="input">
+				<input id="input-created_by" value={envGroup.createdBy} readonly disabled>
+			</div>
+		</div>
+
+		<hr>
+
+		<div class="flex items-center justify-between gap-3 flex-wrap">
+			<div>
+				<h6><strong>Environment Variables</strong></h6>
+				<p class="text-content/50 text-sm mt-1">
+					Variables injected into deployments that reference this group.
+				</p>
+			</div>
+			{#if entries.length}
+				<button type="button" class="button is-variant-secondary is-size-small is-icon-left"
+					onclick={() => showAllEnv = !showAllEnv}>
+					<i class="fa-solid {showAllEnv ? 'fa-eye-slash' : 'fa-eye'}"></i>
+					{showAllEnv ? 'Hide all' : 'Show all'}
+				</button>
+			{/if}
+		</div>
+
+		<div class="table-container">
+			<table class="table is-variant-compact">
+				<thead>
+					<tr>
+						<th class="is-collapse" style="min-width: 256px">Key</th>
+						<th>Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each entries as [k, v] (k)}
+						<tr>
+							<td>{k}</td>
+							<td><Secret value={v} show={showAllEnv} /></td>
+						</tr>
+					{:else}
+						<tr>
+							<td colspan="2" class="text-center text-content/50">This env group has no variables.</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+
+		<DangerZone description="Permanently delete this env group. Deployments referencing it may fail to start.">
+			<button class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</button>
+		</DangerZone>
+	</div>
+</div>

--- a/src/routes/(auth)/(project)/pull-secret/create/+page.svelte
+++ b/src/routes/(auth)/(project)/pull-secret/create/+page.svelte
@@ -69,15 +69,14 @@
 </div>
 
 <br>
-<div class="panel is-level-300 grid gap-6">
-	<div class="grid grid-cols-1 gap-3">
-		<div class="flex items-center">
-			<h3 class="mr-6 mb-4 xl:mb-0"><strong>Create pull secret</strong></h3>
-		</div>
+<div class="page-head">
+	<div>
+		<h4><strong>Create pull secret</strong></h4>
+		<p class="page-sub">Registry credentials used to pull private images.</p>
 	</div>
+</div>
 
-	<hr>
-
+<div class="panel is-level-300 grid gap-6">
 	<form class="grid gap-4 w-full" onsubmit={save}>
 		<div class="field">
 			<label for="input-name">Name</label>

--- a/src/routes/(auth)/(project)/pull-secret/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/pull-secret/detail/+page.svelte
@@ -43,14 +43,16 @@
 </div>
 
 <br>
-<div class="panel is-level-300 grid gap-6">
-	<div class="grid grid-cols-1 gap-3">
-		<h3><strong>Pull secret "{pullSecret.name}"</strong></h3>
+
+<div class="page-head">
+	<div>
+		<h4><strong>Pull secret</strong></h4>
+		<p class="page-sub">Registry credentials used to pull private images.</p>
 	</div>
+</div>
 
-	<hr>
-
-	<div class="content grid gap-4 w-full">
+<div class="panel is-level-300 grid gap-6">
+	<div class="grid gap-4 w-full">
 		<div class="field">
 			<label for="input-name">Name</label>
 			<div class="input">

--- a/src/routes/(auth)/(project)/role/+page.svelte
+++ b/src/routes/(auth)/(project)/role/+page.svelte
@@ -57,6 +57,10 @@
 										<i class="fa-solid fa-pen"></i>
 									</div>
 								</a>
+							{:else}
+								<!-- Reserve the icon-button's footprint so rows without an
+								     edit action keep the same height as the others. -->
+								<div class="w-8 h-8" aria-hidden="true"></div>
 							{/if}
 						</td>
 					</tr>

--- a/src/routes/(auth)/(project)/role/+page.svelte
+++ b/src/routes/(auth)/(project)/role/+page.svelte
@@ -43,13 +43,9 @@
 				{#each roles as it (it.role)}
 					<tr>
 						<td>
-							{#if roleCanUpdate(it.role)}
-								<a href="/role/create?project={project}&role={it.role}" class="link">
-									<strong>{it.role}</strong>
-								</a>
-							{:else}
+							<a href="/role/detail?project={project}&role={it.role}" class="link">
 								<strong>{it.role}</strong>
-							{/if}
+							</a>
 						</td>
 						<td>{it.name}</td>
 						<td>{format.datetime(it.createdAt)}</td>

--- a/src/routes/(auth)/(project)/role/bind/+page.svelte
+++ b/src/routes/(auth)/(project)/role/bind/+page.svelte
@@ -13,8 +13,12 @@
 
 	const project = $derived(data.project)
 
+	// allUsers / allAuthenticatedUsers are valid principals alongside a normal
+	// email. The editable Select has no native pattern, so validate on submit.
+	const EMAIL_RE = /^(allUsers|allAuthenticatedUsers|[^@\s]+@[^@\s]+\.[^@\s]+)$/
+
 	const form = $state(untrack(() => ({
-		email,
+		email: email ?? '',
 		roles: selected
 	})))
 
@@ -39,6 +43,12 @@
 		e.preventDefault()
 
 		if (saving) {
+			return
+		}
+
+		form.email = (form.email ?? '').trim()
+		if (!EMAIL_RE.test(form.email)) {
+			modal.error({ error: 'Enter a valid email address, or use allUsers / allAuthenticatedUsers.' })
 			return
 		}
 
@@ -96,16 +106,21 @@
 	<form class="grid gap-4 w-full" onsubmit={save}>
 		<div class="field">
 			<label for="input-email">Email</label>
-			<div class="input">
-				<input id="input-email" type="text" placeholder="Email / allUsers / allAuthenticatedUsers"
-					bind:value={form.email} readonly={!!email} required
-					list="email-suggestions"
-					pattern="^(allUsers|allAuthenticatedUsers|[^@\s]+@[^@\s]+\.[^@\s]+)$">
-			</div>
-			<datalist id="email-suggestions">
-				<option value="allUsers"></option>
-				<option value="allAuthenticatedUsers"></option>
-			</datalist>
+			{#if email}
+				<div class="input">
+					<input id="input-email" value={form.email} readonly>
+				</div>
+			{:else}
+				<Select
+					id="input-email"
+					editable
+					bind:value={form.email}
+					placeholder="Email / allUsers / allAuthenticatedUsers"
+					options={[
+						{ value: 'allUsers', label: 'allUsers' },
+						{ value: 'allAuthenticatedUsers', label: 'allAuthenticatedUsers' }
+					]} />
+			{/if}
 		</div>
 		<div class="field">
 			<label for="input-role">Role</label>

--- a/src/routes/(auth)/(project)/role/bind/+page.svelte
+++ b/src/routes/(auth)/(project)/role/bind/+page.svelte
@@ -64,25 +64,40 @@
 	<div class="breadcrumb-item">
 		<a href={`/role/users?project=${project}`} class="link"><h6>Users</h6></a>
 	</div>
-	<div class="breadcrumb-item">
-		<h6>Add</h6>
-	</div>
+	{#if email}
+		<div class="breadcrumb-item min-w-0">
+			<h6 class="min-w-0 wrap-anywhere">{email}</h6>
+		</div>
+		<div class="breadcrumb-item">
+			<h6>Update</h6>
+		</div>
+	{:else}
+		<div class="breadcrumb-item">
+			<h6>Add</h6>
+		</div>
+	{/if}
 </div>
 
 <br>
-<div class="panel is-level-300 grid gap-6">
-	<div class="grid grid-cols-1 gap-3">
-		<div class="flex items-center">
-			<h3 class="mr-6 mb-4 xl:mb-0"><strong>Add member to "{project}" project</strong></h3>
-		</div>
+<div class="page-head">
+	<div>
+		<h4><strong>{#if email}Edit member{:else}Add member{/if}</strong></h4>
+		<p class="page-sub">
+			{#if email}
+				Change the roles assigned to this member.
+			{:else}
+				Grant a user or group roles in <span class="font-mono">{project}</span>.
+			{/if}
+		</p>
 	</div>
+</div>
 
-	<hr>
-
+<div class="panel is-level-300 grid gap-6">
 	<form class="grid gap-4 w-full" onsubmit={save}>
 		<div class="field">
+			<label for="input-email">Email</label>
 			<div class="input">
-				<input type="text" placeholder="Email / allUsers / allAuthenticatedUsers"
+				<input id="input-email" type="text" placeholder="Email / allUsers / allAuthenticatedUsers"
 					bind:value={form.email} readonly={!!email} required
 					list="email-suggestions"
 					pattern="^(allUsers|allAuthenticatedUsers|[^@\s]+@[^@\s]+\.[^@\s]+)$">
@@ -93,7 +108,9 @@
 			</datalist>
 		</div>
 		<div class="field">
+			<label for="input-role">Role</label>
 			<Select
+				id="input-role"
 				placeholder="Select Role"
 				resetOnSelect
 				onchange={(v) => addRole(String(v))}

--- a/src/routes/(auth)/(project)/role/create/+page.svelte
+++ b/src/routes/(auth)/(project)/role/create/+page.svelte
@@ -4,7 +4,6 @@
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
-	import DangerZone from '$lib/components/DangerZone.svelte'
 	import Select from '$lib/components/Select.svelte'
 
 	const { data } = $props()
@@ -18,23 +17,6 @@
 		name: role?.name ?? '',
 		permissions: role?.permissions ?? []
 	})))
-
-	function deleteItem () {
-		if (!role) return
-
-		modal.confirm({
-			title: `Delete ${role.role} and its users?`,
-			yes: 'Delete',
-			callback: async () => {
-				const resp = await api.invoke('role.delete', { project, role: role.role }, fetch)
-				if (!resp.ok) {
-					modal.error({ error: resp.error })
-					return
-				}
-				goto(`/role?project=${project}`)
-			}
-		})
-	}
 
 	/**
 	 * @param {string} permission
@@ -88,7 +70,7 @@
 	</div>
 	{#if role}
 		<div class="breadcrumb-item">
-			<h6>{role.role}</h6>
+			<a href={`/role/detail?project=${project}&role=${encodeURIComponent(role.role)}`} class="link"><h6>{role.role}</h6></a>
 		</div>
 		<div class="breadcrumb-item">
 			<h6>Update</h6>
@@ -102,19 +84,14 @@
 
 <br>
 
-<div class="panel is-level-300 grid gap-4">
-	<div class="grid grid-cols-1 gap-3">
-		<h3><strong>
-			{#if role}
-				Update role "{form.role}"
-			{:else}
-				Create new role
-			{/if}
-		</strong></h3>
+<div class="page-head">
+	<div>
+		<h4><strong>{#if role}Edit role{:else}Create role{/if}</strong></h4>
+		<p class="page-sub">A named set of permissions you can assign to members.</p>
 	</div>
+</div>
 
-	<hr>
-
+<div class="panel is-level-300 grid gap-4">
 	<form class="grid gap-4 w-full" onsubmit={save}>
 		<div class="field">
 			<label for="input-role">Role ID</label>
@@ -179,10 +156,5 @@
 				{#if role}Update{:else}Create{/if}
 			</button>
 		</div>
-		{#if role}
-			<DangerZone description="Permanently delete this role. Members assigned only this role will lose their access.">
-				<button class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</button>
-			</DangerZone>
-		{/if}
 	</form>
 </div>

--- a/src/routes/(auth)/(project)/role/detail/+page.js
+++ b/src/routes/(auth)/(project)/role/detail/+page.js
@@ -1,0 +1,29 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+
+export async function load ({ url, parent, fetch }) {
+	const { project } = await parent()
+	const roleId = url.searchParams.get('role')
+	if (!roleId) redirect(302, `/role?project=${project}`)
+
+	/** @type {Api.Response<Api.Role>} */
+	const roleInfo = await api.invoke('role.get', { project, role: roleId }, fetch)
+	if (!roleInfo.ok) {
+		if (roleInfo.error?.notFound) redirect(302, `/role?project=${project}`)
+		error(500, roleInfo.error?.message)
+	}
+	if (!roleInfo.result) redirect(302, `/role?project=${project}`)
+
+	// Members come from the project-wide user/role map; viewing them is a
+	// separate permission, so a forbidden response here must not break the page.
+	/** @type {Api.Response<Api.List<Api.RoleUser>>} */
+	const users = await api.invoke('role.users', { project }, fetch)
+	const members = (users.result?.items ?? []).filter((u) => u.roles?.includes(roleId))
+
+	return {
+		menu: 'role',
+		role: roleInfo.result,
+		members,
+		membersError: users.error
+	}
+}

--- a/src/routes/(auth)/(project)/role/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/role/detail/+page.svelte
@@ -1,0 +1,163 @@
+<script>
+	import { goto } from '$app/navigation'
+	import * as format from '$lib/format'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import DangerZone from '$lib/components/DangerZone.svelte'
+
+	const { data } = $props()
+
+	const project = $derived(data.project)
+	const role = $derived(data.role)
+	const members = $derived(data.members)
+	const membersError = $derived(data.membersError)
+
+	// The built-in `owner` role is fixed — it can't be edited or deleted.
+	const canUpdate = $derived(role.role !== 'owner')
+
+	function deleteItem () {
+		modal.confirm({
+			title: `Delete ${role.role} and its users?`,
+			yes: 'Delete',
+			callback: async () => {
+				const resp = await api.invoke('role.delete', { project, role: role.role }, fetch)
+				if (!resp.ok) {
+					modal.error({ error: resp.error })
+					return
+				}
+				goto(`/role?project=${project}`)
+			}
+		})
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/role?project=${project}`} class="link"><h6>Roles</h6></a>
+	</div>
+	<div class="breadcrumb-item min-w-0">
+		<h6 class="min-w-0 wrap-anywhere">{role.role}</h6>
+	</div>
+</div>
+
+<br>
+
+<div class="page-head">
+	<div class="min-w-0">
+		<h4 class="min-w-0 wrap-anywhere"><strong>{role.role}</strong></h4>
+		<p class="page-sub">{role.name}</p>
+	</div>
+	{#if canUpdate}
+		<a class="button is-variant-secondary is-icon-left"
+			href={`/role/create?project=${project}&role=${encodeURIComponent(role.role)}`}>
+			<i class="fa-solid fa-pen"></i>
+			Edit
+		</a>
+	{/if}
+</div>
+
+<div class="panel is-level-300 grid gap-6">
+	<div class="grid gap-4 w-full">
+		<div class="field">
+			<label for="input-role">Role ID</label>
+			<div class="input">
+				<input id="input-role" class="font-mono" value={role.role} readonly disabled>
+			</div>
+		</div>
+		<div class="field">
+			<label for="input-name">Name</label>
+			<div class="input">
+				<input id="input-name" value={role.name} readonly disabled>
+			</div>
+		</div>
+		<div class="field">
+			<label for="input-created_at">Created at</label>
+			<div class="input">
+				<input id="input-created_at" value={format.datetime(role.createdAt)} readonly disabled>
+			</div>
+		</div>
+		<div class="field">
+			<label for="input-created_by">Created by</label>
+			<div class="input">
+				<input id="input-created_by" value={role.createdBy} readonly disabled>
+			</div>
+		</div>
+
+		<hr>
+
+		<div>
+			<h6><strong>Permissions</strong></h6>
+			<p class="text-content/50 text-sm mt-1">
+				What this role is allowed to do —
+				{role.permissions.length} {role.permissions.length === 1 ? 'permission' : 'permissions'}.
+			</p>
+		</div>
+
+		<div class="table-container">
+			<table class="table is-variant-compact">
+				<thead>
+					<tr><th>Permission</th></tr>
+				</thead>
+				<tbody>
+					{#each role.permissions as p (p)}
+						<tr><td><span class="font-mono text-sm">{p}</span></td></tr>
+					{:else}
+						<tr>
+							<td class="text-center text-content/50">This role has no permissions.</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+
+		<hr>
+
+		<div>
+			<h6><strong>Members</strong></h6>
+			<p class="text-content/50 text-sm mt-1">Users assigned this role.</p>
+		</div>
+
+		{#if membersError?.forbidden}
+			<p class="text-content/60 text-sm">
+				<i class="fa-solid fa-lock mr-2"></i>
+				You don't have permission to view members.
+			</p>
+		{:else}
+			<div class="table-container">
+				<table class="table is-variant-compact">
+					<thead>
+						<tr>
+							<th>Email</th>
+							<th>Other roles</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each members as m (m.email)}
+							{@const other = m.roles.filter((r) => r !== role.role)}
+							<tr>
+								<td>{m.email}</td>
+								<td>
+									{#if other.length}
+										<span class="font-mono text-sm text-content/70">{other.join(', ')}</span>
+									{:else}
+										<span class="text-content/40">—</span>
+									{/if}
+								</td>
+							</tr>
+						{:else}
+							<tr>
+								<td colspan="2" class="text-center text-content/50">No users have this role.</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+
+		{#if canUpdate}
+			<DangerZone description="Permanently delete this role. Members assigned only this role will lose their access.">
+				<button class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</button>
+			</DangerZone>
+		{/if}
+	</div>
+</div>

--- a/src/routes/(auth)/(project)/route/create/+page.svelte
+++ b/src/routes/(auth)/(project)/route/create/+page.svelte
@@ -131,13 +131,14 @@
 </div>
 
 <br>
-<div class="panel is-level-300 grid gap-6">
-	<div class="grid grid-cols-1 gap-3">
-		<div class="flex items-center">
-			<h3 class="mr-6 mb-4 xl:mb-0"><strong>Create route</strong></h3>
-		</div>
+<div class="page-head">
+	<div>
+		<h4><strong>Create route</strong></h4>
+		<p class="page-sub">Forward traffic on a domain path to a deployment.</p>
 	</div>
-	<hr>
+</div>
+
+<div class="panel is-level-300 grid gap-6">
 	<form class="grid gap-4 w-full" onsubmit={save}>
 		<div class="field">
 			<label for="input-location">Location</label>

--- a/src/routes/(auth)/(project)/service-account/create/+page.svelte
+++ b/src/routes/(auth)/(project)/service-account/create/+page.svelte
@@ -66,21 +66,14 @@
 
 <br>
 
-<div class="panel is-level-300 grid gap-6">
-	<div class="grid grid-cols-1 gap-3">
-		<div class="flex items-center">
-			<h3 class="mr-6 mb-4 xl:mb-0"><strong>
-				{#if id}
-					Update service account "{serviceAccount.sid}"
-				{:else}
-					Create service account
-				{/if}
-			</strong></h3>
-		</div>
+<div class="page-head">
+	<div>
+		<h4><strong>{#if id}Edit service account{:else}Create service account{/if}</strong></h4>
+		<p class="page-sub">Programmatic identity for API and automation access.</p>
 	</div>
+</div>
 
-	<hr>
-
+<div class="panel is-level-300 grid gap-6">
 	<form class="grid gap-4 w-full" onsubmit={save}>
 		{#if id}
 			<div class="field">

--- a/src/routes/(auth)/(project)/service-account/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/service-account/detail/+page.svelte
@@ -79,16 +79,15 @@
 
 <br>
 
-<div class="panel is-level-300 grid gap-6">
-	<div class="grid grid-cols-1 gap-3">
-		<h3 class="mr-6 mb-4 xl:mb-0">
-			<strong>{serviceAccount.name}</strong>
-		</h3>
+<div class="page-head">
+	<div>
+		<h4><strong>Service account</strong></h4>
+		<p class="page-sub">Programmatic identity and its API keys.</p>
 	</div>
+</div>
 
-	<hr>
-
-	<div class="content grid gap-4 w-full">
+<div class="panel is-level-300 grid gap-6">
+	<div class="grid gap-4 w-full">
 		<div class="field">
 			<label for="input-email">Email</label>
 			<div class="input">

--- a/src/routes/(auth)/(project)/waf/create/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/create/+page.svelte
@@ -55,15 +55,14 @@
 
 <br>
 
-<div class="panel is-level-300 grid gap-6">
-	<div class="grid grid-cols-1 gap-3">
-		<div class="flex items-center">
-			<h3 class="mr-6 mb-4 xl:mb-0"><strong>Create firewall</strong></h3>
-		</div>
+<div class="page-head">
+	<div>
+		<h4><strong>Create firewall</strong></h4>
 		<p class="page-sub">Enable the web application firewall in a location.</p>
 	</div>
-	<hr>
+</div>
 
+<div class="panel is-level-300 grid gap-6">
 	{#if locations.length === 0}
 		<p class="text-content/60">
 			Every location already has a firewall configured. Manage an existing one

--- a/src/routes/(auth)/(project)/workload-identity/create/+page.svelte
+++ b/src/routes/(auth)/(project)/workload-identity/create/+page.svelte
@@ -57,13 +57,14 @@
 </div>
 
 <br>
-<div class="panel is-level-300 grid gap-6">
-	<div class="grid grid-cols-1 gap-3">
-		<div class="flex items-center">
-			<h3 class="mr-6 mb-4 xl:mb-0"><strong>Create</strong></h3>
-		</div>
+<div class="page-head">
+	<div>
+		<h4><strong>Create workload identity</strong></h4>
+		<p class="page-sub">Map a workload to a Google service account for GCP access.</p>
 	</div>
-	<hr>
+</div>
+
+<div class="panel is-level-300 grid gap-6">
 	<form class="grid gap-4 w-full" onsubmit={save}>
 		<div class="field">
 			<label for="input-name">Name</label>

--- a/src/routes/(auth)/(project)/workload-identity/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/workload-identity/detail/+page.svelte
@@ -47,12 +47,16 @@
 </div>
 
 <br>
-<div class="panel is-level-300 grid gap-6">
-	<div class="grid grid-cols-1 justify-items-start gap-3">
-		<h3><strong>Workload Identity: {workloadIdentity.name}</strong></h3>
+
+<div class="page-head">
+	<div>
+		<h4><strong>Workload identity</strong></h4>
+		<p class="page-sub">Maps this workload to a Google service account for GCP access.</p>
 	</div>
-	<hr>
-	<div class="content grid gap-4 w-full">
+</div>
+
+<div class="panel is-level-300 grid gap-6">
+	<div class="grid gap-4 w-full">
 		<div class="field">
 			<label for="input-gsa">GSA</label>
 			<div class="input">

--- a/src/routes/(auth)/billing/create/+page.svelte
+++ b/src/routes/(auth)/billing/create/+page.svelte
@@ -68,13 +68,14 @@
 
 <br>
 
-<div class="panel is-level-300 grid gap-6">
-	<div class="grid grid-cols-1 gap-3">
-		<div class="flex items-center">
-			<h3 class="mr-6 mb-4 xl:mb-0"><strong>Account information</strong></h3>
-		</div>
+<div class="page-head">
+	<div>
+		<h4><strong>{#if billingAccount}Edit billing account{:else}Create billing account{/if}</strong></h4>
+		<p class="page-sub">Contact and tax details used on your invoices.</p>
 	</div>
-	<hr>
+</div>
+
+<div class="panel is-level-300 grid gap-6">
 	<form class="grid gap-4 w-full" onsubmit={save}>
 		<div class="field">
 			<label for="input-name">Account name</label>

--- a/src/routes/(auth)/project/create/+page.svelte
+++ b/src/routes/(auth)/project/create/+page.svelte
@@ -68,17 +68,14 @@
 </div>
 
 <br>
-<div class="panel is-level-300 grid gap-6">
-	<div class="grid grid-cols-1 justify-items-start gap-3">
-		{#if project}
-			<h5><strong>Update Project: {project.name}</strong></h5>
-		{:else}
-			<h5><strong>Create Project</strong></h5>
-		{/if}
+<div class="page-head">
+	<div>
+		<h4><strong>{#if project}Edit project{:else}Create project{/if}</strong></h4>
+		<p class="page-sub">Your project's identity and billing account.</p>
 	</div>
+</div>
 
-	<hr>
-
+<div class="panel is-level-300 grid gap-6">
 	<form class="grid gap-4 w-full" onsubmit={save}>
 		<div class="field">
 			<label for="input-project">ID</label>

--- a/tests/env-group.spec.js
+++ b/tests/env-group.spec.js
@@ -35,11 +35,13 @@ test.describe('env groups', () => {
 		await page.goto('/env-group/create?project=test-project&name=shared-config')
 
 		const main = page.locator('.content-wrapper')
-		await expect(main.getByRole('heading', { name: 'Update env group "shared-config"' })).toBeVisible()
+		await expect(main.getByRole('heading', { name: 'Edit env group' })).toBeVisible()
 		await expect(main.getByRole('textbox', { name: 'Name', exact: true })).toHaveValue('shared-config')
 		await expect(main.locator('input[placeholder="Variable name"]').nth(0)).toHaveValue('LOG_LEVEL')
 		await expect(main.locator('input[placeholder="Value"]').nth(0)).toHaveValue('info')
 		await expect(main.getByRole('button', { name: 'Update' })).toBeVisible()
-		await expect(main.getByRole('button', { name: 'Delete' })).toBeVisible()
+		// Deletion now lives on the env-group detail page, not the edit form.
+		await expect(main.getByRole('button', { name: 'Delete' })).toHaveCount(0)
+		await expect(main.getByRole('link', { name: 'shared-config' })).toHaveAttribute('href', /\/env-group\/detail\?/)
 	})
 })


### PR DESCRIPTION
## Summary

Standardizes the page-header treatment across the console so index, detail, and create/edit pages all use the `page-head` pattern (title + one-line description **outside** the panel), using the firewall page as the reference.

## Changes

**Detail pages**
- pull-secret, service-account, workload-identity, domain: in-panel `<h3>` → `page-head`; `DangerZone` always last; full-width content (dropped the `.content` 768px cap).
- Tabbed detail (deployment, disk): `page-head` outside the panel, underline tabs as the panel's first row. Moved deployment's `DangerZone` from mid-page to the end.

**Status icons**
- `StatusIcon` / `DeploymentStatusIcon` use `mr-3` instead of `mx-3`, so detail titles sit flush-left and list-row icons align with the column header.

**New detail pages**
- `role/detail` — read-only view with permissions + members (the built-in `owner` role is viewable but not editable/deletable).
- `env-group/detail` — variables shown via the `Secret` show/hide toggle.
- List pages now link the resource name → detail, and the edit pencil → create/edit form.

**Create/edit forms**
- All forms converted to `page-head` with dynamic Create/Edit titles (disk, domain, env-group, pull-secret, role, role/bind, route, service-account, waf, workload-identity, billing, deployment/deploy, project).
- `role/create` & `env-group/create`: edit breadcrumb links to the detail page; removed the form's delete button (deletion lives on the detail page).
- `role/bind`: fixed edit-mode breadcrumb + header ("Edit member"), and added labels to the email field and role dropdown to match the other forms.

## Test plan
- `bun lint` — clean
- `bun check` — clean (0 errors, 0 warnings)
- Verified the changed pages render in mock mode (`bun dev:mock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)