### PR TITLE
fix: anchor audit log date picker to right edge so it stays in viewport

### DIFF
--- a/src/routes/(auth)/(project)/audit-log/+page.svelte
+++ b/src/routes/(auth)/(project)/audit-log/+page.svelte
@@ -308,7 +308,7 @@
 					isRange
 					isMultipane
 					showPresets
-					align="left"
+					align="right"
 					includeFont={false}
 				>
 					<button type="button" class="date-range-trigger" onclick={toggleDatePicker}>


### PR DESCRIPTION
## Problem

The Date range filter on the Audit Logs page lives in the rightmost column of the 3-column filter row. With `align="left"` (the default), the `@svelte-plugins/datepicker` opens its dropdown with `left: 0` anchored to the trigger. Because the picker is `isMultipane` + `showPresets`, the dropdown is ~800 px wide — it pops out past the right edge of the viewport on every common width.

Measured at 1280×800: picker spans x=836 → x=1638, **358 px past the right edge**. The second month pane and most of the first are unreachable.

## Fix

Switch the single `align` prop from `"left"` to `"right"`. The library then sets `left: auto; right: 0` on the container, anchoring the picker's right edge to the trigger column's right edge and growing leftward — fully inside the panel.

## Verification

- Visual: opened the picker at 1024 / 1280 / 1440 / 1920 px viewports — no overflow on either side in any case (right edges at 967 / 1081 / 1081 / 1081 respectively, well within the viewport). Below 800 px the library already stacks panes into a single column, so right-anchoring stays in-bounds there too.
- `bun lint` ✅
- `bun check` ✅
- `bun run test tests/audit-log.spec.js` — 3/3 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)