### PR TITLE
test: regression coverage for the firewall feature

### DIFF
--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -29,6 +29,18 @@ export async function setMocks (overrides) {
 }
 
 /**
+ * Fetch the mock server's request log (every upstream call since the last
+ * reset), so a test can assert what the page sent — e.g. the `waf.set` body.
+ *
+ * @returns {Promise<{ path: string, method: string, body: string }[]>}
+ */
+export async function getRequestLog () {
+	const res = await fetch(`${MOCK_URL}/__log`)
+	if (!res.ok) throw new Error(`failed to read request log: ${res.status}`)
+	return res.json()
+}
+
+/**
  * Inject the auth token cookie so the SvelteKit `(auth)` group treats
  * the session as authenticated.
  *

--- a/tests/waf-expression.spec.js
+++ b/tests/waf-expression.spec.js
@@ -1,0 +1,356 @@
+// Unit/round-trip regression tests for the WAF CEL expression engine and rule
+// helpers. These modules are pure (no Svelte/SvelteKit imports), so they're
+// imported directly and exercised without a browser — fast and deterministic.
+//
+// The central invariant guarded here: `parseExpression` is the exact inverse of
+// `buildGroup`/`buildExpression` for every form the generator can emit, and
+// returns `null` for anything the visual builder can't faithfully represent
+// (the page relies on that null to drop into raw-CEL mode).
+import { test, expect } from '@playwright/test'
+import {
+	celString,
+	parseList,
+	getField,
+	operatorsForField,
+	isMultiOperator,
+	buildExpression,
+	combineExpression,
+	buildGroup,
+	parseExpression
+} from '../src/lib/waf/expression.js'
+import {
+	ruleForm,
+	genId,
+	normalizeRules,
+	toApiRules,
+	DEFAULT_STATUS,
+	DEFAULT_MESSAGE
+} from '../src/lib/waf/rules.js'
+
+test.describe('waf expression: celString', () => {
+	test('escapes backslash, quote, and control chars', () => {
+		expect(celString('a"b')).toBe('a\\"b')
+		expect(celString('a\\b')).toBe('a\\\\b')
+		expect(celString('a\nb\tc\rd')).toBe('a\\nb\\tc\\rd')
+		expect(celString('plain')).toBe('plain')
+	})
+
+	test('coerces nullish to empty string', () => {
+		expect(celString(/** @type {any} */ (undefined))).toBe('')
+		expect(celString(/** @type {any} */ (null))).toBe('')
+	})
+})
+
+test.describe('waf expression: parseList', () => {
+	test('splits on commas and newlines, trims, drops empties', () => {
+		expect(parseList('a, b\nc')).toEqual(['a', 'b', 'c'])
+		expect(parseList(' a ,, \n b \n')).toEqual(['a', 'b'])
+		expect(parseList('')).toEqual([])
+	})
+})
+
+test.describe('waf expression: operatorsForField', () => {
+	test('HTTP method offers membership only (no prefix/regex/contains)', () => {
+		const ops = operatorsForField(getField('method')).map((o) => o.value)
+		expect(ops).toEqual(['equals', 'not_equals', 'in_list', 'not_in_list'])
+		expect(ops).not.toContain('contains_any')
+		expect(ops).not.toContain('starts_with')
+	})
+
+	test('string field offers the full operator set', () => {
+		const ops = operatorsForField(getField('path')).map((o) => o.value)
+		expect(ops).toContain('contains_any')
+		expect(ops).toContain('starts_with')
+		expect(ops).toContain('matches_regex')
+	})
+
+	test('ip / numeric / membership / tls field types map to their operator sets', () => {
+		expect(operatorsForField(getField('remote_ip')).map((o) => o.value))
+			.toEqual(['in_cidr', 'ip_equals'])
+		expect(operatorsForField(getField('content_length')).map((o) => o.value))
+			.toEqual(['num_eq', 'num_ne', 'num_lt', 'num_gt', 'num_le', 'num_ge'])
+		expect(operatorsForField(getField('country')).map((o) => o.value))
+			.toEqual(['equals', 'not_equals', 'in_list', 'not_in_list'])
+		// TLS is a fixed on/off toggle — no operators.
+		expect(operatorsForField(getField('scheme'))).toEqual([])
+	})
+
+	test('isMultiOperator covers exactly the list operators', () => {
+		expect(isMultiOperator('contains_any')).toBe(true)
+		expect(isMultiOperator('in_list')).toBe(true)
+		expect(isMultiOperator('not_in_list')).toBe(true)
+		expect(isMultiOperator('equals')).toBe(false)
+		expect(isMultiOperator('starts_with')).toBe(false)
+	})
+})
+
+test.describe('waf expression: buildExpression', () => {
+	test('string operators', () => {
+		expect(buildExpression({ field: 'path', operator: 'equals', value: '/admin' }))
+			.toBe('request.path == "/admin"')
+		expect(buildExpression({ field: 'path', operator: 'not_equals', value: '/admin' }))
+			.toBe('request.path != "/admin"')
+		expect(buildExpression({ field: 'path', operator: 'starts_with', value: '/admin' }))
+			.toBe('request.path.startsWith("/admin")')
+		expect(buildExpression({ field: 'path', operator: 'not_starts_with', value: '/admin' }))
+			.toBe('!request.path.startsWith("/admin")')
+		expect(buildExpression({ field: 'path', operator: 'ends_with', value: '.php' }))
+			.toBe('request.path.endsWith(".php")')
+		expect(buildExpression({ field: 'path', operator: 'not_ends_with', value: '.php' }))
+			.toBe('!request.path.endsWith(".php")')
+		expect(buildExpression({ field: 'path', operator: 'matches_regex', value: '^/api/' }))
+			.toBe('regexMatch(request.path, "^/api/")')
+	})
+
+	test('list operators (contains_any / in_list / not_in_list)', () => {
+		expect(buildExpression({ field: 'path', operator: 'contains_any', values: 'a\nb' }))
+			.toBe('containsAny(request.path, ["a", "b"])')
+		expect(buildExpression({ field: 'path', operator: 'in_list', values: '/a\n/b' }))
+			.toBe('request.path in ["/a", "/b"]')
+		expect(buildExpression({ field: 'path', operator: 'not_in_list', values: '/a\n/b' }))
+			.toBe('!(request.path in ["/a", "/b"])')
+	})
+
+	test('named map fields lowercase the name', () => {
+		expect(buildExpression({ field: 'header', name: 'User-Agent', operator: 'equals', value: 'curl' }))
+			.toBe('request.headers["user-agent"] == "curl"')
+		expect(buildExpression({ field: 'cookie', name: 'Session', operator: 'equals', value: 'abc' }))
+			.toBe('request.cookies["session"] == "abc"')
+		expect(buildExpression({ field: 'arg', name: 'q', operator: 'equals', value: 'x' }))
+			.toBe('request.args["q"] == "x"')
+	})
+
+	test('tls toggle ignores the operator (on → https, off → http)', () => {
+		expect(buildExpression({ field: 'scheme', operator: 'equals', tls: true }))
+			.toBe('request.scheme == "https"')
+		expect(buildExpression({ field: 'scheme', operator: 'equals', tls: false }))
+			.toBe('request.scheme == "http"')
+		// tls defaults to on when unspecified.
+		expect(buildExpression({ field: 'scheme', operator: 'equals' }))
+			.toBe('request.scheme == "https"')
+	})
+
+	test('ip operators', () => {
+		expect(buildExpression({ field: 'remote_ip', operator: 'in_cidr', value: '10.0.0.0/8' }))
+			.toBe('ipInCidr(request.remote_ip, "10.0.0.0/8")')
+		expect(buildExpression({ field: 'remote_ip', operator: 'ip_equals', value: '1.2.3.4' }))
+			.toBe('request.remote_ip == "1.2.3.4"')
+	})
+
+	test('numeric operators', () => {
+		expect(buildExpression({ field: 'content_length', operator: 'num_gt', value: '1048576' }))
+			.toBe('request.content_length > 1048576')
+		expect(buildExpression({ field: 'content_length', operator: 'num_le', value: '0' }))
+			.toBe('request.content_length <= 0')
+	})
+
+	test('country membership quotes operands; asn membership keeps raw ints', () => {
+		expect(buildExpression({ field: 'country', operator: 'in_list', values: 'US\nGB' }))
+			.toBe('request.country in ["US", "GB"]')
+		expect(buildExpression({ field: 'country', operator: 'not_in_list', values: 'US\nGB' }))
+			.toBe('!(request.country in ["US", "GB"])')
+		expect(buildExpression({ field: 'asn', operator: 'in_list', values: '13335\n16509' }))
+			.toBe('request.asn in [13335, 16509]')
+		expect(buildExpression({ field: 'asn', operator: 'equals', value: '13335' }))
+			.toBe('request.asn == 13335')
+	})
+
+	test('escapes embedded quotes in operands', () => {
+		expect(buildExpression({ field: 'path', operator: 'equals', value: 'a"b' }))
+			.toBe('request.path == "a\\"b"')
+	})
+
+	test('returns empty string for incomplete specs', () => {
+		expect(buildExpression({ field: 'path', operator: 'equals', value: '' })).toBe('')
+		expect(buildExpression({ field: 'header', operator: 'equals', value: 'x' })).toBe('') // no name
+		expect(buildExpression({ field: 'path', operator: 'in_list', values: '' })).toBe('') // empty list
+		expect(buildExpression({ field: 'content_length', operator: 'num_gt', value: 'abc' })).toBe('') // not int
+		expect(buildExpression({ field: 'asn', operator: 'equals', value: 'x' })).toBe('') // not digits
+		expect(buildExpression({ field: 'remote_ip', operator: 'in_cidr', value: '' })).toBe('')
+		expect(buildExpression({ field: 'nope', operator: 'equals', value: 'x' })).toBe('') // unknown field
+	})
+})
+
+test.describe('waf expression: combineExpression', () => {
+	test('replace / and / or, with empty existing handled', () => {
+		expect(combineExpression('', 'A', 'and')).toBe('A')
+		expect(combineExpression('A', 'B', 'replace')).toBe('B')
+		expect(combineExpression('A', 'B', 'and')).toBe('A && B')
+		expect(combineExpression('A', 'B', 'or')).toBe('A || B')
+	})
+})
+
+test.describe('waf expression: buildGroup', () => {
+	test('joins complete conditions and drops incomplete ones', () => {
+		const conditions = [
+			{ field: 'path', operator: 'equals', value: '/admin' },
+			{ field: 'method', operator: 'equals', value: 'POST' },
+			{ field: 'host', operator: 'equals', value: '' } // incomplete → dropped
+		]
+		expect(buildGroup('and', conditions))
+			.toBe('request.path == "/admin" && request.method == "POST"')
+		expect(buildGroup('or', conditions))
+			.toBe('request.path == "/admin" || request.method == "POST"')
+	})
+
+	test('empty conditions produce an empty string', () => {
+		expect(buildGroup('and', [])).toBe('')
+	})
+})
+
+test.describe('waf expression: parseExpression round-trips', () => {
+	// Every canonical string the generator can emit must parse back into specs
+	// that regenerate the identical string (with the right combinator).
+	const representable = [
+		// string field, all operators
+		'request.path == "/admin"',
+		'request.path != "/admin"',
+		'request.path in ["/a", "/b"]',
+		'!(request.path in ["/a", "/b"])',
+		'containsAny(request.path, ["a", "b"])',
+		'request.path.startsWith("/admin")',
+		'!request.path.startsWith("/admin")',
+		'request.path.endsWith(".php")',
+		'!request.path.endsWith(".php")',
+		'regexMatch(request.path, "^/api/")',
+		// method (membership)
+		'request.method == "GET"',
+		'request.method in ["GET", "POST"]',
+		// named map fields
+		'request.headers["user-agent"] == "curl"',
+		'request.args["q"] != "x"',
+		'request.cookies["session"] in ["a", "b"]',
+		// tls
+		'request.scheme == "https"',
+		'request.scheme == "http"',
+		// ip
+		'ipInCidr(request.remote_ip, "10.0.0.0/8")',
+		'request.remote_ip == "1.2.3.4"',
+		// numeric
+		'request.content_length > 1048576',
+		'request.content_length <= 0',
+		// country
+		'request.country == "US"',
+		'request.country in ["US", "GB"]',
+		'!(request.country in ["US", "GB"])',
+		// asn
+		'request.asn == 13335',
+		'request.asn in [13335, 16509]',
+		'!(request.asn in [13335, 16509])',
+		// escaped operand
+		'request.path == "a\\"b"'
+	]
+
+	for (const cel of representable) {
+		test(`round-trips: ${cel}`, () => {
+			const parsed = parseExpression(cel)
+			if (!parsed) throw new Error(`should be representable: ${cel}`)
+			// Regenerating the parsed specs reproduces the exact input string.
+			expect(buildGroup(parsed.combinator, parsed.conditions)).toBe(cel)
+		})
+	}
+
+	test('multi-condition AND / OR keep their combinator', () => {
+		const andExpr = 'request.path == "/a" && request.method == "GET"'
+		const parsedAnd = parseExpression(andExpr)
+		if (!parsedAnd) throw new Error('AND expression should be representable')
+		expect(parsedAnd.combinator).toBe('and')
+		expect(parsedAnd.conditions).toHaveLength(2)
+		expect(buildGroup('and', parsedAnd.conditions)).toBe(andExpr)
+
+		const orExpr = 'request.path == "/a" || request.path == "/b"'
+		const parsedOr = parseExpression(orExpr)
+		if (!parsedOr) throw new Error('OR expression should be representable')
+		expect(parsedOr.combinator).toBe('or')
+		expect(buildGroup('or', parsedOr.conditions)).toBe(orExpr)
+	})
+
+	test('empty expression is an empty AND group (not null)', () => {
+		expect(parseExpression('')).toEqual({ combinator: 'and', conditions: [] })
+		expect(parseExpression('   ')).toEqual({ combinator: 'and', conditions: [] })
+	})
+})
+
+test.describe('waf expression: parseExpression rejects non-representable input', () => {
+	const complex = [
+		'request.path == "/a" && request.method == "GET" || request.host == "x"', // mixed && / ||
+		'(request.path == "/a")', // grouping
+		'lower(request.path) == "/a"', // unknown function
+		'request.path.contains("admin")', // unsupported method
+		'request.path == ', // missing operand
+		'request.path = "/a"', // not a valid operator
+		'request.unknown == "x"', // unknown accessor
+		'request.path in []', // empty list never emitted
+		'request.asn == abc' // non-numeric asn operand
+	]
+
+	for (const cel of complex) {
+		test(`returns null: ${cel}`, () => {
+			expect(parseExpression(cel)).toBeNull()
+		})
+	}
+})
+
+test.describe('waf rules helpers', () => {
+	test('ruleForm fills defaults for a blank rule', () => {
+		const f = ruleForm()
+		expect(f.action).toBe('log')
+		expect(f.status).toBe(DEFAULT_STATUS)
+		expect(f.message).toBe(DEFAULT_MESSAGE)
+		expect(f.expression).toBe('')
+	})
+
+	test('genId produces unique ids that avoid the taken set', () => {
+		const taken = []
+		for (let i = 0; i < 50; i++) {
+			const id = genId(taken)
+			expect(taken).not.toContain(id)
+			expect(id).toMatch(/^rule-[a-z0-9]+$/)
+			taken.push(id)
+		}
+	})
+
+	test('normalizeRules sorts by priority and keeps order = execution order', () => {
+		const out = normalizeRules([
+			{ id: 'b', description: '', expression: 'x', action: 'log', priority: 2 },
+			{ id: 'a', description: '', expression: 'y', action: 'log', priority: 1 }
+		])
+		expect(out.map((r) => r.id)).toEqual(['a', 'b'])
+	})
+
+	test('normalizeRules assigns ids to rules missing/duplicating one', () => {
+		const out = normalizeRules([
+			{ id: '', description: '', expression: 'x', action: 'log', priority: 0 },
+			{ id: 'dup', description: '', expression: 'y', action: 'log', priority: 1 },
+			{ id: 'dup', description: '', expression: 'z', action: 'log', priority: 2 }
+		])
+		const ids = out.map((r) => r.id)
+		expect(new Set(ids).size).toBe(3) // all unique
+		expect(ids.every((id) => id.length > 0)).toBe(true)
+	})
+
+	test('toApiRules sets priority from row order', () => {
+		const api = toApiRules([
+			{ id: 'r1', description: 'first', expression: 'a', action: 'log', status: null, message: '' },
+			{ id: 'r2', description: 'second', expression: 'b', action: 'allow', status: null, message: '' }
+		])
+		expect(api.map((r) => r.priority)).toEqual([0, 1])
+	})
+
+	test('toApiRules includes status/message only for block, with fallbacks', () => {
+		const [logRule, blockRule, blockDefault] = toApiRules([
+			{ id: 'r1', description: '', expression: 'a', action: 'log', status: 500, message: 'x' },
+			{ id: 'r2', description: '', expression: 'b', action: 'block', status: 429, message: 'Too many' },
+			{ id: 'r3', description: '', expression: 'c', action: 'block', status: null, message: '' }
+		])
+		// Non-block rules never carry a response status/message.
+		expect(logRule.status).toBeUndefined()
+		expect(logRule.message).toBeUndefined()
+		// Block rules carry their configured status/message.
+		expect(blockRule.status).toBe(429)
+		expect(blockRule.message).toBe('Too many')
+		// Block rules fall back to the defaults when unset.
+		expect(blockDefault.status).toBe(DEFAULT_STATUS)
+		expect(blockDefault.message).toBe(DEFAULT_MESSAGE)
+	})
+})

--- a/tests/waf.spec.js
+++ b/tests/waf.spec.js
@@ -1,4 +1,169 @@
-import { test, expect } from './helpers.js'
+import { test, expect, setMocks, getRequestLog } from './helpers.js'
+import { defaultLocation } from './fixtures/mocks.js'
+
+// A WAF-capable location (the default fixture location has no `waf` feature).
+const wafLocation = { ...defaultLocation, id: 'gke', features: { waf: true } }
+
+/** Build a WAF zone fixture. */
+function wafZone (overrides = {}) {
+	return {
+		project: 'test-project',
+		location: 'gke',
+		description: '',
+		rules: [],
+		status: 'success',
+		action: 'create',
+		createdAt: '2024-01-01T00:00:00Z',
+		createdBy: '[email protected]',
+		...overrides
+	}
+}
+
+/** Build a WAF rule fixture. */
+function wafRule (overrides = {}) {
+	return {
+		id: 'rule-aaaaaa',
+		description: '',
+		expression: 'request.path == "/admin"',
+		action: 'log',
+		priority: 0,
+		...overrides
+	}
+}
+
+test.describe('firewall list', () => {
+	test('renders zones with status and links to manage', async ({ page }) => {
+		await setMocks({
+			'waf.list': {
+				ok: true,
+				result: {
+					project: 'test-project',
+					items: [
+						wafZone({ location: 'gke', description: 'prod edge', status: 'success', rules: [wafRule()] }),
+						wafZone({ location: 'sgp', status: 'pending', action: 'create', rules: [] })
+					]
+				}
+			},
+			// The list fetches metrics per zone client-side; keep it quiet/empty.
+			'waf.metrics': { ok: true, result: { series: [], total: 0 } }
+		})
+
+		await page.goto('/waf?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Firewall' })).toBeVisible()
+		await expect(main.getByRole('link', { name: 'gke', exact: true })).toBeVisible()
+		await expect(main.getByRole('link', { name: 'sgp', exact: true })).toBeVisible()
+		await expect(main.getByText('prod edge')).toBeVisible()
+		// Settled zone shows Active; the in-flight create shows Deploying.
+		await expect(main.getByText('Active')).toBeVisible()
+		await expect(main.getByText('Deploying')).toBeVisible()
+		// Manage shortcut points at the per-location manage page.
+		await expect(main.getByRole('link', { name: 'Manage' }).first())
+			.toHaveAttribute('href', /\/waf\/manage\?project=test-project&location=gke/)
+	})
+
+	test('shows the empty state when there are no zones', async ({ page }) => {
+		await setMocks({
+			'waf.list': { ok: true, result: { project: 'test-project', items: [] } }
+		})
+
+		await page.goto('/waf?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('No firewalls yet')).toBeVisible()
+		await expect(main.getByText('Create a firewall to start filtering traffic in a location.')).toBeVisible()
+	})
+})
+
+test.describe('firewall create', () => {
+	test('offers only unconfigured WAF locations and saves an empty zone', async ({ page }) => {
+		await setMocks({
+			'location.list': { ok: true, result: { items: [wafLocation] } }
+			// waf.get is unmocked → 404 (notFound) → the location is unconfigured/available.
+		})
+
+		await page.goto('/waf/create?project=test-project')
+
+		// Select the available location via the custom Select.
+		await page.locator('#input-location').click()
+		await page.getByRole('option', { name: 'gke' }).click()
+		await page.locator('#input-description').fill('block bots')
+
+		await page.getByRole('button', { name: 'Save' }).click()
+
+		// The page persists the new zone via waf.set with an empty rule list.
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/waf.set')
+		}).toBe(true)
+
+		const setReq = (await getRequestLog()).find((r) => r.path === '/waf.set')
+		const body = JSON.parse(setReq?.body ?? '{}')
+		expect(body.location).toBe('gke')
+		expect(body.description).toBe('block bots')
+		expect(body.rules).toEqual([])
+	})
+
+	test('reports when every location already has a firewall', async ({ page }) => {
+		await setMocks({
+			'location.list': { ok: true, result: { items: [wafLocation] } },
+			// The only supported location already has a zone → nothing to create.
+			'waf.get': { ok: true, result: wafZone({ location: 'gke' }) }
+		})
+
+		await page.goto('/waf/create?project=test-project')
+		await expect(page.getByText('Every location already has a firewall configured')).toBeVisible()
+	})
+})
+
+test.describe('firewall manage', () => {
+	test('lists the zone rules with action badges', async ({ page }) => {
+		await setMocks({
+			'waf.get': {
+				ok: true,
+				result: wafZone({
+					location: 'gke',
+					description: 'prod edge',
+					rules: [
+						wafRule({ id: 'rule-block1', description: 'block admin', action: 'block', status: 403, message: 'Forbidden', priority: 0 }),
+						wafRule({ id: 'rule-log1', description: '', expression: 'request.method == "POST"', action: 'log', priority: 1 })
+					]
+				})
+			}
+		})
+
+		await page.goto('/waf/manage?project=test-project&location=gke')
+		const main = page.locator('.content-wrapper')
+
+		await expect(main.getByRole('heading', { name: 'Firewall rules' })).toBeVisible()
+		await expect(main.getByText('rule-block1')).toBeVisible()
+		await expect(main.getByText('block admin')).toBeVisible()
+		await expect(main.getByText('Block', { exact: true })).toBeVisible()
+		await expect(main.getByText('Log', { exact: true })).toBeVisible()
+	})
+
+	test('disable firewall confirms then calls waf.delete', async ({ page }) => {
+		await setMocks({
+			'waf.get': { ok: true, result: wafZone({ location: 'gke', rules: [wafRule()] }) },
+			'waf.delete': { ok: true, result: true },
+			'waf.list': { ok: true, result: { project: 'test-project', items: [] } }
+		})
+
+		await page.goto('/waf/manage?project=test-project&location=gke')
+
+		await page.getByRole('button', { name: 'Disable firewall' }).click()
+		// Confirm in the SweetAlert dialog.
+		await page.locator('.swal2-confirm').click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/waf.delete')
+		}).toBe(true)
+
+		const delReq = (await getRequestLog()).find((r) => r.path === '/waf.delete')
+		expect(JSON.parse(delReq?.body ?? '{}').location).toBe('gke')
+	})
+})
 
 test.describe('firewall rule builder', () => {
 	// The add-rule page opens the visual condition builder. Changing a condition's
@@ -27,5 +192,58 @@ test.describe('firewall rule builder', () => {
 
 		// The previously entered value is reset to empty.
 		await expect(page.locator('#waf-value')).toHaveValue('')
+	})
+
+	test('builds a condition and saves it as CEL', async ({ page }) => {
+		await page.goto('/waf/edit?project=test-project&location=gke')
+
+		const addCondition = page.getByRole('button', { name: 'Add condition' })
+		const value = page.locator('#waf-value')
+		await expect(async () => {
+			await addCondition.click()
+			await expect(value).toBeVisible({ timeout: 1000 })
+		}).toPass()
+
+		// Default field is Path with the "equals" operator; give it a value.
+		await value.fill('/admin')
+
+		// Save becomes enabled only once the rule has a complete condition.
+		const save = page.getByRole('button', { name: 'Save' })
+		await expect(save).toBeEnabled()
+		await save.click()
+
+		// The whole zone is written via waf.set; the new rule carries the
+		// generated CEL expression.
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/waf.set')
+		}).toBe(true)
+
+		const setReq = (await getRequestLog()).find((r) => r.path === '/waf.set')
+		const body = JSON.parse(setReq?.body ?? '{}')
+		expect(body.location).toBe('gke')
+		expect(body.rules).toHaveLength(1)
+		expect(body.rules[0].expression).toBe('request.path == "/admin"')
+		expect(body.rules[0].action).toBe('log')
+	})
+
+	test('opens a non-representable expression in raw mode', async ({ page }) => {
+		const complex = 'request.path == "/a" && request.method == "GET" || request.host == "x"'
+		await setMocks({
+			'waf.get': {
+				ok: true,
+				result: wafZone({
+					location: 'gke',
+					rules: [wafRule({ id: 'rule-cx', expression: complex, action: 'log', priority: 0 })]
+				})
+			}
+		})
+
+		await page.goto('/waf/edit?project=test-project&location=gke&rule=rule-cx')
+
+		// Visual editing can't represent mixed && / ||, so the Visual tab is
+		// disabled and the raw CEL textarea shows the expression verbatim.
+		await expect(page.getByRole('tab', { name: 'Visual' })).toBeDisabled()
+		await expect(page.locator('#rule-expression-raw')).toHaveValue(complex)
 	})
 })


### PR DESCRIPTION
## Summary

Adds a regression net for the firewall (WAF) feature, which was thinly tested — the pure CEL engine and rule helpers had **no** direct coverage, and the e2e spec had a single case.

### `tests/waf-expression.spec.js` (new) — pure unit / round-trip
The richest, most regression-prone logic lives in `src/lib/waf/expression.js` and `src/lib/waf/rules.js`. These modules are dependency-free, so they're imported directly and run without a browser (fast + deterministic). Coverage:
- `celString` escaping, `parseList`, `operatorsForField` per field type (method → membership-only, ip, numeric, country/asn, tls → none).
- `buildExpression` for every branch — string/list/method/regex/ip/numeric/country/asn/tls/named-map — including incomplete specs collapsing to `''`.
- **The core invariant:** `parseExpression` is the exact inverse of `buildGroup`/`buildExpression` for every form the generator emits, and returns `null` for anything non-representable (mixed `&&`/`||`, grouping, unknown functions, partial input) — which is what makes the editor correctly fall back to raw-CEL mode.

### `tests/waf.spec.js` — expanded e2e
- **list**: status badges (Active / Deploying), zone links, empty state.
- **create**: offers only unconfigured WAF-capable locations; persists an empty zone via `waf.set`; reports when every location is already configured.
- **manage**: renders the rule table with action badges; *Disable firewall* → confirm → `waf.delete`.
- **rule builder**: building a condition produces the right CEL and saves it; a non-representable expression opens in raw/Expression mode with the Visual tab disabled.

### `tests/helpers.js`
- Add `getRequestLog()` to assert what a page actually sent upstream (e.g. the `waf.set` / `waf.delete` body).

## Test plan
- `bun lint` ✅
- `bun check` ✅
- `bun run test` ✅ — full suite, **131 passed** (64 new unit + 8 new e2e + existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)