### PR TITLE
feat: infinite-scroll the audit log list

### DIFF
--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -433,26 +433,34 @@ const serviceAccounts = [
 	}
 ]
 
-const auditLogItems = [
-	{
-		id: 1042,
-		resource: { type: 'Deployment', id: 'web', name: 'web', locationId: LOCATION_ID },
-		actor: { email: USER_EMAIL, type: 'User' },
-		action: 'deployment.deploy',
-		outcome: 'success',
-		detail: 'Deployed revision 7',
-		createdAt: CREATED_AT
-	},
-	{
-		id: 1041,
-		resource: { type: 'Domain', id: 'acme.example.com', name: 'acme.example.com', locationId: LOCATION_ID },
-		actor: { email: USER_EMAIL, type: 'User' },
-		action: 'domain.create',
-		outcome: 'success',
-		detail: 'Added domain acme.example.com',
-		createdAt: CREATED_AT
+// Synthesize enough rows to exercise the infinite-scroll cursor offline. The
+// real backend orders `id desc`; we mirror that here so the array is already in
+// the order the API would return.
+const auditLogItems = (() => {
+	const samples = [
+		{ resource: { type: 'Deployment', id: 'web', name: 'web' }, action: 'deployment.deploy', detail: 'Deployed revision' },
+		{ resource: { type: 'Domain', id: 'acme.example.com', name: 'acme.example.com' }, action: 'domain.create', detail: 'Added domain' },
+		{ resource: { type: 'Disk', id: 'data', name: 'data' }, action: 'disk.create', detail: 'Created disk' },
+		{ resource: { type: 'Role', id: 'admin', name: 'admin' }, action: 'role.update', detail: 'Updated role' },
+		{ resource: { type: 'PullSecret', id: 'ghcr', name: 'ghcr' }, action: 'pullSecret.create', detail: 'Added pull secret' },
+		{ resource: { type: 'EnvGroup', id: 'web-env', name: 'web-env' }, action: 'envGroup.update', detail: 'Updated env group' }
+	]
+	const t0 = new Date(CREATED_AT).getTime()
+	const items = []
+	for (let i = 0; i < 137; i++) {
+		const s = samples[i % samples.length]
+		items.push({
+			id: 1042 - i,
+			resource: { ...s.resource, locationId: LOCATION_ID },
+			actor: { email: USER_EMAIL, type: 'User' },
+			action: s.action,
+			outcome: i % 11 === 0 ? 'failure' : 'success',
+			detail: `${s.detail} (#${1042 - i})`,
+			createdAt: new Date(t0 - i * 60_000).toISOString()
+		})
 	}
-]
+	return items
+})()
 
 const repositories = [
 	{ name: 'acme/web', size: 184320000, createdAt: CREATED_AT },
@@ -708,7 +716,21 @@ const handlers = {
 		expiresAt: '2026-06-02T00:00:00Z'
 	}),
 
-	'auditLog.list': (args) => list(auditLogItems.slice(0, args?.limit ?? auditLogItems.length)),
+	'auditLog.list': (args) => {
+		let arr = auditLogItems
+		if (args?.before) {
+			const cutoff = new Date(args.before).getTime()
+			arr = arr.filter((it) => new Date(it.createdAt).getTime() < cutoff)
+		}
+		if (args?.after) {
+			const lo = new Date(args.after).getTime()
+			arr = arr.filter((it) => new Date(it.createdAt).getTime() >= lo)
+		}
+		if (args?.resourceType) arr = arr.filter((it) => it.resource.type.toLowerCase() === String(args.resourceType).toLowerCase())
+		if (args?.actor) arr = arr.filter((it) => it.actor.email === args.actor)
+		if (args?.outcome) arr = arr.filter((it) => it.outcome === args.outcome)
+		return list(arr.slice(0, args?.limit ?? arr.length))
+	},
 
 	'location.list': () => list(locations),
 	'location.get': (args) => ok(locations.find((l) => l.id === args?.location) ?? locations[0]),

--- a/src/routes/(auth)/(project)/audit-log/+page.svelte
+++ b/src/routes/(auth)/(project)/audit-log/+page.svelte
@@ -4,16 +4,20 @@
 	import { goto } from '$app/navigation'
 	import { DatePicker } from '@svelte-plugins/datepicker'
 	import dayjs from 'dayjs'
+	import api from '$lib/api'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import OutcomeBadge from '$lib/components/OutcomeBadge.svelte'
 	import Select from '$lib/components/Select.svelte'
 	import * as format from '$lib/format'
 
+	// Must match the LIMIT used by +page.js so a "full" first page implies more
+	// rows are available on the server.
+	const PAGE_SIZE = 50
+
 	const { data } = $props()
 
 	const project = $derived(data.project)
-	const items = $derived(data.items)
 	const error = $derived(data.error)
 
 	const RESOURCE_TYPES = [
@@ -46,6 +50,94 @@
 
 	let isDatePickerOpen = $state(false)
 	let applying = $state(false)
+
+	// Infinite-scroll state. `data.items` from the loader is just the first
+	// page; we mirror it locally so we can append on scroll, and re-sync it
+	// whenever the loader runs again (filter / project change).
+	/** @type {Api.AuditLogItem[]} */
+	let items = $state([])
+	let hasMore = $state(false)
+	let loadingMore = $state(false)
+	let loadMoreError = $state('')
+	// Cursor for the next page: the `createdAt` of the oldest item currently
+	// loaded. We pass it as `before` on the next request. The backend uses a
+	// strict less-than, so the boundary item is not duplicated. Two rows with
+	// the same microsecond timestamp could be missed, which is acceptable for
+	// audit logs (very low chance of collision).
+	let cursor = $state('')
+	// Token bumped on every re-sync so an in-flight loadMore from the previous
+	// filter can be discarded.
+	let loadToken = 0
+
+	$effect(() => {
+		// Depending on `data.items` causes this to re-run on every loader update
+		// (URL/filter change).
+		const fresh = data.items
+		loadToken += 1
+		items = fresh
+		hasMore = fresh.length >= PAGE_SIZE
+		cursor = fresh.length ? fresh[fresh.length - 1].createdAt : ''
+		loadMoreError = ''
+		loadingMore = false
+	})
+
+	/** @type {HTMLElement | null} */
+	let sentinel = $state(null)
+	$effect(() => {
+		if (!sentinel) return
+		const io = new IntersectionObserver((entries) => {
+			if (entries[0].isIntersecting) loadMore()
+		}, { rootMargin: '300px' })
+		io.observe(sentinel)
+		return () => io.disconnect()
+	})
+
+	/**
+	 * @param {string} v
+	 * @returns {string | undefined}
+	 */
+	function toRFC3339 (v) {
+		if (!v) return undefined
+		const d = new Date(v)
+		if (isNaN(d.getTime())) return undefined
+		return d.toISOString()
+	}
+
+	async function loadMore () {
+		if (loadingMore || !hasMore || !cursor) return
+		const token = loadToken
+		loadingMore = true
+		loadMoreError = ''
+		try {
+			/** @type {Api.Response<Api.List<Api.AuditLogItem>>} */
+			const res = await api.invoke('auditLog.list', {
+				project,
+				resourceType: data.filters.resourceType,
+				actor: data.filters.actor,
+				outcome: data.filters.outcome,
+				after: toRFC3339(data.filters.after),
+				before: cursor,
+				limit: PAGE_SIZE
+			}, fetch)
+			if (token !== loadToken) return // filters changed; discard
+			if (res.error) {
+				loadMoreError = res.error.message || 'Failed to load more'
+				return
+			}
+			const next = res.result?.items ?? []
+			items = [...items, ...next]
+			hasMore = next.length >= PAGE_SIZE
+			if (next.length > 0) {
+				cursor = next[next.length - 1].createdAt
+			}
+		} catch (e) {
+			if (token === loadToken) {
+				loadMoreError = e instanceof Error ? e.message : 'Failed to load more'
+			}
+		} finally {
+			if (token === loadToken) loadingMore = false
+		}
+	}
 
 	const dateRangeLabel = $derived.by(() => {
 		const s = form.startDate ? dayjs(form.startDate).format('YYYY-MM-DD') : ''
@@ -269,12 +361,32 @@
 		color: hsl(var(--hsl-content) / 0.7);
 		vertical-align: middle;
 	}
+
+	.loadmore-row > td {
+		padding: 0;
+	}
+
+	.loadmore-sentinel {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		padding: 1rem 0.75rem;
+		color: hsl(var(--hsl-content) / 0.6);
+		font-size: 0.875rem;
+	}
+
+	.loadmore-error {
+		color: hsl(var(--hsl-negative));
+	}
 </style>
 
 <div class="page-head">
 	<div>
 		<h4><strong>Audit Logs</strong></h4>
-		<p class="page-sub">{items.length} {items.length === 1 ? 'event' : 'events'}</p>
+		<p class="page-sub">
+			{items.length} {items.length === 1 ? 'event' : 'events'}{hasMore ? '+' : ''}
+		</p>
 	</div>
 </div>
 <div class="panel is-level-300">
@@ -389,6 +501,22 @@
 				{/each}
 				<NoDataRow span={6} list={items} />
 				<ErrorRow span={6} {error} />
+				{#if hasMore || loadingMore || loadMoreError}
+					<tr class="loadmore-row">
+						<td colspan="6">
+							<div bind:this={sentinel} class="loadmore-sentinel">
+								{#if loadingMore}
+									<i class="fa-solid fa-circle-notch fa-spin"></i>
+									<span>Loading more…</span>
+								{:else if loadMoreError}
+									<span class="loadmore-error">{loadMoreError}</span>
+									<button type="button" class="button is-variant-tertiary is-size-small"
+										onclick={loadMore}>Retry</button>
+								{/if}
+							</div>
+						</td>
+					</tr>
+				{/if}
 			</tbody>
 		</table>
 	</div>


### PR DESCRIPTION
## Summary

The audit log page only ever showed the first 50 rows — there was no way to see older events without narrowing the date range. This PR adds cursor-based infinite scroll so older entries stream in as the user scrolls.

## How it works

- Local `items` state, seeded from the loader's first page. An `$effect` re-syncs on every loader update (URL / filter change), and a bumped `loadToken` discards stale in-flight responses so changing a filter mid-load can't pollute the new list.
- An `IntersectionObserver` watches a sentinel row at the bottom of the table (`rootMargin: 300px`) and calls `loadMore()`, which posts `auditLog.list` with `before = cursor` (the oldest loaded item's `createdAt`) plus the current filters. New rows are appended; `hasMore` flips off when a page returns fewer than `PAGE_SIZE` rows.
- The sentinel row shows a spinner while loading and an inline error + Retry on failure. The page-head count gains a trailing `+` while more rows are still available (`137 events+` vs. `137 events`).

## Trade-off

The backend exposes only time-based filters (`before` / `after`) — no `idBefore` cursor — so the cursor is `created_at` with the backend's strict less-than. Two audit rows sharing the same microsecond timestamp could theoretically be skipped at a page boundary. For audit logs that collision is vanishingly rare and the alternative (changing the api / apiserver repos) felt out of scope here. If it ever bites, the clean fix is adding `idBefore` to `AuditLogList` in the `api` package and threading it through the apiserver query.

## Offline / mock

The mock fixture only had 2 rows, which couldn't exercise the scroll. Extended to 137 generated rows and taught the `auditLog.list` mock to honour `before` / `after` / `resourceType` / `actor` / `outcome` so the feature is exercisable via `bun dev:mock`.

## Verification

- `bun lint` — clean
- `bun check` — 668 files, 0 errors, 0 warnings
- Manual: `bun dev:mock`, open /audit-log, scroll → next page loads near bottom; change a filter → list resets cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)