### PR TITLE
feat: global search palette ("/" command palette)

### DIFF
--- a/src/lib/nav.js
+++ b/src/lib/nav.js
@@ -1,0 +1,32 @@
+/**
+ * Project-scoped navigation menu.
+ *
+ * Single source of truth shared by the sidebar (`Sidebar.svelte`) and the
+ * global search palette (`lib/search`) so the two never drift apart.
+ *
+ * @typedef {Object} ProjectMenuItem
+ * @property {string} id
+ * @property {string} title
+ * @property {string} icon     Font Awesome class, e.g. `fa-rocket`
+ * @property {string} link     route path, without the `?project=` query
+ * @property {boolean} [preview]
+ */
+
+/** @type {ProjectMenuItem[]} */
+export const projectMenu = [
+	{ id: 'dashboard', title: 'Dashboard', icon: 'fa-columns', link: '/' },
+	{ id: 'deployment', title: 'Deployments', icon: 'fa-rocket', link: '/deployment' },
+	{ id: 'domain', title: 'Domains', icon: 'fa-globe', link: '/domain' },
+	{ id: 'route', title: 'Routes', icon: 'fa-router', link: '/route' },
+	{ id: 'waf', title: 'Firewall', icon: 'fa-shield-halved', link: '/waf', preview: true },
+	{ id: 'workload-identity', title: 'Workload Identities', icon: 'fa-network-wired', link: '/workload-identity' },
+	{ id: 'disk', title: 'Disks', icon: 'fa-hdd', link: '/disk' },
+	{ id: 'pull-secret', title: 'Pull Secrets', icon: 'fa-key', link: '/pull-secret' },
+	{ id: 'env-group', title: 'Env Groups', icon: 'fa-cog', link: '/env-group' },
+	{ id: 'role', title: 'Roles', icon: 'fa-user-tag', link: '/role' },
+	{ id: 'role.users', title: 'Users', icon: 'fa-users', link: '/role/users' },
+	{ id: 'service-account', title: 'Service Accounts', icon: 'fa-user-lock', link: '/service-account' },
+	{ id: 'dropbox', title: 'Dropbox', icon: 'fa-box-open', link: '/dropbox' },
+	{ id: 'registry', title: 'Registry', icon: 'fa-warehouse-full', link: '/registry' },
+	{ id: 'audit-log', title: 'Audit Logs', icon: 'fa-clipboard-list', link: '/audit-log' }
+]

--- a/src/lib/search/index.js
+++ b/src/lib/search/index.js
@@ -151,6 +151,38 @@ const resourceSources = [
 ]
 
 /**
+ * Project-switch entries. Mirrors {@link ../routes/(auth)/ModalSelectProject.svelte}'s
+ * `setProject` URL shape: keep the current query params, swap `project=`, and
+ * honour `data.overrideRedirect` so switching from a detail page lands on the
+ * section's list in the new project instead of a stale deep link.
+ *
+ * The current project is excluded — switching to where you already are is a
+ * no-op and would just be visual noise in the palette.
+ *
+ * @param {Api.Project[]} projects
+ * @param {string} currentProject
+ * @param {{ url: { search: string }, data: { overrideRedirect?: string } }} page
+ * @returns {SearchEntry[]}
+ */
+export function projectEntries (projects, currentProject, page) {
+	const overrideRedirect = page.data?.overrideRedirect || ''
+	return projects
+		.filter((p) => p.project !== currentProject)
+		.map((p) => {
+			const q = new URLSearchParams(page.url.search)
+			q.set('project', p.project)
+			return /** @type {SearchEntry} */ ({
+				id: `project:${p.project}`,
+				group: 'Switch project',
+				icon: 'fa-folder-open',
+				label: p.name,
+				sublabel: p.project,
+				href: `${overrideRedirect}?${q.toString()}`
+			})
+		})
+}
+
+/**
  * Navigation entries — the sidebar sections, jumpable by name. Always available
  * (no fetch) so the palette is useful the instant it opens.
  *

--- a/src/lib/search/index.js
+++ b/src/lib/search/index.js
@@ -1,0 +1,218 @@
+import api from '$lib/api'
+import { projectMenu } from '$lib/nav'
+
+/**
+ * A single searchable item shown in the command palette.
+ *
+ * @typedef {Object} SearchEntry
+ * @property {string} id        stable key, unique across all entries
+ * @property {string} group     section heading, e.g. "Deployments" / "Go to"
+ * @property {string} icon      Font Awesome class, e.g. `fa-rocket`
+ * @property {string} label     primary text (the thing you'd type)
+ * @property {string} [sublabel] secondary text (location, target, …)
+ * @property {string} href      navigation target
+ */
+
+const enc = encodeURIComponent
+
+/**
+ * Resource sources fanned out on open. Each calls a project-scoped `*.list`
+ * endpoint and maps every item to a {@link SearchEntry}. Keep the labels to the
+ * fields a user would actually type to find the resource.
+ *
+ * @typedef {Object} ResourceSource
+ * @property {string} group
+ * @property {string} icon
+ * @property {string} fn                          api function name
+ * @property {(it: any, project: string) => { key: string, label: string, sublabel?: string, href: string }} map
+ */
+
+/** @type {ResourceSource[]} */
+const resourceSources = [
+	{
+		group: 'Deployments',
+		icon: 'fa-rocket',
+		fn: 'deployment.list',
+		map: (it, p) => ({
+			key: `${it.location}/${it.name}`,
+			label: it.name,
+			sublabel: it.location,
+			href: `/deployment/metrics?project=${p}&location=${enc(it.location)}&name=${enc(it.name)}`
+		})
+	},
+	{
+		group: 'Domains',
+		icon: 'fa-globe',
+		fn: 'domain.list',
+		map: (it, p) => ({
+			key: `${it.location}/${it.domain}`,
+			label: it.domain,
+			sublabel: it.location,
+			href: `/domain/detail?project=${p}&domain=${enc(it.domain)}`
+		})
+	},
+	{
+		group: 'Routes',
+		icon: 'fa-router',
+		fn: 'route.list',
+		map: (it, p) => ({
+			key: `${it.location}/${it.domain}${it.path}`,
+			label: `${it.domain}${it.path}`,
+			sublabel: it.target,
+			href: `/route/manage?project=${p}&location=${enc(it.location)}&domain=${enc(it.domain)}&path=${enc(it.path)}`
+		})
+	},
+	{
+		group: 'Firewall',
+		icon: 'fa-shield-halved',
+		fn: 'waf.list',
+		map: (it, p) => ({
+			key: it.location,
+			label: it.location,
+			sublabel: it.description || undefined,
+			href: `/waf/manage?project=${p}&location=${enc(it.location)}`
+		})
+	},
+	{
+		group: 'Workload Identities',
+		icon: 'fa-network-wired',
+		fn: 'workloadIdentity.list',
+		map: (it, p) => ({
+			key: `${it.location}/${it.name}`,
+			label: it.name,
+			sublabel: it.location,
+			href: `/workload-identity/detail?project=${p}&location=${enc(it.location)}&name=${enc(it.name)}`
+		})
+	},
+	{
+		group: 'Disks',
+		icon: 'fa-hdd',
+		fn: 'disk.list',
+		map: (it, p) => ({
+			key: `${it.location}/${it.name}`,
+			label: it.name,
+			sublabel: it.location,
+			href: `/disk/metrics?project=${p}&location=${enc(it.location)}&name=${enc(it.name)}`
+		})
+	},
+	{
+		group: 'Pull Secrets',
+		icon: 'fa-key',
+		fn: 'pullSecret.list',
+		map: (it, p) => ({
+			key: `${it.location}/${it.name}`,
+			label: it.name,
+			sublabel: it.location,
+			href: `/pull-secret/detail?project=${p}&location=${enc(it.location)}&name=${enc(it.name)}`
+		})
+	},
+	{
+		group: 'Env Groups',
+		icon: 'fa-cog',
+		fn: 'envGroup.list',
+		map: (it, p) => ({
+			key: it.name,
+			label: it.name,
+			href: `/env-group/detail?project=${p}&name=${enc(it.name)}`
+		})
+	},
+	{
+		group: 'Roles',
+		icon: 'fa-user-tag',
+		fn: 'role.list',
+		map: (it, p) => ({
+			key: it.role,
+			label: it.role,
+			sublabel: it.name,
+			href: `/role/detail?project=${p}&role=${enc(it.role)}`
+		})
+	},
+	{
+		group: 'Service Accounts',
+		icon: 'fa-user-lock',
+		fn: 'serviceAccount.list',
+		map: (it, p) => ({
+			key: it.sid,
+			label: it.email,
+			sublabel: it.name,
+			href: `/service-account/detail?project=${p}&id=${enc(it.sid)}`
+		})
+	},
+	{
+		group: 'Registry',
+		icon: 'fa-warehouse-full',
+		fn: 'registry.list',
+		map: (it, p) => ({
+			key: it.name,
+			label: it.name,
+			href: `/registry/detail?project=${p}&repository=${enc(it.name)}`
+		})
+	}
+]
+
+/**
+ * Navigation entries — the sidebar sections, jumpable by name. Always available
+ * (no fetch) so the palette is useful the instant it opens.
+ *
+ * @param {string} project
+ * @returns {SearchEntry[]}
+ */
+export function navEntries (project) {
+	return projectMenu.map((m) => ({
+		id: `nav:${m.id}`,
+		group: 'Go to',
+		icon: m.icon,
+		label: m.title,
+		href: `${m.link}?project=${project}`
+	}))
+}
+
+/**
+ * Fan out to every resource `*.list` endpoint in parallel and flatten the
+ * results into search entries. Endpoints that fail (e.g. no permission) are
+ * skipped silently so one forbidden resource never blanks the whole palette.
+ *
+ * @param {string} project
+ * @param {typeof fetch} fetch
+ * @returns {Promise<SearchEntry[]>}
+ */
+export async function fetchResourceEntries (project, fetch) {
+	const settled = await Promise.all(resourceSources.map(async (src) => {
+		try {
+			/** @type {Api.Response<Api.List<any>>} */
+			const res = await api.invoke(src.fn, { project }, fetch)
+			const items = res.result?.items ?? []
+			return items.map((it) => {
+				const m = src.map(it, project)
+				return /** @type {SearchEntry} */ ({
+					id: `${src.fn}:${m.key}`,
+					group: src.group,
+					icon: src.icon,
+					label: m.label,
+					sublabel: m.sublabel,
+					href: m.href
+				})
+			})
+		} catch {
+			return /** @type {SearchEntry[]} */ ([])
+		}
+	}))
+	return settled.flat()
+}
+
+/**
+ * Token AND-match over label + sublabel + group, mirroring the project picker:
+ * every whitespace-separated token must appear somewhere in the haystack.
+ *
+ * @param {SearchEntry[]} entries
+ * @param {string} query
+ * @returns {SearchEntry[]}
+ */
+export function filterEntries (entries, query) {
+	const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
+	if (!tokens.length) return entries
+	return entries.filter((e) => {
+		const haystack = `${e.label} ${e.sublabel ?? ''} ${e.group}`.toLowerCase()
+		return tokens.every((t) => haystack.includes(t))
+	})
+}

--- a/src/routes/(auth)/+layout.svelte
+++ b/src/routes/(auth)/+layout.svelte
@@ -6,6 +6,7 @@
 	import Navbar from './Navbar.svelte'
 	import Sidebar from './Sidebar.svelte'
 	import ModalSelectProject from './ModalSelectProject.svelte'
+	import SearchModal from './SearchModal.svelte'
 
 	const { data, children } = $props()
 
@@ -21,6 +22,9 @@
 	/** @type {?ModalSelectProject} */
 	let projectModal = $state(null)
 
+	/** @type {?SearchModal} */
+	let searchModal = $state(null)
+
 	onMount(() => {
 		api.setOnUnauth(() => {
 			location.reload()
@@ -30,12 +34,28 @@
 	function hideSidebar () {
 		showSidebar = false
 	}
+
+	/**
+	 * Open the search palette on "/", unless the user is typing into a field
+	 * (including the palette's own input, so "/" types normally once it's open).
+	 * @param {KeyboardEvent} e
+	 */
+	function onWindowKeydown (e) {
+		if (e.key !== '/' || e.metaKey || e.ctrlKey || e.altKey) return
+		const el = /** @type {?HTMLElement} */ (e.target)
+		const tag = el?.tagName
+		if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el?.isContentEditable) return
+		e.preventDefault()
+		searchModal?.open()
+	}
 </script>
+
+<svelte:window onkeydown={onWindowKeydown} />
 
 <div class="app-layout"
 	class:is-shown-sidebar={showSidebar}>
 	<div class="navbar-wrapper">
-		<Navbar {profile} toggleSidebar={() => showSidebar = !showSidebar} />
+		<Navbar {profile} toggleSidebar={() => showSidebar = !showSidebar} openSearch={() => searchModal?.open()} />
 	</div>
 
 	<div class="sidebar-wrapper z-[2]">
@@ -50,6 +70,7 @@
 </div>
 
 <ModalSelectProject bind:this={projectModal} {projects} />
+<SearchModal bind:this={searchModal} />
 
 <style>
 	:root {

--- a/src/routes/(auth)/+layout.svelte
+++ b/src/routes/(auth)/+layout.svelte
@@ -13,6 +13,11 @@
 	const profile = $derived(data.profile)
 	const projects = $derived(data.projects ?? [])
 
+	// The global search palette is project-scoped — only enabled when a
+	// `?project=` is selected. On `/project` (the project picker page) the page
+	// itself owns the `/` shortcut for its own ModalSelectProject.
+	const hasProject = $derived(!!$page.url.searchParams.get('project'))
+
 	let showSidebar = $state(false)
 	$effect(() => {
 		$page
@@ -42,6 +47,7 @@
 	 */
 	function onWindowKeydown (e) {
 		if (e.key !== '/' || e.metaKey || e.ctrlKey || e.altKey) return
+		if (!hasProject) return
 		const el = /** @type {?HTMLElement} */ (e.target)
 		const tag = el?.tagName
 		if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el?.isContentEditable) return
@@ -55,7 +61,7 @@
 <div class="app-layout"
 	class:is-shown-sidebar={showSidebar}>
 	<div class="navbar-wrapper">
-		<Navbar {profile} toggleSidebar={() => showSidebar = !showSidebar} openSearch={() => searchModal?.open()} />
+		<Navbar {profile} toggleSidebar={() => showSidebar = !showSidebar} openSearch={hasProject ? () => searchModal?.open() : undefined} />
 	</div>
 
 	<div class="sidebar-wrapper z-[2]">

--- a/src/routes/(auth)/+layout.svelte
+++ b/src/routes/(auth)/+layout.svelte
@@ -76,7 +76,7 @@
 </div>
 
 <ModalSelectProject bind:this={projectModal} {projects} />
-<SearchModal bind:this={searchModal} />
+<SearchModal bind:this={searchModal} {projects} />
 
 <style>
 	:root {

--- a/src/routes/(auth)/Navbar.svelte
+++ b/src/routes/(auth)/Navbar.svelte
@@ -9,7 +9,7 @@
 	 * @typedef {Object} Props
 	 * @property {Api.Profile | null} [profile]
 	 * @property {() => void} toggleSidebar
-	 * @property {() => void} openSearch
+	 * @property {() => void} [openSearch]
 	 */
 
 	/** @type {Props} */
@@ -79,11 +79,13 @@
 		<i class="fa-light fa-bars"></i>
 	</div>
 
-	<button type="button" class="search-trigger" onclick={openSearch} aria-label="Search">
-		<i class="fa-solid fa-magnifying-glass"></i>
-		<span class="search-text">Search…</span>
-		<kbd>/</kbd>
-	</button>
+	{#if openSearch}
+		<button type="button" class="search-trigger" onclick={openSearch} aria-label="Search">
+			<i class="fa-solid fa-magnifying-glass"></i>
+			<span class="search-text">Search…</span>
+			<kbd>/</kbd>
+		</button>
+	{/if}
 
 	<div class="flex items-center gap-2 ml-auto">
 		<div class="theme-toggle" role="group" aria-label="Theme">

--- a/src/routes/(auth)/Navbar.svelte
+++ b/src/routes/(auth)/Navbar.svelte
@@ -9,10 +9,11 @@
 	 * @typedef {Object} Props
 	 * @property {Api.Profile | null} [profile]
 	 * @property {() => void} toggleSidebar
+	 * @property {() => void} openSearch
 	 */
 
 	/** @type {Props} */
-	const { profile = null, toggleSidebar } = $props()
+	const { profile = null, toggleSidebar, openSearch } = $props()
 
 	let active = $state(false)
 
@@ -78,6 +79,12 @@
 		<i class="fa-light fa-bars"></i>
 	</div>
 
+	<button type="button" class="search-trigger" onclick={openSearch} aria-label="Search">
+		<i class="fa-solid fa-magnifying-glass"></i>
+		<span class="search-text">Search…</span>
+		<kbd>/</kbd>
+	</button>
+
 	<div class="flex items-center gap-2 ml-auto">
 		<div class="theme-toggle" role="group" aria-label="Theme">
 			<span class="theme-knob" style="transform: translateX({themeIndex * 2}rem)"></span>
@@ -127,6 +134,63 @@
 </nav>
 
 <style>
+	.search-trigger {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		height: 2.25rem;
+		margin-left: 0.75rem;
+		padding: 0 0.5rem 0 0.75rem;
+		min-width: 16rem;
+		background-color: hsl(var(--hsl-base-200));
+		border: 1px solid hsl(var(--hsl-line));
+		border-radius: var(--radius-md);
+		color: hsl(var(--hsl-content) / 0.5);
+		font-size: var(--fs-2);
+		cursor: pointer;
+		transition: border-color var(--timing-faster) ease, background-color var(--timing-faster) ease;
+	}
+
+	.search-trigger:hover {
+		border-color: hsl(var(--hsl-primary) / 0.5);
+		background-color: hsl(var(--hsl-primary) / 0.06);
+	}
+
+	.search-trigger:focus-visible {
+		outline: 2px solid hsl(var(--hsl-primary));
+		outline-offset: 2px;
+	}
+
+	.search-text {
+		margin-right: auto;
+	}
+
+	.search-trigger kbd {
+		display: inline-block;
+		min-width: 1.25rem;
+		padding: 0.0625rem 0.375rem;
+		text-align: center;
+		font-family: inherit;
+		font-size: 0.75rem;
+		line-height: 1.4;
+		color: hsl(var(--hsl-content) / 0.7);
+		background-color: hsl(var(--hsl-base-300));
+		border: 1px solid hsl(var(--hsl-line));
+		border-radius: var(--radius-sm);
+	}
+
+	/* On narrow screens collapse to just the icon. */
+	@media (max-width: 640px) {
+		.search-trigger {
+			min-width: 0;
+		}
+
+		.search-text,
+		.search-trigger kbd {
+			display: none;
+		}
+	}
+
 	.theme-toggle {
 		position: relative;
 		display: inline-flex;

--- a/src/routes/(auth)/SearchModal.svelte
+++ b/src/routes/(auth)/SearchModal.svelte
@@ -2,7 +2,15 @@
 	import { tick } from 'svelte'
 	import { page } from '$app/stores'
 	import { goto } from '$app/navigation'
-	import { navEntries, fetchResourceEntries, filterEntries } from '$lib/search'
+	import { navEntries, projectEntries, fetchResourceEntries, filterEntries } from '$lib/search'
+
+	/**
+	 * @typedef {Object} Props
+	 * @property {Api.Project[]} [projects]
+	 */
+
+	/** @type {Props} */
+	const { projects = [] } = $props()
 
 	const project = $derived($page.url.searchParams.get('project'))
 
@@ -16,10 +24,15 @@
 	let loadedProject = $state(/** @type {?string} */ (null))
 	let resources = $state(/** @type {import('$lib/search').SearchEntry[]} */ ([]))
 
-	const allEntries = $derived(project ? [...navEntries(project), ...resources] : [])
+	// Project entries are first so typing a project name highlights the switch
+	// row before any nav/resource match (intent: "I'm trying to switch project").
+	const allEntries = $derived(project
+		? [...projectEntries(projects, project, $page), ...navEntries(project), ...resources]
+		: [])
 
-	// Empty query → just the nav sections (showing every resource would be a wall
-	// of rows); once the user types, search across nav + fetched resources.
+	// Empty query → just the nav sections (showing every resource — or every
+	// project — would be a wall of rows); typing surfaces projects + nav + fetched
+	// resources together.
 	const base = $derived(search.trim() ? allEntries : (project ? navEntries(project) : []))
 	const filtered = $derived(filterEntries(base, search))
 
@@ -122,7 +135,7 @@
 				onkeydown={onSearchKeydown}
 				oninput={() => highlighted = 0}
 				type="text"
-				placeholder="Search deployments, domains, routes, settings…"
+				placeholder="Search projects, deployments, domains, routes…"
 				autocomplete="off"
 			>
 		</div>

--- a/src/routes/(auth)/SearchModal.svelte
+++ b/src/routes/(auth)/SearchModal.svelte
@@ -1,0 +1,296 @@
+<script>
+	import { tick } from 'svelte'
+	import { page } from '$app/stores'
+	import { goto } from '$app/navigation'
+	import { navEntries, fetchResourceEntries, filterEntries } from '$lib/search'
+
+	const project = $derived($page.url.searchParams.get('project'))
+
+	let isActive = $state(false)
+	let search = $state('')
+	let elSearch = $state(/** @type {?HTMLInputElement} */ (null))
+	let highlighted = $state(0)
+	const rowEls = $state(/** @type {HTMLElement[]} */ ([]))
+
+	let loading = $state(false)
+	let loadedProject = $state(/** @type {?string} */ (null))
+	let resources = $state(/** @type {import('$lib/search').SearchEntry[]} */ ([]))
+
+	const allEntries = $derived(project ? [...navEntries(project), ...resources] : [])
+
+	// Empty query → just the nav sections (showing every resource would be a wall
+	// of rows); once the user types, search across nav + fetched resources.
+	const base = $derived(search.trim() ? allEntries : (project ? navEntries(project) : []))
+	const filtered = $derived(filterEntries(base, search))
+
+	// Group consecutive entries by section for display while keeping the flat
+	// index that drives keyboard highlighting.
+	const grouped = $derived.by(() => {
+		/** @type {{ group: string, items: { entry: import('$lib/search').SearchEntry, index: number }[] }[]} */
+		const out = []
+		filtered.forEach((entry, index) => {
+			let g = out.at(-1)
+			if (!g || g.group !== entry.group) {
+				g = { group: entry.group, items: [] }
+				out.push(g)
+			}
+			g.items.push({ entry, index })
+		})
+		return out
+	})
+
+	// Keep the keyboard-highlighted row scrolled into view as it moves.
+	$effect(() => {
+		rowEls[highlighted]?.scrollIntoView({ block: 'nearest' })
+	})
+
+	export async function open () {
+		search = ''
+		highlighted = 0
+		isActive = true
+		await tick()
+		elSearch?.focus()
+
+		// Fetch the project's resources once per project, lazily on first open.
+		if (project && loadedProject !== project) {
+			loading = true
+			loadedProject = project
+			try {
+				resources = await fetchResourceEntries(project, fetch)
+			} finally {
+				loading = false
+			}
+		}
+	}
+
+	function close () {
+		isActive = false
+		// Release focus so the page-level "/" shortcut can reopen the palette.
+		elSearch?.blur()
+	}
+
+	/**
+	 * @param {import('$lib/search').SearchEntry} entry
+	 */
+	function navigate (entry) {
+		close()
+		goto(entry.href)
+	}
+
+	/**
+	 * Close only when the backdrop itself is clicked, not when a click inside the
+	 * panel bubbles up.
+	 * @param {MouseEvent} e
+	 */
+	function onBackdrop (e) {
+		if (e.target === e.currentTarget) close()
+	}
+
+	/**
+	 * Arrow Up/Down move the highlighted row; Enter opens it; Escape closes.
+	 * @param {KeyboardEvent} e
+	 */
+	function onSearchKeydown (e) {
+		if (e.key === 'Escape') {
+			close()
+			return
+		}
+		if (!filtered.length) return
+		if (e.key === 'ArrowDown') {
+			e.preventDefault()
+			highlighted = Math.min(highlighted + 1, filtered.length - 1)
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault()
+			highlighted = Math.max(highlighted - 1, 0)
+		} else if (e.key === 'Enter') {
+			e.preventDefault()
+			navigate(filtered[highlighted])
+		}
+	}
+</script>
+
+<div class="modal" onclick={onBackdrop} class:is-active={isActive} aria-hidden={!isActive}>
+	<div class="modal-panel">
+		<div class="modal-close" onclick={close} onkeypress={close} tabindex="0" role="button">✕</div>
+		<h4>Search</h4>
+
+		<div class="input -has-icon-left mt-4">
+			<span class="icon -is-left"><i class="fa-solid fa-magnifying-glass"></i></span>
+			<input
+				bind:this={elSearch}
+				bind:value={search}
+				onkeydown={onSearchKeydown}
+				oninput={() => highlighted = 0}
+				type="text"
+				placeholder="Search deployments, domains, routes, settings…"
+				autocomplete="off"
+			>
+		</div>
+
+		<div class="results mt-4">
+			{#if !project}
+				<div class="empty">
+					<i class="fa-solid fa-folder-open"></i>
+					<span>Select a project to search its resources.</span>
+				</div>
+			{:else}
+				{#each grouped as section (section.group)}
+					<div class="group-label">{section.group}</div>
+					{#each section.items as { entry, index } (entry.id)}
+						<div
+							bind:this={rowEls[index]}
+							class="result"
+							class:is-highlighted={index === highlighted}
+							onmouseenter={() => highlighted = index}
+							onclick={() => navigate(entry)}
+							onkeypress={() => navigate(entry)}
+							tabindex="0"
+							role="link">
+							<span class="result-icon"><i class="fa-solid {entry.icon}"></i></span>
+							<span class="result-label">{entry.label}</span>
+							{#if entry.sublabel}
+								<span class="result-sublabel">{entry.sublabel}</span>
+							{/if}
+						</div>
+					{/each}
+				{/each}
+
+				{#if !filtered.length}
+					<div class="empty">
+						{#if loading}
+							<i class="fa-solid fa-spinner fa-spin"></i>
+							<span>Loading resources…</span>
+						{:else}
+							<i class="fa-solid fa-magnifying-glass"></i>
+							<span>No matches for “{search}”.</span>
+						{/if}
+					</div>
+				{:else if loading}
+					<div class="loading-hint">
+						<i class="fa-solid fa-spinner fa-spin"></i> Loading more resources…
+					</div>
+				{/if}
+			{/if}
+		</div>
+
+		<div class="footer-hints">
+			<span><kbd>↑</kbd><kbd>↓</kbd> navigate</span>
+			<span><kbd>↵</kbd> open</span>
+			<span><kbd>esc</kbd> close</span>
+		</div>
+	</div>
+</div>
+
+<style>
+	.modal-panel {
+		box-shadow: 0 15px 15px 0 rgba(43, 43, 43, 0.1);
+		width: 100%;
+		max-width: 42rem;
+	}
+
+	.results {
+		max-height: 420px;
+		overflow-y: auto;
+	}
+
+	.group-label {
+		padding: 0.5rem 0.5rem 0.25rem;
+		font-size: 0.6875rem;
+		font-weight: 600;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: hsl(var(--hsl-content) / 0.45);
+	}
+
+	.result {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.5rem 0.625rem;
+		border-radius: var(--radius-md);
+		cursor: pointer;
+		color: hsl(var(--hsl-content) / 0.85);
+	}
+
+	.result.is-highlighted {
+		background-color: hsl(var(--hsl-primary) / 0.1);
+		color: hsl(var(--hsl-content));
+	}
+
+	.result-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.25rem;
+		font-size: 0.875rem;
+		color: hsl(var(--hsl-content) / 0.55);
+	}
+
+	.result.is-highlighted .result-icon {
+		color: hsl(var(--hsl-primary));
+	}
+
+	.result-label {
+		font-weight: 500;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.result-sublabel {
+		margin-left: auto;
+		padding-left: 1rem;
+		font-size: var(--fs-1);
+		color: hsl(var(--hsl-content) / 0.5);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 50%;
+	}
+
+	.empty {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 2.5rem 1rem;
+		color: hsl(var(--hsl-content) / 0.5);
+		font-size: var(--fs-2);
+	}
+
+	.empty i {
+		font-size: 1.5rem;
+		opacity: 0.6;
+	}
+
+	.loading-hint {
+		padding: 0.5rem 0.625rem;
+		font-size: var(--fs-1);
+		color: hsl(var(--hsl-content) / 0.5);
+	}
+
+	.footer-hints {
+		display: flex;
+		gap: 1rem;
+		margin-top: 0.75rem;
+		padding-top: 0.75rem;
+		border-top: 1px solid hsl(var(--hsl-line));
+		font-size: var(--fs-1);
+		color: hsl(var(--hsl-content) / 0.5);
+	}
+
+	.footer-hints kbd {
+		display: inline-block;
+		min-width: 1.25rem;
+		margin-right: 0.125rem;
+		padding: 0.0625rem 0.3125rem;
+		text-align: center;
+		font-family: inherit;
+		font-size: 0.6875rem;
+		line-height: 1.4;
+		color: hsl(var(--hsl-content) / 0.7);
+		background-color: hsl(var(--hsl-base-200));
+		border: 1px solid hsl(var(--hsl-line));
+		border-radius: var(--radius-sm);
+	}
+</style>

--- a/src/routes/(auth)/Sidebar.svelte
+++ b/src/routes/(auth)/Sidebar.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { page } from '$app/stores'
+	import { projectMenu as projectMenuList } from '$lib/nav'
 
 	/**
 	 * @typedef {Object} Props
@@ -13,101 +14,6 @@
 	const pageMenu = $derived($page.data.menu || '')
 	const project = $derived($page.url.searchParams.get('project'))
 	const projectName = $derived(projects.find((p) => p.project === project)?.name || project)
-
-	/** @type {{ id: string, title: string, icon: string, link: string, preview?: boolean }[]} */
-	const projectMenuList = [
-		{
-			id: 'dashboard',
-			title: 'Dashboard',
-			icon: 'fa-columns',
-			link: '/'
-		},
-		{
-			id: 'deployment',
-			title: 'Deployments',
-			icon: 'fa-rocket',
-			link: '/deployment'
-		},
-		{
-			id: 'domain',
-			title: 'Domains',
-			icon: 'fa-globe',
-			link: '/domain'
-		},
-		{
-			id: 'route',
-			title: 'Routes',
-			icon: 'fa-router',
-			link: '/route'
-		},
-		{
-			id: 'waf',
-			title: 'Firewall',
-			icon: 'fa-shield-halved',
-			link: '/waf',
-			preview: true
-		},
-		{
-			id: 'workload-identity',
-			title: 'Workload Identities',
-			icon: 'fa-network-wired',
-			link: '/workload-identity'
-		},
-		{
-			id: 'disk',
-			title: 'Disks',
-			icon: 'fa-hdd',
-			link: '/disk'
-		},
-		{
-			id: 'pull-secret',
-			title: 'Pull Secrets',
-			icon: 'fa-key',
-			link: '/pull-secret'
-		},
-		{
-			id: 'env-group',
-			title: 'Env Groups',
-			icon: 'fa-cog',
-			link: '/env-group'
-		},
-		{
-			id: 'role',
-			title: 'Roles',
-			icon: 'fa-user-tag',
-			link: '/role'
-		},
-		{
-			id: 'role.users',
-			title: 'Users',
-			icon: 'fa-users',
-			link: '/role/users'
-		},
-		{
-			id: 'service-account',
-			title: 'Service Accounts',
-			icon: 'fa-user-lock',
-			link: '/service-account'
-		},
-		{
-			id: 'dropbox',
-			title: 'Dropbox',
-			icon: 'fa-box-open',
-			link: '/dropbox'
-		},
-		{
-			id: 'registry',
-			title: 'Registry',
-			icon: 'fa-warehouse-full',
-			link: '/registry'
-		},
-		{
-			id: 'audit-log',
-			title: 'Audit Logs',
-			icon: 'fa-clipboard-list',
-			link: '/audit-log'
-		}
-	]
 </script>
 
 <style>

--- a/tests/search.spec.js
+++ b/tests/search.spec.js
@@ -1,0 +1,86 @@
+import { test, expect, setMocks } from './helpers.js'
+import { sampleDeployment } from './fixtures/mocks.js'
+
+test.describe('global search palette', () => {
+	test('"/" opens the palette on a project page and shows the nav sections', async ({ page }) => {
+		await page.goto('/deployment?project=test-project')
+		await expect(page.locator('.content-wrapper').getByRole('heading', { name: 'Deployments' })).toBeVisible()
+		await expect(page.locator('.modal.is-active')).toHaveCount(0)
+
+		await page.keyboard.press('/')
+		const dialog = page.locator('.modal.is-active')
+		await expect(dialog).toBeVisible()
+		// The global palette — not the project picker.
+		await expect(dialog.getByPlaceholder(/Search deployments, domains/)).toBeFocused()
+		// Empty query → "Go to" nav sections only.
+		await expect(dialog.getByText('Go to', { exact: false })).toBeVisible()
+		await expect(dialog.getByRole('link', { name: 'Deployments' })).toBeVisible()
+
+		await page.keyboard.press('Escape')
+		await expect(page.locator('.modal.is-active')).toHaveCount(0)
+	})
+
+	test('typing surfaces fetched resources; clicking navigates to the detail route', async ({ page }) => {
+		await setMocks({
+			'deployment.list': { ok: true, result: { items: [sampleDeployment] } },
+			// The destination route's loader needs deployment.get to succeed,
+			// otherwise SvelteKit cancels the navigation and the URL won't change.
+			'deployment.get': { ok: true, result: sampleDeployment }
+		})
+
+		await page.goto('/deployment?project=test-project')
+		await page.keyboard.press('/')
+		const dialog = page.locator('.modal.is-active')
+		await expect(dialog).toBeVisible()
+
+		await dialog.getByPlaceholder(/Search deployments, domains/).fill('web')
+		// The resource row from deployment.list, with its location as sublabel.
+		const webRow = dialog.getByRole('link', { name: /web/ }).first()
+		await expect(webRow).toBeVisible()
+		await expect(dialog.getByText('gke', { exact: false })).toBeVisible()
+
+		await webRow.click()
+		await expect(page).toHaveURL(/\/deployment\/metrics\?project=test-project&location=gke&name=web/)
+		await expect(page.locator('.modal.is-active')).toHaveCount(0)
+	})
+
+	test('"/" is ignored while typing in a text field', async ({ page }) => {
+		await page.goto('/deployment?project=test-project')
+		// Inject a focused text field so the global "/" handler sees a typing target.
+		await page.evaluate(() => {
+			const i = document.createElement('input')
+			i.id = '__probe'; i.type = 'text'
+			document.body.appendChild(i); i.focus()
+		})
+		await page.keyboard.press('/')
+		await expect(page.locator('.modal.is-active')).toHaveCount(0)
+		await expect(page.locator('#__probe')).toHaveValue('/')
+	})
+
+	test('does not open the global palette on /project (project picker owns "/")', async ({ page }) => {
+		await page.goto('/project')
+		await expect(page.locator('.content-wrapper').getByRole('heading', { name: 'Projects' })).toBeVisible()
+
+		// Page must have hydrated before we press "/", so click the trigger first.
+		await page.locator('.content-wrapper').getByRole('button', { name: /Search projects/ }).click()
+		await expect(page.locator('.modal.is-active')).toBeVisible()
+		await page.keyboard.press('Escape')
+		await expect(page.locator('.modal.is-active')).toHaveCount(0)
+
+		await page.keyboard.press('/')
+		// Exactly one modal opens — the project picker — not also the global palette.
+		await expect(page.locator('.modal.is-active')).toHaveCount(1)
+		await expect(page.locator('.modal.is-active').getByPlaceholder(/Search projects/)).toBeFocused()
+		// The global palette's placeholder must not appear in any open modal
+		// (its element is always in the DOM, just hidden via `.is-active`).
+		await expect(page.locator('.modal.is-active').getByPlaceholder(/Search deployments, domains/)).toHaveCount(0)
+	})
+
+	test('navbar search trigger is hidden when no project is selected', async ({ page }) => {
+		await page.goto('/project')
+		await expect(page.locator('.content-wrapper').getByRole('heading', { name: 'Projects' })).toBeVisible()
+		// The trigger lives in the navbar (outside `.content-wrapper`), so a
+		// global "Search" button query should turn up nothing here.
+		await expect(page.getByRole('button', { name: 'Search', exact: true })).toHaveCount(0)
+	})
+})

--- a/tests/search.spec.js
+++ b/tests/search.spec.js
@@ -1,5 +1,5 @@
 import { test, expect, setMocks } from './helpers.js'
-import { sampleDeployment } from './fixtures/mocks.js'
+import { defaultProject, sampleDeployment } from './fixtures/mocks.js'
 
 test.describe('global search palette', () => {
 	test('"/" opens the palette on a project page and shows the nav sections', async ({ page }) => {
@@ -11,7 +11,7 @@ test.describe('global search palette', () => {
 		const dialog = page.locator('.modal.is-active')
 		await expect(dialog).toBeVisible()
 		// The global palette — not the project picker.
-		await expect(dialog.getByPlaceholder(/Search deployments, domains/)).toBeFocused()
+		await expect(dialog.getByPlaceholder(/Search projects, deployments/)).toBeFocused()
 		// Empty query → "Go to" nav sections only.
 		await expect(dialog.getByText('Go to', { exact: false })).toBeVisible()
 		await expect(dialog.getByRole('link', { name: 'Deployments' })).toBeVisible()
@@ -33,7 +33,7 @@ test.describe('global search palette', () => {
 		const dialog = page.locator('.modal.is-active')
 		await expect(dialog).toBeVisible()
 
-		await dialog.getByPlaceholder(/Search deployments, domains/).fill('web')
+		await dialog.getByPlaceholder(/Search projects, deployments/).fill('web')
 		// The resource row from deployment.list, with its location as sublabel.
 		const webRow = dialog.getByRole('link', { name: /web/ }).first()
 		await expect(webRow).toBeVisible()
@@ -73,7 +73,32 @@ test.describe('global search palette', () => {
 		await expect(page.locator('.modal.is-active').getByPlaceholder(/Search projects/)).toBeFocused()
 		// The global palette's placeholder must not appear in any open modal
 		// (its element is always in the DOM, just hidden via `.is-active`).
-		await expect(page.locator('.modal.is-active').getByPlaceholder(/Search deployments, domains/)).toHaveCount(0)
+		await expect(page.locator('.modal.is-active').getByPlaceholder(/Search projects, deployments/)).toHaveCount(0)
+	})
+
+	test('typing a project name surfaces it as a "Switch project" row and Enter switches', async ({ page }) => {
+		const otherProject = { ...defaultProject, id: '2', project: 'staging', name: 'Staging' }
+		await setMocks({
+			'project.list': { ok: true, result: { items: [defaultProject, otherProject] } }
+		})
+
+		await page.goto('/deployment?project=test-project')
+		await page.keyboard.press('/')
+		const dialog = page.locator('.modal.is-active')
+		await expect(dialog).toBeVisible()
+
+		await dialog.getByPlaceholder(/Search projects, deployments/).fill('staging')
+		// The other project shows up under "Switch project" — the current project
+		// is intentionally excluded.
+		await expect(dialog.getByText('Switch project', { exact: false })).toBeVisible()
+		const switchRow = dialog.locator('.result').filter({ hasText: 'Staging' }).first()
+		await expect(switchRow).toBeVisible()
+		// Current project should NOT appear (filtered out at source).
+		await expect(dialog.locator('.result').filter({ hasText: 'Test Project' })).toHaveCount(0)
+
+		await switchRow.click()
+		await expect(page).toHaveURL(/[?&]project=staging\b/)
+		await expect(page.locator('.modal.is-active')).toHaveCount(0)
 	})
 
 	test('navbar search trigger is hidden when no project is selected', async ({ page }) => {


### PR DESCRIPTION
## What

Press <kbd>/</kbd> anywhere inside a project to open a command palette that searches **across all of the project's resources and navigation** in one place — deployments, domains, routes, firewall zones, disks, pull secrets, env groups, roles, service accounts, workload identities, registry repositories, plus every sidebar section.

## How it works

- **No new backend API.** The palette fans out to the existing project-scoped `*.list` endpoints in parallel on open and flattens the results into search entries. Endpoints that fail (e.g. no permission) are skipped silently so one forbidden resource never blanks the palette. Results are cached per project for the session.
- **`SearchModal.svelte`** is modeled on the existing `ModalSelectProject` pattern: autofocus, token AND-match filtering, keyboard navigation (↑/↓ to move, ↵ to open, Esc to close), and results grouped by type. With an empty query it shows the nav sections ("Go to"); once you type, it searches across nav + fetched resources.
- **`lib/nav.js`** extracts the project menu so the sidebar and the palette's "Go to" section share a single source of truth (no drift).
- **Navbar** gets a discoverable search trigger with a `/` hint; the `(auth)` layout wires the window-level `/` shortcut, which is ignored while the user is typing in an input/textarea/select/contenteditable.

## Verification

`bun lint` and `bun check` both pass with zero errors. Verified locally against mock fixtures (`dev:mock`) with Playwright:

- `/` opens the palette and is **not** typed into the field
- `/` is ignored while a text field is focused (the `/` types normally there)
- ↵ on a highlighted result navigates to the correct detail route and closes the palette
- light + dark themes render correctly

## Notes / follow-ups

- Audit logs and dropbox files are intentionally **not** indexed as resources (no per-item detail route); they remain reachable as "Go to" sections.
- If per-project resource counts ever grow large enough that the fan-out hurts, this is the point to introduce a single server-side `project.search` endpoint — the client shape (`SearchEntry`) wouldn't need to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)