### PR TITLE
refactor: remove Total storage card from registry list

### DIFF
--- a/src/routes/(auth)/(project)/registry/(list)/+page.js
+++ b/src/routes/(auth)/(project)/registry/(list)/+page.js
@@ -3,15 +3,10 @@ import api from '$lib/api'
 export async function load ({ parent, fetch }) {
 	const { project } = await parent()
 
-	const [res, storageRes] = await Promise.all([
-		/** @type {Promise<Api.Response<Api.List<Api.Repository>>>} */
-		api.invoke('registry/list', { project }, fetch),
-		/** @type {Promise<Api.Response<Api.ProjectStorage>>} */
-		api.invoke('registry/getProjectStorage', { project }, fetch)
-	])
+	/** @type {Api.Response<Api.List<Api.Repository>>} */
+	const res = await api.invoke('registry/list', { project }, fetch)
 	return {
 		repositories: res.result?.items ?? [],
-		error: res.error,
-		storage: storageRes.result ?? null
+		error: res.error
 	}
 }

--- a/src/routes/(auth)/(project)/registry/(list)/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/(list)/+page.svelte
@@ -1,7 +1,6 @@
 <script>
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
-	import * as format from '$lib/format'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 
@@ -10,7 +9,6 @@
 	const project = $derived(data.project)
 	const repositories = $derived(data.repositories)
 	const error = $derived(data.error)
-	const storage = $derived(data.storage)
 
 	function deleteRepository (name) {
 		modal.confirm({
@@ -38,18 +36,6 @@
 		Usage
 	</a>
 </div>
-{#if storage !== null}
-	<div class="stat-grid">
-		<div class="stat-tile">
-			<div class="stat-head">Total storage</div>
-			<div class="stat-value">{format.storage(storage.size)}</div>
-			<div class="stat-foot">
-				across {repositories.length} {repositories.length === 1 ? 'repository' : 'repositories'}
-			</div>
-		</div>
-	</div>
-{/if}
-
 <div class="panel is-level-300">
 	<div class="table-container">
 		<table class="table is-variant-compact">
@@ -81,55 +67,3 @@
 		</table>
 	</div>
 </div>
-
-<style>
-	/* KPI card — mirrors the firewall metrics "total" stat tile. */
-	.stat-grid {
-		display: grid;
-		gap: 1rem;
-		grid-template-columns: repeat(auto-fit, minmax(220px, 280px));
-		margin-bottom: 1rem;
-	}
-
-	.stat-tile {
-		position: relative;
-		display: flex;
-		flex-direction: column;
-		gap: 0.55rem;
-		padding: 1rem 1.125rem;
-		border-radius: 0.75rem;
-		background: linear-gradient(135deg, hsl(var(--hsl-primary) / 0.12) 0%, hsl(var(--hsl-accent) / 0.12) 100%);
-		border: 1px solid hsl(var(--hsl-primary) / 0.2);
-		overflow: hidden;
-	}
-
-	.stat-tile::before {
-		content: '';
-		position: absolute;
-		top: 0;
-		bottom: 0;
-		left: 0;
-		width: 3px;
-		background: linear-gradient(hsl(var(--hsl-primary)), hsl(var(--hsl-accent)));
-	}
-
-	.stat-head {
-		font-size: 0.8125rem;
-		font-weight: 600;
-		color: hsl(var(--hsl-content) / 0.6);
-	}
-
-	.stat-value {
-		font-size: 1.9rem;
-		font-weight: 700;
-		line-height: 1;
-		letter-spacing: -0.02em;
-		font-variant-numeric: tabular-nums;
-		color: hsl(var(--hsl-primary));
-	}
-
-	.stat-foot {
-		font-size: 0.75rem;
-		color: hsl(var(--hsl-content) / 0.55);
-	}
-</style>

--- a/tests/registry.spec.js
+++ b/tests/registry.spec.js
@@ -7,10 +7,6 @@ test.describe('registry', () => {
 			'__registry/list': {
 				ok: true,
 				result: { items: [sampleRepository, { ...sampleRepository, name: 'api' }] }
-			},
-			'__registry/getProjectStorage': {
-				ok: true,
-				result: { size: 99999 }
 			}
 		})
 
@@ -20,21 +16,6 @@ test.describe('registry', () => {
 		await expect(main.getByRole('heading', { name: 'Registry' })).toBeVisible()
 		await expect(main.getByRole('link', { name: 'web' })).toBeVisible()
 		await expect(main.getByRole('link', { name: 'api' })).toBeVisible()
-	})
-
-	test('shows total storage from getProjectStorage', async ({ page }) => {
-		await setMocks({
-			'__registry/getProjectStorage': {
-				ok: true,
-				result: { size: 1024 ** 3 * 10 } // 10 GiB
-			}
-		})
-
-		await page.goto('/registry?project=test-project')
-
-		const main = page.locator('.content-wrapper')
-		await expect(main.getByText('Total storage')).toBeVisible()
-		await expect(main.getByText('10 GiB')).toBeVisible()
 	})
 
 	test('empty state when no repositories', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Remove the **Total storage** KPI tile from the registry list page (`registry/(list)/+page.svelte`).
- Drop the now-unused `.stat-*` styles, the `format` import, and the `registry/getProjectStorage` fetch in `+page.js`.

## Test plan
- `bun lint` ✅
- `bun check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)