### PR TITLE
feat: add /healthz endpoint for k8s probes

### DIFF
--- a/src/routes/healthz/+server.js
+++ b/src/routes/healthz/+server.js
@@ -1,0 +1,8 @@
+export const prerender = false
+
+export function GET () {
+	return new Response('ok', {
+		status: 200,
+		headers: { 'cache-control': 'no-store' }
+	})
+}


### PR DESCRIPTION
Adds a lightweight `GET /healthz` route for Kubernetes liveness/readiness probes.

## Why

The console currently has no health endpoint. None of the existing routes work as a probe target:

- `/` redirects to `/auth/signin` when no token cookie is present (it's inside the `(auth)` group).
- `/auth/signin` is a full SSR page render — too heavy and couples liveness to the UI.
- `/api/[fn]` is a POST-only proxy that forwards to `API_ENDPOINT`, so using it would tie liveness to backend health (anti-pattern — one backend blip restarts the whole frontend fleet).

## What

`src/routes/healthz/+server.js` — a tiny `GET` handler that returns `200 ok` with `cache-control: no-store`. It sits at the top level (outside the `(auth)` group) so no auth redirect happens, and it makes no upstream calls.

## Example probe config

```yaml
livenessProbe:
  httpGet: { path: /healthz, port: 3000 }
  periodSeconds: 10
  failureThreshold: 3
readinessProbe:
  httpGet: { path: /healthz, port: 3000 }
  periodSeconds: 5
```

Since this app is a pure frontend (all real work is the `/api/[fn]` proxy), liveness and readiness can share the same endpoint — there's no warm-up state or local dependency to gate readiness on. If we later want readiness to fail when `API_ENDPOINT` is unreachable, we can split out a `/readyz` that probes the backend.

## Verification

- `bun lint` ✅
- `bun check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)