### PR TITLE
refactor: align registry repo header with other detail pages

### DIFF
--- a/src/routes/(auth)/(project)/registry/detail/+layout.svelte
+++ b/src/routes/(auth)/(project)/registry/detail/+layout.svelte
@@ -20,18 +20,16 @@
 
 <br>
 
-<div class="panel is-level-300 grid gap-6">
-	<div class="grid grid-cols-1 gap-3">
-		<h3 class="mr-6 mb-4 xl:mb-0">
-			<strong>{repository.name}</strong>
-			<div class="text-base mt-1 break-all">registry.deploys.app/{project}/{repository.name}</div>
-			<div class="text-base mt-1 break-all">{format.storage(repository.size)}</div>
-		</h3>
+<div class="page-head">
+	<div class="min-w-0">
+		<h4 class="min-w-0"><strong class="wrap-anywhere">{repository.name}</strong></h4>
+		<p class="page-sub font-mono min-w-0 wrap-anywhere">registry.deploys.app/{project}/{repository.name}</p>
 	</div>
+	<div class="page-sub">{format.storage(repository.size)}</div>
+</div>
 
-	<hr>
-
-	<div class="tabs is-variant-underline xl:mb-0 w-full flex-col lg:flex-row">
+<div class="panel is-level-300 grid gap-6">
+	<div class="tabs is-variant-underline w-full flex-col lg:flex-row">
 		<a class="tab-button"
 			class:is-active={$page.url.pathname === '/registry/detail/tags'}
 			href={`/registry/detail/tags?project=${project}&repository=${id}`}>


### PR DESCRIPTION
## Summary

Refactors the registry repo (detail) page header so it matches the rest of the console's detail pages (deployment, route, waf).

**Before:** the title lived *inside* the panel as an `<h3>`, with the pull URL and storage size as `text-base` lines, separated from the tabs by an `<hr>`.

**After:** the header is a `.page-head` block placed *outside* the panel — same structure as `deployment/(detail)`, `route/manage`, and `waf/manage`:

- `<h4><strong>{repository.name}</strong></h4>` as the title
- pull URL `registry.deploys.app/{project}/{repository.name}` as a mono `.page-sub`
- storage size as a muted stat on the right (where other pages put action buttons)
- the panel now only holds the tabs + content; the redundant `<hr>` and wrapper `<div>` are gone, and the leftover `xl:mb-0` is dropped from the tabs row

Long repo names / URLs wrap via `min-w-0 wrap-anywhere`, matching the deployment header's defensive treatment.

## Test plan

- `bun lint` — passes, zero errors
- `bun check` — passes, zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)