### PR TITLE
Center the navbar search icon on mobile

### DIFF
--- a/src/routes/(auth)/Navbar.svelte
+++ b/src/routes/(auth)/Navbar.svelte
@@ -181,10 +181,13 @@
 		border-radius: var(--radius-sm);
 	}
 
-	/* On narrow screens collapse to just the icon. */
+	/* On narrow screens collapse to a square icon-only button. */
 	@media (max-width: 640px) {
 		.search-trigger {
 			min-width: 0;
+			width: 2.25rem;
+			padding: 0;
+			justify-content: center;
 		}
 
 		.search-text,


### PR DESCRIPTION
At ≤640px the navbar search trigger collapses to icon-only via the existing
media query that hides \`.search-text\` and the \`/\` kbd. But the desktop's
asymmetric padding (\`0 0.5rem 0 0.75rem\`) stayed in effect, leaving the
magnifying-glass icon visibly pulled to the right of the button.

Setting \`padding: 0\`, \`width: 2.25rem\` (matching the existing 2.25rem
height), and \`justify-content: center\` inside the same media block gives a
clean square button with the icon centered. Desktop (≥641px) unaffected.

\`bun lint\` and \`bun check\` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)