### PR TITLE
Add a Docs link to the sidebar social row

### DIFF
--- a/src/routes/(auth)/Sidebar.svelte
+++ b/src/routes/(auth)/Sidebar.svelte
@@ -227,6 +227,9 @@
 		</div>
 		<div class="flex justify-between items-center flex-col">
 			<div class="social flex justify-end items-center gap-2 w-full px-4">
+				<a href="https://docs.deploys.app" target="_blank" rel="external" class="flex justify-center items-center rounded w-8 h-8" aria-label="Read the docs">
+					<i class="fa-solid fa-book-open"></i>
+				</a>
 				<a href="https://github.com/deploys-app" target="_blank" rel="external" class="flex justify-center items-center rounded w-8 h-8" aria-label="Go to GitHub">
 					<i class="fa-brands fa-github"></i>
 				</a>


### PR DESCRIPTION
The docs site is now live at https://docs.deploys.app. Surface it from the
console so users find it without having to know the URL.

Adds a book-open icon next to GitHub / Discord / Email at the bottom of the
project sidebar — placed first because it's the more useful destination
day-to-day.

\`bun lint\` and \`bun check\` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)