### PR TITLE
feat: "/" to open project search on the project list

### DIFF
--- a/src/routes/(auth)/ModalSelectProject.svelte
+++ b/src/routes/(auth)/ModalSelectProject.svelte
@@ -61,6 +61,9 @@
 
 	function close () {
 		isActive = false
+		// Release focus so a page-level shortcut (e.g. "/") can reopen the modal,
+		// and the search field isn't left focused while hidden.
+		elSearch?.blur()
 	}
 
 	/**
@@ -78,6 +81,10 @@
 	 * @param {KeyboardEvent} e
 	 */
 	function onSearchKeydown (e) {
+		if (e.key === 'Escape') {
+			close()
+			return
+		}
 		if (!filtered.length) return
 		if (e.key === 'ArrowDown') {
 			e.preventDefault()

--- a/src/routes/(auth)/project/+page.svelte
+++ b/src/routes/(auth)/project/+page.svelte
@@ -1,11 +1,34 @@
 <script>
+	import { onMount } from 'svelte'
 	import api from '$lib/api'
 	import Swal from 'sweetalert2'
 	import * as modal from '$lib/modal'
+	import ModalSelectProject from '../ModalSelectProject.svelte'
 
 	const { data } = $props()
 
 	const projects = $derived(data.projects)
+
+	/** @type {?ModalSelectProject} */
+	let projectModal = $state(null)
+
+	// Press "/" anywhere on the page (unless typing in a field) to open the
+	// project search modal.
+	/** @param {KeyboardEvent} e */
+	function onKeydown (e) {
+		if (e.key !== '/' || e.metaKey || e.ctrlKey || e.altKey) return
+		const el = e.target
+		if (el instanceof HTMLElement && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT' || el.isContentEditable)) {
+			return
+		}
+		e.preventDefault()
+		projectModal?.open()
+	}
+
+	onMount(() => {
+		window.addEventListener('keydown', onKeydown)
+		return () => window.removeEventListener('keydown', onKeydown)
+	})
 
 	/**
 	 * @param {string} project
@@ -47,10 +70,17 @@
 		<h4><strong>Projects</strong></h4>
 		<p class="page-sub">{projects.length} {projects.length === 1 ? 'project' : 'projects'}</p>
 	</div>
-	<a class="button is-icon-left" href="/project/create">
-		<i class="fa-solid fa-plus"></i>
-		New project
-	</a>
+	<div class="flex items-center gap-3 flex-wrap">
+		<button type="button" class="project-search" onclick={() => projectModal?.open()}>
+			<i class="fa-solid fa-magnifying-glass"></i>
+			<span>Search projects</span>
+			<kbd>/</kbd>
+		</button>
+		<a class="button is-icon-left" href="/project/create">
+			<i class="fa-solid fa-plus"></i>
+			New project
+		</a>
+	</div>
 </div>
 
 {#if projects.length}
@@ -97,6 +127,8 @@
 		</div>
 	</div>
 {/if}
+
+<ModalSelectProject bind:this={projectModal} {projects} />
 
 <style>
 	.project-grid {
@@ -211,5 +243,46 @@
 	.project-create:hover {
 		color: hsl(var(--hsl-primary));
 		transform: none;
+	}
+
+	/* Search affordance that also advertises the "/" shortcut. */
+	.project-search {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.5rem 0.75rem;
+		font-size: 0.875rem;
+		color: hsl(var(--hsl-content) / 0.6);
+		background-color: hsl(var(--hsl-base-100));
+		border: 1px solid hsl(var(--hsl-line));
+		border-radius: var(--radius-md);
+		cursor: pointer;
+		transition: border-color var(--timing-faster) ease, color var(--timing-faster) ease;
+	}
+
+	.project-search:hover {
+		border-color: hsl(var(--hsl-primary) / 0.45);
+		color: hsl(var(--hsl-content) / 0.85);
+	}
+
+	.project-search kbd {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 1.25rem;
+		height: 1.25rem;
+		padding: 0 0.35rem;
+		font-family: var(--ffml-mono);
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-content) / 0.7);
+		background-color: hsl(var(--hsl-base-300));
+		border: 1px solid hsl(var(--hsl-line));
+		border-radius: 0.3rem;
+	}
+
+	@media (max-width: 640px) {
+		.project-search span {
+			display: none;
+		}
 	}
 </style>

--- a/tests/project.spec.js
+++ b/tests/project.spec.js
@@ -40,6 +40,48 @@ test.describe('project list', () => {
 		const main = page.locator('.content-wrapper')
 		await expect(main.getByRole('link', { name: 'New project' }).first()).toHaveAttribute('href', '/project/create')
 	})
+
+	test('opens the project search modal with the "/" shortcut', async ({ page }) => {
+		await setMocks({
+			'project.list': {
+				ok: true,
+				result: {
+					items: [
+						defaultProject,
+						{ ...defaultProject, id: '2', project: 'another', name: 'Another' }
+					]
+				}
+			}
+		})
+
+		await page.goto('/project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Projects' })).toBeVisible()
+		await expect(page.locator('.modal.is-active')).toHaveCount(0)
+
+		// Clicking the search button opens the modal (and confirms the page has
+		// hydrated, so the global "/" listener is attached before we press it).
+		await main.getByRole('button', { name: /Search projects/ }).click()
+		await expect(page.locator('.modal.is-active')).toBeVisible()
+		await page.keyboard.press('Escape')
+		await expect(page.locator('.modal.is-active')).toHaveCount(0)
+
+		// The "/" shortcut opens the same search modal.
+		await page.keyboard.press('/')
+		const dialog = page.locator('.modal.is-active')
+		await expect(dialog).toBeVisible()
+		const search = dialog.getByPlaceholder(/Search projects/)
+		await expect(search).toBeFocused()
+
+		// Typing filters the list.
+		await search.fill('another')
+		await expect(dialog.getByRole('link', { name: 'Another' })).toBeVisible()
+		await expect(dialog.getByRole('link', { name: 'Test Project' })).toHaveCount(0)
+
+		// Escape closes it.
+		await page.keyboard.press('Escape')
+		await expect(page.locator('.modal.is-active')).toHaveCount(0)
+	})
 })
 
 test.describe('project dashboard', () => {


### PR DESCRIPTION
## Summary

On the project list page, pressing **`/`** now opens the existing project search modal (`ModalSelectProject`) so you can quickly filter and jump to a project. A search affordance in the page header advertises the shortcut.

## Changes
- **`project/+page.svelte`** — mounts a `ModalSelectProject` instance and adds a window `keydown` listener that opens it on `/` (ignored while typing in an input/textarea/select/contenteditable, or with modifier keys). Added a header "Search projects `/`" button that opens the same modal. Listener is registered in `onMount` and removed on unmount, so the shortcut is scoped to this page.
- **`ModalSelectProject.svelte`** — closes on **Escape**, and blurs the search field on close so it isn't left focused while hidden (which otherwise blocked `/` from reopening it).

## Test plan
- New `project.spec.js` test: `/` opens the modal, the field is focused, typing filters the list, and Escape closes it (also covers the header search button).
- `bun lint` + `bun check`: clean.
- Full Playwright suite: 60/60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)