### PR TITLE
fix: equal row height on the deployment revision table

### DIFF
--- a/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
@@ -51,6 +51,10 @@
 				<td>
 					{#if index > 0}
 						<button class="button is-variant-secondary is-size-small" type="button" onclick={() => rollback(it.revision)}>Rollback</button>
+					{:else}
+						<!-- Reserve the button's height so the current revision's row
+						     matches the height of rows that have a Rollback button. -->
+						<button class="button is-variant-secondary is-size-small invisible" type="button" tabindex="-1" aria-hidden="true">Rollback</button>
 					{/if}
 				</td>
 			</tr>


### PR DESCRIPTION
## Summary

On the deployment revision table, the current revision (the first row, `index === 0`) has no **Rollback** button, so its row rendered shorter than the rows that do.

## Fix
Render an invisible copy of the small button (`visibility: hidden`, `aria-hidden`, `tabindex="-1"`) in that cell. It reserves the exact button height without a magic number, so every row lines up. Mirrors the same approach used for the roles list's edit-button column.

## Test plan
- `bun lint` + `bun check`: clean.
- `deployment.spec.js`: 12/12 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)