### PR TITLE
feat(deployment): redesign Detail / Metric / Revision / Events / Header

### DIFF
--- a/src/lib/components/LineChart.svelte
+++ b/src/lib/components/LineChart.svelte
@@ -287,6 +287,15 @@
 	.chart {
 		position: relative;
 		width: 100%;
+		/* The SVG inside is sized via JS (`width={width}` attribute), which gives
+		   it an intrinsic min-content size equal to its current pixel width. Without
+		   `min-width: 0` the chart container is held open against its parent at
+		   that intrinsic size — the grid cell shrinks underneath but `.chart` does
+		   not, ResizeObserver never sees a smaller contentRect, and the SVG never
+		   re-renders. `overflow: hidden` clips the brief transient where the SVG
+		   still has its previous (larger) width between resize and re-render. */
+		min-width: 0;
+		overflow: hidden;
 	}
 
 	.surface {

--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -149,13 +149,17 @@ function deployment (project = 'acme') {
 			limits: { cpu: '500m', memory: '512Mi' }
 		},
 		sidecars: [],
-		url: 'https://web.acme.rcf2.deploys.app',
-		internalUrl: 'http://web.acme.svc.cluster.local',
+		// Hostnames only — both the Detail and Deployment pages prepend the
+		// scheme themselves.
+		url: 'web.acme.rcf2.deploys.app',
+		internalUrl: 'web.acme.svc.cluster.local',
 		// Wired to src/routes/api/mock-logs/+server.js, which streams synthetic
 		// SSE only when MOCK_API is set. The token query param is there so the
 		// page's `${logUrl}&type=text&raw=1` concatenation produces valid URLs.
 		logUrl: '/api/mock-logs?t=mock',
-		eventUrl: '',
+		// Mock pod-event feed (src/routes/api/mock-events/+server.js), so the
+		// deployment Events tab is exercisable offline too.
+		eventUrl: '/api/mock-events?t=mock',
 		podsUrl: '',
 		statusUrl: HEALTHY_STATUS_URL,
 		address: '203.0.113.10',

--- a/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
@@ -10,9 +10,9 @@
 	const deployment = $derived(data.deployment)
 
 	const tabs = [
-		{ label: 'Metric', path: '/deployment/metrics' },
+		{ label: 'Metrics', path: '/deployment/metrics' },
 		{ label: 'Details', path: '/deployment/detail' },
-		{ label: 'Revision', path: '/deployment/revision' },
+		{ label: 'Revisions', path: '/deployment/revision' },
 		{ label: 'Logs', path: '/deployment/logs' },
 		{ label: 'Events', path: '/deployment/events' }
 	]

--- a/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
@@ -46,7 +46,12 @@
 
 <Header {deployment} invalidate={() => api.invalidate('deployment.get')} />
 
-<div class="panel is-level-300 grid gap-6">
+<!-- grid-cols-1 (= `grid-template-columns: repeat(1, minmax(0, 1fr))`) lets
+     wide children (Metrics chart cards, Logs/Events scan-line surfaces)
+     shrink with the viewport. Without it, `grid-auto-columns: auto` would
+     size the implicit column to the children's max-content and push the
+     page past the viewport on narrow / iPhone-sized screens. -->
+<div class="panel is-level-300 grid grid-cols-1 gap-6">
 	<div class="tabs is-variant-underline w-full flex-col lg:flex-row">
 		{#each tabs as t (t.path)}
 			<a class="tab-button" class:is-active={$page.url.pathname === t.path} href={tabHref(t.path)}>

--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -90,6 +90,7 @@
 	}
 
 	.rail__brand {
+		margin: 0;
 		font-weight: 600;
 		color: var(--rail-fg);
 		font-size: 0.9rem;
@@ -316,14 +317,27 @@
 		overflow-wrap: anywhere;
 	}
 
+	/* Empty state — matches the look of the project's NoDataRow component so
+	   "no env groups" / "no mounts" reads the same as any other empty list. */
 	.empty {
-		padding: 0.85rem 1rem;
-		font-family: var(--ffml-primary);
-		font-size: 0.8125rem;
-		color: hsl(var(--hsl-content) / 0.5);
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
 		text-align: center;
-		border: 1px dashed hsl(var(--hsl-content) / 0.12);
-		border-radius: 6px;
+		gap: 0.3rem;
+		padding: 2.5rem 1rem;
+	}
+
+	.empty__icon {
+		font-size: 1.5rem;
+		color: hsl(var(--hsl-content) / 0.3);
+		margin-bottom: 0.35rem;
+	}
+
+	.empty__msg {
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.75);
 	}
 
 	/* sidecar list inside a spec value */
@@ -381,7 +395,7 @@
 <!-- ─── DETAILS shell ─── -->
 <div class="shell">
 	<header class="rail">
-		<span class="rail__brand">Details</span>
+		<h6 class="rail__brand">Details</h6>
 		<div class="rail__stats">
 			<span class="stat">
 				<span class="stat__unit">Revision</span>
@@ -664,7 +678,7 @@
 <!-- ─── ENV GROUPS shell ─── -->
 <div class="shell">
 	<header class="rail">
-		<span class="rail__brand">Env Groups</span>
+		<h6 class="rail__brand">Env Groups</h6>
 		<div class="rail__stats">
 			<span class="stat">
 				<span class="stat__value">{(deployment.envGroups || []).length}</span>
@@ -678,13 +692,16 @@
 				<div class="chips">
 					{#each deployment.envGroups as name (name)}
 						<button type="button" class="chip" onclick={() => viewEnvGroup(name)}>
-							<i class="fa-solid fa-layer-group"></i>
+							<i class="fa-solid fa-layer-group" aria-hidden="true"></i>
 							{name}
 						</button>
 					{/each}
 				</div>
 			{:else}
-				<div class="empty">No env groups attached.</div>
+				<div class="empty">
+					<i class="fa-solid fa-inbox empty__icon" aria-hidden="true"></i>
+					<span class="empty__msg">Nothing here yet</span>
+				</div>
 			{/if}
 		</section>
 	</div>
@@ -693,7 +710,7 @@
 <!-- ─── ENV VARS shell ─── -->
 <div class="shell">
 	<header class="rail">
-		<span class="rail__brand">Env Vars</span>
+		<h6 class="rail__brand">Env Vars</h6>
 		<div class="rail__stats">
 			<span class="stat">
 				<span class="stat__value">{envEntries.length}</span>
@@ -723,7 +740,10 @@
 					{/each}
 				</div>
 			{:else}
-				<div class="empty">no environment variables</div>
+				<div class="empty">
+					<i class="fa-solid fa-inbox empty__icon" aria-hidden="true"></i>
+					<span class="empty__msg">Nothing here yet</span>
+				</div>
 			{/if}
 		</section>
 	</div>
@@ -732,7 +752,7 @@
 <!-- ─── MOUNT DATA shell ─── -->
 <div class="shell">
 	<header class="rail">
-		<span class="rail__brand">Mount Data</span>
+		<h6 class="rail__brand">Mount Data</h6>
 		<div class="rail__stats">
 			<span class="stat">
 				<span class="stat__value">{mountEntries.length}</span>
@@ -752,7 +772,10 @@
 					{/each}
 				</div>
 			{:else}
-				<div class="empty">no mounted data</div>
+				<div class="empty">
+					<i class="fa-solid fa-inbox empty__icon" aria-hidden="true"></i>
+					<span class="empty__msg">Nothing here yet</span>
+				</div>
 			{/if}
 		</section>
 	</div>

--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -52,26 +52,8 @@
 		})
 	}
 
-	// Deterministic hue for env group chips, hashed from the name so the
-	// same group keeps the same colour as the user navigates around.
-	const CHIP_HUES = [355, 28, 48, 142, 175, 205, 260, 312]
-	/** @param {string} s */
-	function chipHue (s) {
-		let h = 0
-		for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0
-		return CHIP_HUES[Math.abs(h) % CHIP_HUES.length]
-	}
-
 	const envEntries = $derived(Object.entries(deployment.env || {}))
 	const mountEntries = $derived(Object.entries(deployment.mountData || {}))
-
-	const statusTone = $derived(
-		deployment.status === 'success'
-			? 'positive'
-			: deployment.status === 'pending'
-				? 'warn'
-				: 'negative'
-	)
 </script>
 
 <style>
@@ -96,30 +78,28 @@
 	.rail {
 		display: flex;
 		align-items: center;
-		gap: 1.25rem;
-		padding: 0.5rem 0.75rem 0.5rem 1rem;
+		gap: 1rem;
+		padding: 0.55rem 1rem;
 		border-bottom: 1px solid var(--rail-divider);
 		background: linear-gradient(180deg,
 			hsl(var(--hsl-base-200)) 0%,
 			hsl(var(--hsl-base-100)) 100%);
 		box-shadow: inset 0 1px 0 hsl(var(--hsl-content) / 0.04);
-		font-family: var(--ffml-mono);
+		font-family: var(--ffml-primary);
 		flex-wrap: wrap;
 	}
 
 	.rail__brand {
-		font-weight: 700;
-		letter-spacing: 0.22em;
-		text-transform: uppercase;
+		font-weight: 600;
 		color: var(--rail-fg);
-		font-size: 0.6875rem;
+		font-size: 0.9rem;
 	}
 
 	.rail__stats {
 		display: flex;
 		align-items: center;
-		gap: 1.1rem;
-		padding-left: 0.5rem;
+		gap: 0.85rem;
+		padding-left: 0.65rem;
 		border-left: 1px solid var(--rail-divider);
 	}
 
@@ -127,42 +107,19 @@
 
 	.stat {
 		display: inline-flex;
-		align-items: center;
-		gap: 0.45rem;
+		align-items: baseline;
+		gap: 0.35rem;
 		color: var(--rail-fg-muted);
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
-		font-size: 0.625rem;
-		font-weight: 600;
+		font-size: 0.8125rem;
 	}
 
 	.stat__value {
 		color: var(--rail-fg);
 		font-variant-numeric: tabular-nums;
-		font-weight: 700;
-		font-size: 0.75rem;
+		font-weight: 600;
 	}
 
-	.stat__unit { color: var(--rail-fg-dim); font-size: 0.625rem; }
-
-	.stat-dot {
-		width: 0.5rem;
-		height: 0.5rem;
-		border-radius: 50%;
-		flex-shrink: 0;
-		background: hsl(var(--hsl-content) / 0.4);
-	}
-	.stat-dot[data-tone='positive'] {
-		background: hsl(var(--hsl-positive));
-		animation: live-pulse 1.8s ease-out infinite;
-	}
-	.stat-dot[data-tone='warn'] { background: hsl(var(--hsl-warning)); }
-	.stat-dot[data-tone='negative'] { background: hsl(var(--hsl-negative)); }
-
-	@keyframes live-pulse {
-		0%, 100% { box-shadow: 0 0 0 0 hsl(var(--hsl-positive) / 0.55); }
-		60%      { box-shadow: 0 0 0 6px hsl(var(--hsl-positive) / 0); }
-	}
+	.stat__unit { color: var(--rail-fg-muted); }
 
 	/* ─── spec body ─── */
 	.body {
@@ -184,12 +141,10 @@
 	}
 
 	.section__title {
-		font-family: var(--ffml-mono);
-		font-weight: 700;
-		text-transform: uppercase;
-		letter-spacing: 0.18em;
-		font-size: 0.6875rem;
-		color: hsl(var(--hsl-content) / 0.7);
+		font-family: var(--ffml-primary);
+		font-weight: 600;
+		font-size: 0.875rem;
+		color: hsl(var(--hsl-content));
 	}
 
 	.section__rule {
@@ -221,12 +176,10 @@
 	}
 
 	.spec__label {
-		font-family: var(--ffml-mono);
-		font-size: 0.625rem;
-		font-weight: 700;
-		letter-spacing: 0.14em;
-		text-transform: uppercase;
-		color: hsl(var(--hsl-content) / 0.45);
+		font-family: var(--ffml-primary);
+		font-size: 0.8125rem;
+		font-weight: 400;
+		color: hsl(var(--hsl-content) / 0.6);
 	}
 
 	.spec__value {
@@ -272,15 +225,13 @@
 
 	.spec__inline-tag {
 		display: inline-block;
-		font-family: var(--ffml-mono);
-		font-size: 0.625rem;
-		font-weight: 700;
-		text-transform: uppercase;
-		letter-spacing: 0.08em;
-		padding: 0.1rem 0.35rem;
-		border-radius: 3px;
-		background: hsl(var(--hsl-content) / 0.08);
-		color: hsl(var(--hsl-content) / 0.6);
+		font-family: var(--ffml-primary);
+		font-size: 0.6875rem;
+		font-weight: 600;
+		padding: 0.1rem 0.4rem;
+		border-radius: 4px;
+		background: hsl(var(--hsl-content) / 0.06);
+		color: hsl(var(--hsl-content) / 0.7);
 		margin-left: 0.35rem;
 	}
 
@@ -297,39 +248,27 @@
 	.chip {
 		display: inline-flex;
 		align-items: center;
-		gap: 0.4rem;
-		padding: 0.2rem 0.55rem;
+		gap: 0.45rem;
+		padding: 0.2rem 0.6rem;
 		border-radius: 4px;
-		background: hsl(var(--chip-h), 60%, 50%, 0.13);
-		color: hsl(var(--chip-h), 65%, 38%);
-		font-family: var(--ffml-mono);
-		font-size: 0.75rem;
-		font-weight: 600;
-		border: 1px solid hsl(var(--chip-h), 60%, 50%, 0.22);
+		background: hsl(var(--hsl-primary) / 0.1);
+		color: hsl(var(--hsl-primary));
+		font-family: var(--ffml-primary);
+		font-size: 0.8125rem;
+		font-weight: 500;
+		border: 1px solid hsl(var(--hsl-primary) / 0.22);
 		cursor: pointer;
 		transition: background 0.15s ease, border-color 0.15s ease;
 	}
 
-	.chip::before {
-		content: '';
-		width: 0.35rem;
-		height: 0.35rem;
-		border-radius: 50%;
-		background: hsl(var(--chip-h), 65%, 50%);
-	}
-
 	.chip:hover {
-		background: hsl(var(--chip-h), 60%, 50%, 0.2);
-		border-color: hsl(var(--chip-h), 60%, 50%, 0.4);
+		background: hsl(var(--hsl-primary) / 0.16);
+		border-color: hsl(var(--hsl-primary) / 0.42);
 	}
 
-	:global(.dark) .chip {
-		color: hsl(var(--chip-h), 75%, 75%);
-		background: hsl(var(--chip-h), 65%, 60%, 0.15);
-		border-color: hsl(var(--chip-h), 65%, 60%, 0.28);
-	}
-	:global(.dark) .chip::before {
-		background: hsl(var(--chip-h), 70%, 65%);
+	.chip i {
+		font-size: 0.7rem;
+		opacity: 0.75;
 	}
 
 	/* ─── env / mount key-value table ─── */
@@ -379,13 +318,11 @@
 
 	.empty {
 		padding: 0.85rem 1rem;
-		font-family: var(--ffml-mono);
-		font-size: 0.75rem;
-		color: hsl(var(--hsl-content) / 0.4);
+		font-family: var(--ffml-primary);
+		font-size: 0.8125rem;
+		color: hsl(var(--hsl-content) / 0.5);
 		text-align: center;
-		text-transform: uppercase;
-		letter-spacing: 0.12em;
-		border: 1px dashed hsl(var(--hsl-content) / 0.1);
+		border: 1px dashed hsl(var(--hsl-content) / 0.12);
 		border-radius: 6px;
 	}
 
@@ -407,12 +344,11 @@
 
 	.sidecars__label {
 		display: inline-block;
-		font-size: 0.625rem;
-		font-weight: 700;
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
-		padding: 0.1rem 0.35rem;
-		border-radius: 3px;
+		font-family: var(--ffml-primary);
+		font-size: 0.6875rem;
+		font-weight: 600;
+		padding: 0.1rem 0.4rem;
+		border-radius: 4px;
 		background: hsl(var(--hsl-primary) / 0.12);
 		color: hsl(var(--hsl-primary));
 		margin-right: 0.35rem;
@@ -423,16 +359,14 @@
 		align-items: center;
 		gap: 0.4rem;
 		background: transparent;
-		border: 1px solid hsl(var(--hsl-content) / 0.12);
+		border: 1px solid hsl(var(--hsl-content) / 0.15);
 		border-radius: 6px;
-		padding: 0 0.65rem;
-		height: 1.65rem;
-		color: hsl(var(--hsl-content) / 0.7);
-		font-family: var(--ffml-mono);
-		font-size: 0.6875rem;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
+		padding: 0 0.75rem;
+		height: 1.75rem;
+		color: hsl(var(--hsl-content));
+		font-family: var(--ffml-primary);
+		font-size: 0.8125rem;
+		font-weight: 500;
 		cursor: pointer;
 		transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 	}
@@ -450,12 +384,8 @@
 		<span class="rail__brand">Details</span>
 		<div class="rail__stats">
 			<span class="stat">
-				<span class="stat-dot" data-tone={statusTone}></span>
-				<span class="stat__value">{deployment.status.toUpperCase()}</span>
-			</span>
-			<span class="stat">
+				<span class="stat__unit">Revision</span>
 				<span class="stat__value">#{deployment.revision}</span>
-				<span class="stat__unit">revision</span>
 			</span>
 		</div>
 	</header>
@@ -747,15 +677,14 @@
 			{#if (deployment.envGroups || []).length}
 				<div class="chips">
 					{#each deployment.envGroups as name (name)}
-						<button type="button" class="chip"
-							style="--chip-h: {chipHue(name)}"
-							onclick={() => viewEnvGroup(name)}>
+						<button type="button" class="chip" onclick={() => viewEnvGroup(name)}>
+							<i class="fa-solid fa-layer-group"></i>
 							{name}
 						</button>
 					{/each}
 				</div>
 			{:else}
-				<div class="empty">no env groups attached</div>
+				<div class="empty">No env groups attached.</div>
 			{/if}
 		</section>
 	</div>

--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -7,7 +7,6 @@
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import Secret from '$lib/components/Secret.svelte'
-	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import EnvGroupModal from '$lib/components/EnvGroupModal.svelte'
 
 	const { data } = $props()
@@ -17,12 +16,9 @@
 
 	/** @type {?EnvGroupModal} */
 	let envGroupModal = $state(null)
-
 	let showAllEnv = $state(false)
 
-	/**
-	 * @param {string} name
-	 */
+	/** @param {string} name */
 	async function viewEnvGroup (name) {
 		const resp = await api.invoke('envGroup.get', { project: deployment.project, name }, fetch)
 		if (!resp.ok) {
@@ -35,9 +31,7 @@
 	const hasExternalTCPAddress = $derived(['TCPService'].includes(deployment.type))
 	const hasInternalTCPAddress = $derived(['WebService', 'TCPService', 'InternalTCPService'].includes(deployment.type))
 
-	onMount(() => {
-		return setupCopy('.copy')
-	})
+	onMount(() => setupCopy('.copy'))
 
 	function deleteItem () {
 		modal.confirm({
@@ -57,288 +51,782 @@
 			}
 		})
 	}
+
+	// Deterministic hue for env group chips, hashed from the name so the
+	// same group keeps the same colour as the user navigates around.
+	const CHIP_HUES = [355, 28, 48, 142, 175, 205, 260, 312]
+	/** @param {string} s */
+	function chipHue (s) {
+		let h = 0
+		for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0
+		return CHIP_HUES[Math.abs(h) % CHIP_HUES.length]
+	}
+
+	const envEntries = $derived(Object.entries(deployment.env || {}))
+	const mountEntries = $derived(Object.entries(deployment.mountData || {}))
+
+	const statusTone = $derived(
+		deployment.status === 'success'
+			? 'positive'
+			: deployment.status === 'pending'
+				? 'warn'
+				: 'negative'
+	)
 </script>
 
-<h6><strong>Deployment Details</strong></h6>
-<div class="table-container">
-	<table class="table is-variant-compact" style="--table-data-border-color: none">
-		<tbody>
-			{#if deployment.type === 'WebService'}
-				{#if !deployment.internal}
-					<tr>
-						<td>URL</td>
-						<td>
-							<a class="link underline" href={`https://${deployment.url}`} target="_blank">
-								{`https://${deployment.url}`}
-							</a>
-							<span class="icon copy" data-clipboard-text={`https://${deployment.url}`}>
-								<i class="fa-light fa-copy"></i>
-							</span>
-						</td>
-					</tr>
+<style>
+	/* shared shell vars */
+	.shell {
+		--rail-fg: hsl(var(--hsl-content));
+		--rail-fg-muted: hsl(var(--hsl-content) / 0.5);
+		--rail-fg-dim: hsl(var(--hsl-content) / 0.32);
+		--rail-divider: hsl(var(--hsl-content) / 0.08);
+		--surface-bg: hsl(var(--hsl-base-100));
+
+		display: flex;
+		flex-direction: column;
+		background: var(--surface-bg);
+		border: 1px solid var(--rail-divider);
+		border-radius: 10px;
+		overflow: hidden;
+		font-family: var(--ffml-primary);
+		margin-bottom: 1rem;
+	}
+
+	.rail {
+		display: flex;
+		align-items: center;
+		gap: 1.25rem;
+		padding: 0.5rem 0.75rem 0.5rem 1rem;
+		border-bottom: 1px solid var(--rail-divider);
+		background: linear-gradient(180deg,
+			hsl(var(--hsl-base-200)) 0%,
+			hsl(var(--hsl-base-100)) 100%);
+		box-shadow: inset 0 1px 0 hsl(var(--hsl-content) / 0.04);
+		font-family: var(--ffml-mono);
+		flex-wrap: wrap;
+	}
+
+	.rail__brand {
+		font-weight: 700;
+		letter-spacing: 0.22em;
+		text-transform: uppercase;
+		color: var(--rail-fg);
+		font-size: 0.6875rem;
+	}
+
+	.rail__stats {
+		display: flex;
+		align-items: center;
+		gap: 1.1rem;
+		padding-left: 0.5rem;
+		border-left: 1px solid var(--rail-divider);
+	}
+
+	.rail__actions { margin-left: auto; }
+
+	.stat {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		color: var(--rail-fg-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		font-size: 0.625rem;
+		font-weight: 600;
+	}
+
+	.stat__value {
+		color: var(--rail-fg);
+		font-variant-numeric: tabular-nums;
+		font-weight: 700;
+		font-size: 0.75rem;
+	}
+
+	.stat__unit { color: var(--rail-fg-dim); font-size: 0.625rem; }
+
+	.stat-dot {
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 50%;
+		flex-shrink: 0;
+		background: hsl(var(--hsl-content) / 0.4);
+	}
+	.stat-dot[data-tone='positive'] {
+		background: hsl(var(--hsl-positive));
+		animation: live-pulse 1.8s ease-out infinite;
+	}
+	.stat-dot[data-tone='warn'] { background: hsl(var(--hsl-warning)); }
+	.stat-dot[data-tone='negative'] { background: hsl(var(--hsl-negative)); }
+
+	@keyframes live-pulse {
+		0%, 100% { box-shadow: 0 0 0 0 hsl(var(--hsl-positive) / 0.55); }
+		60%      { box-shadow: 0 0 0 6px hsl(var(--hsl-positive) / 0); }
+	}
+
+	/* ─── spec body ─── */
+	.body {
+		padding: 0.75rem 0;
+	}
+
+	.section {
+		padding: 0.5rem 1rem 0.85rem;
+		border-top: 1px solid hsl(var(--hsl-content) / 0.05);
+	}
+
+	.section:first-child { border-top: none; }
+
+	.section__head {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		margin-bottom: 0.5rem;
+	}
+
+	.section__title {
+		font-family: var(--ffml-mono);
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.18em;
+		font-size: 0.6875rem;
+		color: hsl(var(--hsl-content) / 0.7);
+	}
+
+	.section__rule {
+		flex: 1;
+		height: 1px;
+		background: linear-gradient(to right,
+			hsl(var(--hsl-content) / 0.08),
+			hsl(var(--hsl-content) / 0));
+	}
+
+	.spec-grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		row-gap: 0.35rem;
+	}
+
+	@media (min-width: 1024px) {
+		.spec-grid { grid-template-columns: 1fr 1fr; column-gap: 2rem; }
+		.spec-grid.is-full { grid-template-columns: 1fr; }
+	}
+
+	.spec {
+		display: grid;
+		grid-template-columns: 10rem 1fr auto;
+		align-items: baseline;
+		column-gap: 0.75rem;
+		padding: 0.2rem 0;
+		min-width: 0;
+	}
+
+	.spec__label {
+		font-family: var(--ffml-mono);
+		font-size: 0.625rem;
+		font-weight: 700;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: hsl(var(--hsl-content) / 0.45);
+	}
+
+	.spec__value {
+		font-family: var(--ffml-primary);
+		font-size: 0.875rem;
+		color: hsl(var(--hsl-content));
+		min-width: 0;
+		overflow-wrap: anywhere;
+		word-break: break-word;
+	}
+
+	.spec__value.is-mono {
+		font-family: var(--ffml-mono);
+		font-size: 0.8125rem;
+		color: hsl(var(--hsl-content) / 0.92);
+	}
+
+	.spec__value.is-dim { color: hsl(var(--hsl-content) / 0.45); }
+
+	.spec__copy {
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-content) / 0.35);
+		cursor: pointer;
+		padding: 0.15rem 0.3rem;
+		border-radius: 3px;
+		transition: color 0.15s ease, background 0.15s ease;
+	}
+	.spec__copy:hover {
+		color: hsl(var(--hsl-content));
+		background: hsl(var(--hsl-content) / 0.06);
+	}
+
+	.spec__link {
+		font-family: var(--ffml-mono);
+		font-size: 0.8125rem;
+		color: hsl(var(--hsl-primary));
+		text-decoration: none;
+		border-bottom: 1px dashed hsl(var(--hsl-primary) / 0.35);
+		transition: border-color 0.15s ease;
+		overflow-wrap: anywhere;
+	}
+	.spec__link:hover { border-bottom-color: hsl(var(--hsl-primary)); }
+
+	.spec__inline-tag {
+		display: inline-block;
+		font-family: var(--ffml-mono);
+		font-size: 0.625rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		padding: 0.1rem 0.35rem;
+		border-radius: 3px;
+		background: hsl(var(--hsl-content) / 0.08);
+		color: hsl(var(--hsl-content) / 0.6);
+		margin-left: 0.35rem;
+	}
+
+	.spec__inline-tag.is-warning { background: hsl(var(--hsl-warning) / 0.13); color: hsl(var(--hsl-warning)); }
+	.spec__inline-tag.is-negative { background: hsl(var(--hsl-negative) / 0.13); color: hsl(var(--hsl-negative)); }
+
+	/* ─── env-group chips ─── */
+	.chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+	}
+
+	.chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		padding: 0.2rem 0.55rem;
+		border-radius: 4px;
+		background: hsl(var(--chip-h), 60%, 50%, 0.13);
+		color: hsl(var(--chip-h), 65%, 38%);
+		font-family: var(--ffml-mono);
+		font-size: 0.75rem;
+		font-weight: 600;
+		border: 1px solid hsl(var(--chip-h), 60%, 50%, 0.22);
+		cursor: pointer;
+		transition: background 0.15s ease, border-color 0.15s ease;
+	}
+
+	.chip::before {
+		content: '';
+		width: 0.35rem;
+		height: 0.35rem;
+		border-radius: 50%;
+		background: hsl(var(--chip-h), 65%, 50%);
+	}
+
+	.chip:hover {
+		background: hsl(var(--chip-h), 60%, 50%, 0.2);
+		border-color: hsl(var(--chip-h), 60%, 50%, 0.4);
+	}
+
+	:global(.dark) .chip {
+		color: hsl(var(--chip-h), 75%, 75%);
+		background: hsl(var(--chip-h), 65%, 60%, 0.15);
+		border-color: hsl(var(--chip-h), 65%, 60%, 0.28);
+	}
+	:global(.dark) .chip::before {
+		background: hsl(var(--chip-h), 70%, 65%);
+	}
+
+	/* ─── env / mount key-value table ─── */
+	.kv-list {
+		display: grid;
+		grid-template-columns: minmax(10rem, max-content) 1fr;
+		gap: 0;
+		font-family: var(--ffml-mono);
+		font-size: 0.8125rem;
+		border: 1px solid hsl(var(--hsl-content) / 0.06);
+		border-radius: 6px;
+		overflow: hidden;
+		background:
+			repeating-linear-gradient(
+				to bottom,
+				transparent 0,
+				transparent calc(1.6rem - 1px),
+				hsl(var(--hsl-content) / 0.014) calc(1.6rem - 1px),
+				hsl(var(--hsl-content) / 0.014) 1.6rem
+			);
+	}
+
+	.kv-list__row {
+		display: contents;
+	}
+
+	.kv-list__key,
+	.kv-list__val {
+		padding: 0.35rem 0.75rem;
+		border-bottom: 1px solid hsl(var(--hsl-content) / 0.04);
+	}
+
+	.kv-list__row:last-child .kv-list__key,
+	.kv-list__row:last-child .kv-list__val { border-bottom: none; }
+
+	.kv-list__key {
+		color: hsl(var(--hsl-content));
+		font-weight: 600;
+		background: hsl(var(--hsl-content) / 0.025);
+		border-right: 1px solid hsl(var(--hsl-content) / 0.04);
+	}
+
+	.kv-list__val {
+		color: hsl(var(--hsl-content) / 0.92);
+		overflow-wrap: anywhere;
+	}
+
+	.empty {
+		padding: 0.85rem 1rem;
+		font-family: var(--ffml-mono);
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-content) / 0.4);
+		text-align: center;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		border: 1px dashed hsl(var(--hsl-content) / 0.1);
+		border-radius: 6px;
+	}
+
+	/* sidecar list inside a spec value */
+	.sidecars {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.sidecars li {
+		font-family: var(--ffml-mono);
+		font-size: 0.8125rem;
+		color: hsl(var(--hsl-content));
+	}
+
+	.sidecars__label {
+		display: inline-block;
+		font-size: 0.625rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		padding: 0.1rem 0.35rem;
+		border-radius: 3px;
+		background: hsl(var(--hsl-primary) / 0.12);
+		color: hsl(var(--hsl-primary));
+		margin-right: 0.35rem;
+	}
+
+	.show-toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		background: transparent;
+		border: 1px solid hsl(var(--hsl-content) / 0.12);
+		border-radius: 6px;
+		padding: 0 0.65rem;
+		height: 1.65rem;
+		color: hsl(var(--hsl-content) / 0.7);
+		font-family: var(--ffml-mono);
+		font-size: 0.6875rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		cursor: pointer;
+		transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+	}
+	.show-toggle:hover {
+		background: hsl(var(--hsl-content) / 0.06);
+		color: hsl(var(--hsl-content));
+		border-color: hsl(var(--hsl-content) / 0.2);
+	}
+
+</style>
+
+<!-- ─── DETAILS shell ─── -->
+<div class="shell">
+	<header class="rail">
+		<span class="rail__brand">Details</span>
+		<div class="rail__stats">
+			<span class="stat">
+				<span class="stat-dot" data-tone={statusTone}></span>
+				<span class="stat__value">{deployment.status.toUpperCase()}</span>
+			</span>
+			<span class="stat">
+				<span class="stat__value">#{deployment.revision}</span>
+				<span class="stat__unit">revision</span>
+			</span>
+		</div>
+	</header>
+
+	<div class="body">
+		<!-- ─── Network ─── -->
+		<section class="section">
+			<div class="section__head">
+				<span class="section__title">Network</span>
+				<span class="section__rule"></span>
+			</div>
+			<div class="spec-grid is-full">
+				{#if deployment.type === 'WebService' && !deployment.internal}
+					<div class="spec">
+						<span class="spec__label">URL</span>
+						<a class="spec__link" href={`https://${deployment.url}`} target="_blank" rel="noopener">
+							{`https://${deployment.url}`}
+						</a>
+						<span class="spec__copy copy" data-clipboard-text={`https://${deployment.url}`} title="Copy URL">
+							<i class="fa-light fa-copy"></i>
+						</span>
+					</div>
 				{/if}
-				<tr>
-					<td>Internal URL</td>
-					<td>
-						http://{deployment.internalUrl}
-						<span class="icon copy" data-clipboard-text={`http://${deployment.internalUrl}`}>
+				{#if deployment.type === 'WebService'}
+					<div class="spec">
+						<span class="spec__label">Internal URL</span>
+						<span class="spec__value is-mono">http://{deployment.internalUrl}</span>
+						<span class="spec__copy copy" data-clipboard-text={`http://${deployment.internalUrl}`} title="Copy">
 							<i class="fa-light fa-copy"></i>
 						</span>
-					</td>
-				</tr>
-			{/if}
-			{#if hasExternalTCPAddress}
-				<tr>
-					<td>Address</td>
-					<td>{deployment.address}:{deployment.nodePort}</td>
-				</tr>
-			{/if}
-			{#if hasInternalTCPAddress}
-				<tr>
-					<td>Internal Address</td>
-					<td>
-						{deployment.internalAddress}:{deployment.port}
-						<span class="icon copy" data-clipboard-text={`${deployment.internalAddress}:${deployment.port}`}>
+					</div>
+				{/if}
+				{#if hasExternalTCPAddress}
+					<div class="spec">
+						<span class="spec__label">Address</span>
+						<span class="spec__value is-mono">{deployment.address}:{deployment.nodePort}</span>
+						<span></span>
+					</div>
+				{/if}
+				{#if hasInternalTCPAddress}
+					<div class="spec">
+						<span class="spec__label">Internal Address</span>
+						<span class="spec__value is-mono">{deployment.internalAddress}:{deployment.port}</span>
+						<span class="spec__copy copy" data-clipboard-text={`${deployment.internalAddress}:${deployment.port}`} title="Copy">
 							<i class="fa-light fa-copy"></i>
 						</span>
-					</td>
-				</tr>
-			{/if}
-			<tr>
-				<td>Type</td>
-				<td>
-					{format.deploymentType(deployment.type)}
-					{#if deployment.internal}
-						(Internal)
-					{/if}
-				</td>
-			</tr>
-			<tr>
-				<td>Location</td>
-				<td>
-					{deployment.location}
-					<span class="icon copy" data-clipboard-text={`${deployment.location}`}>
+					</div>
+				{/if}
+				{#if deployment.type === 'WebService'}
+					<div class="spec">
+						<span class="spec__label">Port / Protocol</span>
+						<span class="spec__value is-mono">
+							{deployment.port}{deployment.protocol ? ` · ${deployment.protocol}` : ''}
+						</span>
+						<span></span>
+					</div>
+				{:else if deployment.type === 'TCPService'}
+					<div class="spec">
+						<span class="spec__label">Port</span>
+						<span class="spec__value is-mono">{deployment.port}:{deployment.nodePort}</span>
+						<span></span>
+					</div>
+				{/if}
+			</div>
+		</section>
+
+		<!-- ─── Runtime ─── -->
+		<section class="section">
+			<div class="section__head">
+				<span class="section__title">Runtime</span>
+				<span class="section__rule"></span>
+			</div>
+			<div class="spec-grid">
+				<div class="spec">
+					<span class="spec__label">Type</span>
+					<span class="spec__value">
+						{format.deploymentType(deployment.type)}
+						{#if deployment.internal}
+							<span class="spec__inline-tag">Internal</span>
+						{/if}
+					</span>
+					<span></span>
+				</div>
+				<div class="spec">
+					<span class="spec__label">Image</span>
+					<span class="spec__value is-mono">{deployment.image}</span>
+					<span class="spec__copy copy" data-clipboard-text={deployment.image} title="Copy image">
 						<i class="fa-light fa-copy"></i>
 					</span>
-				</td>
-			</tr>
-			<tr>
-				<td>Image</td>
-				<td>
-					{deployment.image}
-					<span class="icon copy" data-clipboard-text={`${deployment.image}`}>
-						<i class="fa-light fa-copy"></i>
-					</span>
-				</td>
-			</tr>
-			{#if deployment.type === 'WebService'}
-				<tr>
-					<td>Port</td>
-					<td>{deployment.port}{deployment.protocol ? `:${deployment.protocol}` : ''}</td>
-				</tr>
-			{:else if deployment.type === 'TCPService'}
-				<tr>
-					<td>Port</td>
-					<td>{deployment.port}:{deployment.nodePort}</td>
-				</tr>
-			{/if}
-			{#if location.features.disk}
-				<tr>
-					<td>Disk</td>
-					<td>
-						{#if deployment.disk}
-							{deployment.disk.name}
-							(mount: {deployment.disk.mountPath || '-'}, sub: {deployment.disk.subPath || '-'})
-						{:else}
-							-
-						{/if}
-					</td>
-				</tr>
-			{/if}
-			{#if deployment.minReplicas > 0}
-			<tr>
-				<td>Replicas</td>
-				<td>
-					{#if deployment.minReplicas > 0}
-						{#if deployment.minReplicas === deployment.maxReplicas}
-							{deployment.minReplicas}
-						{:else}
-							{deployment.minReplicas} - {deployment.maxReplicas}
-						{/if}
+				</div>
+				<div class="spec">
+					<span class="spec__label">Command</span>
+					{#if deployment.command.length}
+						<span class="spec__value is-mono">{deployment.command.join(' ')}</span>
 					{:else}
-						-
+						<span class="spec__value is-dim">—</span>
 					{/if}
-				</td>
-			</tr>
-			{/if}
-			{#if deployment.type === 'CronJob'}
-				<tr>
-					<td>Schedule</td>
-					<td>{deployment.schedule}</td>
-				</tr>
-			{/if}
-			<tr>
-				<td>Command</td>
-				<td>{deployment.command.join(' ') || '-'}</td>
-			</tr>
-			<tr>
-				<td>Args</td>
-				<td>{deployment.args.join(' ') || '-'}</td>
-			</tr>
-			<tr>
-				<td>Pull Secret</td>
-				<td>{deployment.pullSecret || '-'}</td>
-			</tr>
-			{#if location.features.workloadIdentity}
-				<tr>
-					<td>Workload Identity</td>
-					<td>{deployment.workloadIdentity || '-'}</td>
-				</tr>
-			{/if}
-			<!--{{/*			<tr>*/}}-->
-			<!--{{/*				<td>CPU allocated</td>*/}}-->
-			<!--{{/*				<td>{{.Deployment.Resources.Requests.CPU | textDeploymentCPU}}</td>*/}}-->
-			<!--{{/*			</tr>*/}}-->
-			<tr>
-				<td>CPU limited</td>
-				<td>{format.cpuLimited(deployment.resources.limits.cpu)}</td>
-			</tr>
-			<tr>
-				<td>Memory allocated</td>
-				<td>{format.memory(deployment.resources.requests.memory)}</td>
-			</tr>
-			{#if deployment.sidecars?.length}
-				<tr>
-					<td>Sidecars</td>
-					<td>
-						<ul class="m-0 pl-4">
+					<span></span>
+				</div>
+				<div class="spec">
+					<span class="spec__label">Args</span>
+					{#if deployment.args.length}
+						<span class="spec__value is-mono">{deployment.args.join(' ')}</span>
+					{:else}
+						<span class="spec__value is-dim">—</span>
+					{/if}
+					<span></span>
+				</div>
+				{#if deployment.type === 'CronJob'}
+					<div class="spec">
+						<span class="spec__label">Schedule</span>
+						<span class="spec__value is-mono">{deployment.schedule}</span>
+						<span></span>
+					</div>
+				{/if}
+			</div>
+		</section>
+
+		<!-- ─── Resources ─── -->
+		<section class="section">
+			<div class="section__head">
+				<span class="section__title">Resources</span>
+				<span class="section__rule"></span>
+			</div>
+			<div class="spec-grid">
+				<div class="spec">
+					<span class="spec__label">CPU Limited</span>
+					<span class="spec__value is-mono">{format.cpuLimited(deployment.resources.limits.cpu)}</span>
+					<span></span>
+				</div>
+				<div class="spec">
+					<span class="spec__label">Memory Allocated</span>
+					<span class="spec__value is-mono">{format.memory(deployment.resources.requests.memory)}</span>
+					<span></span>
+				</div>
+				{#if deployment.minReplicas > 0}
+					<div class="spec">
+						<span class="spec__label">Replicas</span>
+						<span class="spec__value is-mono">
+							{#if deployment.minReplicas === deployment.maxReplicas}
+								{deployment.minReplicas}
+							{:else}
+								{deployment.minReplicas} – {deployment.maxReplicas}
+							{/if}
+						</span>
+						<span></span>
+					</div>
+				{/if}
+				{#if location.features.disk}
+					<div class="spec">
+						<span class="spec__label">Disk</span>
+						{#if deployment.disk}
+							<span class="spec__value is-mono">
+								{deployment.disk.name}
+								<span class="spec__inline-tag">mount {deployment.disk.mountPath || '-'}</span>
+								{#if deployment.disk.subPath}
+									<span class="spec__inline-tag">sub {deployment.disk.subPath}</span>
+								{/if}
+							</span>
+						{:else}
+							<span class="spec__value is-dim">—</span>
+						{/if}
+						<span></span>
+					</div>
+				{/if}
+				{#if deployment.sidecars?.length}
+					<div class="spec">
+						<span class="spec__label">Sidecars</span>
+						<ul class="sidecars">
 							{#each deployment.sidecars as s, i (i)}
 								{#if s.cloudSqlProxy}
 									<li>
-										<strong>Cloud SQL Proxy</strong>
-										&nbsp;—&nbsp;
-										<span>{s.cloudSqlProxy.instance}</span>
-										{#if s.cloudSqlProxy.port}
-											<span>:{s.cloudSqlProxy.port}</span>
-										{/if}
+										<span class="sidecars__label">Cloud SQL Proxy</span>
+										{s.cloudSqlProxy.instance}{#if s.cloudSqlProxy.port}:{s.cloudSqlProxy.port}{/if}
 									</li>
 								{/if}
 							{/each}
 						</ul>
-					</td>
-				</tr>
+						<span></span>
+					</div>
+				{/if}
+			</div>
+		</section>
+
+		<!-- ─── Integration ─── -->
+		<section class="section">
+			<div class="section__head">
+				<span class="section__title">Integration</span>
+				<span class="section__rule"></span>
+			</div>
+			<div class="spec-grid">
+				<div class="spec">
+					<span class="spec__label">Location</span>
+					<span class="spec__value is-mono">{deployment.location}</span>
+					<span class="spec__copy copy" data-clipboard-text={deployment.location} title="Copy">
+						<i class="fa-light fa-copy"></i>
+					</span>
+				</div>
+				<div class="spec">
+					<span class="spec__label">Pull Secret</span>
+					{#if deployment.pullSecret}
+						<span class="spec__value is-mono">{deployment.pullSecret}</span>
+					{:else}
+						<span class="spec__value is-dim">—</span>
+					{/if}
+					<span></span>
+				</div>
+				{#if location.features.workloadIdentity}
+					<div class="spec">
+						<span class="spec__label">Workload Identity</span>
+						{#if deployment.workloadIdentity}
+							<span class="spec__value is-mono">{deployment.workloadIdentity}</span>
+						{:else}
+							<span class="spec__value is-dim">—</span>
+						{/if}
+						<span></span>
+					</div>
+				{/if}
+			</div>
+		</section>
+
+		<!-- ─── Lifecycle ─── -->
+		<section class="section">
+			<div class="section__head">
+				<span class="section__title">Lifecycle</span>
+				<span class="section__rule"></span>
+			</div>
+			<div class="spec-grid">
+				<div class="spec">
+					<span class="spec__label">Deployed At</span>
+					<span class="spec__value is-mono">{format.datetime(deployment.createdAt)}</span>
+					<span></span>
+				</div>
+				<div class="spec">
+					<span class="spec__label">Deployed By</span>
+					<span class="spec__value is-mono">{deployment.createdBy}</span>
+					<span></span>
+				</div>
+				<div class="spec">
+					<span class="spec__label">Allocated Price</span>
+					<span class="spec__value">
+						<span class="spec__value is-mono" style="font-family: var(--ffml-mono);">
+							{deployment.allocatedPrice.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+						</span>
+						THB / month / replica
+					</span>
+					<span></span>
+				</div>
+				{#if deployment.ttl === -1}
+					<div class="spec">
+						<span class="spec__label">Auto-delete</span>
+						<span class="spec__value">
+							<span class="spec__inline-tag is-negative">
+								<i class="fa-regular fa-clock"></i> Expired · pending deletion
+							</span>
+						</span>
+						<span></span>
+					</div>
+				{:else if deployment.ttl > 0}
+					<div class="spec">
+						<span class="spec__label">Auto-delete</span>
+						<span class="spec__value">
+							<span class="spec__value is-mono">{format.ttlExpireAt(deployment.ttl)}</span>
+							<span class="spec__inline-tag is-warning">
+								<i class="fa-regular fa-clock"></i> in {format.duration(deployment.ttl)}
+							</span>
+						</span>
+						<span></span>
+					</div>
+				{/if}
+			</div>
+		</section>
+	</div>
+</div>
+
+<!-- ─── ENV GROUPS shell ─── -->
+<div class="shell">
+	<header class="rail">
+		<span class="rail__brand">Env Groups</span>
+		<div class="rail__stats">
+			<span class="stat">
+				<span class="stat__value">{(deployment.envGroups || []).length}</span>
+				<span class="stat__unit">attached</span>
+			</span>
+		</div>
+	</header>
+	<div class="body">
+		<section class="section">
+			{#if (deployment.envGroups || []).length}
+				<div class="chips">
+					{#each deployment.envGroups as name (name)}
+						<button type="button" class="chip"
+							style="--chip-h: {chipHue(name)}"
+							onclick={() => viewEnvGroup(name)}>
+							{name}
+						</button>
+					{/each}
+				</div>
+			{:else}
+				<div class="empty">no env groups attached</div>
 			{/if}
-			{#if deployment.ttl === -1}
-				<tr>
-					<td>Auto-delete</td>
-					<td>
-						<i class="fa-regular fa-clock mr-3 text-negative"></i>
-						Expired — pending deletion
-					</td>
-				</tr>
-			{:else if deployment.ttl > 0}
-				<tr>
-					<td>Auto-delete</td>
-					<td>
-						<i class="fa-regular fa-clock mr-3 text-warning"></i>
-						{format.ttlExpireAt(deployment.ttl)}
-						<span class="text-content/60 ml-1">(in {format.duration(deployment.ttl)})</span>
-					</td>
-				</tr>
+		</section>
+	</div>
+</div>
+
+<!-- ─── ENV VARS shell ─── -->
+<div class="shell">
+	<header class="rail">
+		<span class="rail__brand">Env Vars</span>
+		<div class="rail__stats">
+			<span class="stat">
+				<span class="stat__value">{envEntries.length}</span>
+				<span class="stat__unit">{envEntries.length === 1 ? 'variable' : 'variables'}</span>
+			</span>
+		</div>
+		{#if envEntries.length}
+			<div class="rail__actions">
+				<button type="button" class="show-toggle" onclick={() => showAllEnv = !showAllEnv}>
+					<i class="fa-solid {showAllEnv ? 'fa-eye-slash' : 'fa-eye'}"></i>
+					{showAllEnv ? 'Hide all' : 'Show all'}
+				</button>
+			</div>
+		{/if}
+	</header>
+	<div class="body">
+		<section class="section">
+			{#if envEntries.length}
+				<div class="kv-list">
+					{#each envEntries as [k, v] (k)}
+						<div class="kv-list__row">
+							<span class="kv-list__key">{k}</span>
+							<span class="kv-list__val">
+								<Secret value={v} show={showAllEnv} />
+							</span>
+						</div>
+					{/each}
+				</div>
+			{:else}
+				<div class="empty">no environment variables</div>
 			{/if}
-			<tr>
-				<td>Deployed At</td>
-				<td>{format.datetime(deployment.createdAt)}</td>
-			</tr>
-			<tr>
-				<td>Deployed By</td>
-				<td>{deployment.createdBy}</td>
-			</tr>
-			<tr>
-				<td>Allocated Price</td>
-				<td>{deployment.allocatedPrice.toLocaleString(undefined, { maximumFractionDigits: 2 })} THB/month/replica</td>
-			</tr>
-		</tbody>
-	</table>
+		</section>
+	</div>
 </div>
 
-<h6><strong>Env Groups</strong></h6>
-<div class="table-container">
-	<table class="table is-variant-compact" style="--table-data-border-color: none">
-		<thead>
-		<tr>
-			<th>Name</th>
-		</tr>
-		</thead>
-		<tbody>
-		{#each deployment.envGroups || [] as name (name)}
-			<tr>
-				<td>
-					<button type="button" class="button is-variant-underline" onclick={() => viewEnvGroup(name)}>
-						{name}
-					</button>
-				</td>
-			</tr>
-		{:else}
-			<NoDataRow span={1} />
-		{/each}
-		</tbody>
-	</table>
-</div>
-
-<div class="flex items-center gap-3">
-	<h6><strong>Environment Variables</strong></h6>
-	{#if Object.keys(deployment.env || {}).length}
-		<button type="button" class="button is-variant-secondary is-size-small is-icon-left"
-			onclick={() => showAllEnv = !showAllEnv}>
-			<i class="fa-solid {showAllEnv ? 'fa-eye-slash' : 'fa-eye'}"></i>
-			{showAllEnv ? 'Hide all' : 'Show all'}
-		</button>
-	{/if}
-</div>
-<div class="table-container">
-	<table class="table is-variant-compact" style="--table-data-border-color: none">
-		<thead>
-		<tr>
-			<th class="is-collapse" style="min-width: 256px">Env</th>
-			<th>Value</th>
-		</tr>
-		</thead>
-		<tbody>
-		{#each Object.entries(deployment.env || {}) as [k, v] (k)}
-			<tr>
-				<td>{k}</td>
-				<td>
-					<Secret value={v} show={showAllEnv} />
-				</td>
-			</tr>
-		{:else}
-			<NoDataRow span={2} />
-		{/each}
-		</tbody>
-	</table>
-</div>
-
-<h6><strong>Mount Data</strong></h6>
-<div class="table-container">
-	<table class="table is-variant-compact" style="--table-data-border-color: none">
-		<thead>
-		<tr>
-			<th class="is-collapse" style="min-width: 256px">Path</th>
-			<th>Data</th>
-		</tr>
-		</thead>
-		<tbody>
-		{#each Object.entries(deployment.mountData || {}) as [k, v] (k)}
-			<tr>
-				<td>{k}</td>
-				<td class="whitespace-pre">{v}</td>
-			</tr>
-		{:else}
-			<NoDataRow span={2} />
-		{/each}
-		</tbody>
-	</table>
+<!-- ─── MOUNT DATA shell ─── -->
+<div class="shell">
+	<header class="rail">
+		<span class="rail__brand">Mount Data</span>
+		<div class="rail__stats">
+			<span class="stat">
+				<span class="stat__value">{mountEntries.length}</span>
+				<span class="stat__unit">{mountEntries.length === 1 ? 'mount' : 'mounts'}</span>
+			</span>
+		</div>
+	</header>
+	<div class="body">
+		<section class="section">
+			{#if mountEntries.length}
+				<div class="kv-list">
+					{#each mountEntries as [k, v] (k)}
+						<div class="kv-list__row">
+							<span class="kv-list__key">{k}</span>
+							<span class="kv-list__val" style="white-space: pre">{v}</span>
+						</div>
+					{/each}
+				</div>
+			{:else}
+				<div class="empty">no mounted data</div>
+			{/if}
+		</section>
+	</div>
 </div>
 
 <DangerZone description="Permanently delete this deployment. All running instances will be stopped and removed.">

--- a/src/routes/(auth)/(project)/deployment/(detail)/events/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/events/+page.svelte
@@ -89,58 +89,53 @@
 		border: 1px solid var(--rail-divider);
 		border-radius: 10px;
 		overflow: hidden;
-		font-family: var(--ffml-mono);
 		font-feature-settings: 'tnum' 1, 'ss02' 1;
 	}
 
 	.events-rail {
 		display: flex;
 		align-items: center;
-		gap: 1.25rem;
-		padding: 0.5rem 0.75rem 0.5rem 1rem;
+		gap: 1rem;
+		padding: 0.55rem 1rem;
 		border-bottom: 1px solid var(--rail-divider);
 		background: linear-gradient(180deg,
 			hsl(var(--hsl-base-200)) 0%,
 			hsl(var(--hsl-base-100)) 100%);
 		box-shadow: inset 0 1px 0 hsl(var(--hsl-content) / 0.04);
+		font-family: var(--ffml-primary);
 		flex-wrap: wrap;
 	}
 
 	.events-rail__brand {
-		font-weight: 700;
-		letter-spacing: 0.22em;
-		text-transform: uppercase;
+		font-weight: 600;
 		color: var(--rail-fg);
-		font-size: 0.6875rem;
+		font-size: 0.9rem;
 	}
 
 	.events-rail__stats {
 		display: flex;
 		align-items: center;
-		gap: 1.1rem;
-		padding-left: 0.5rem;
+		gap: 0.85rem;
+		padding-left: 0.65rem;
 		border-left: 1px solid var(--rail-divider);
+		flex-wrap: wrap;
 	}
 
 	.stat {
 		display: inline-flex;
-		align-items: center;
-		gap: 0.45rem;
+		align-items: baseline;
+		gap: 0.35rem;
 		color: var(--rail-fg-muted);
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
-		font-size: 0.625rem;
-		font-weight: 600;
+		font-size: 0.8125rem;
 	}
 
 	.stat__value {
 		color: var(--rail-fg);
 		font-variant-numeric: tabular-nums;
-		font-weight: 700;
-		font-size: 0.75rem;
+		font-weight: 600;
 	}
 
-	.stat__unit { color: var(--rail-fg-dim); font-size: 0.625rem; }
+	.stat__unit { color: var(--rail-fg-muted); }
 
 	.stat-dot {
 		position: relative;
@@ -175,17 +170,14 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.35rem;
-		font-size: 0.625rem;
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
+		font-size: 0.8125rem;
 		color: var(--rail-fg-muted);
-		font-weight: 600;
 	}
 
 	.stat-count::before {
 		content: '';
-		width: 0.3rem;
-		height: 0.3rem;
+		width: 0.4rem;
+		height: 0.4rem;
 		border-radius: 50%;
 		background: currentColor;
 	}
@@ -196,7 +188,7 @@
 
 	.stat-count__num {
 		font-variant-numeric: tabular-nums;
-		font-weight: 700;
+		font-weight: 600;
 		color: var(--rail-fg);
 	}
 
@@ -284,16 +276,14 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.35rem;
-		padding: 0 0.45rem;
-		height: 1.1rem;
+		padding: 0.1rem 0.5rem;
 		align-self: center;
-		border-radius: 3px;
+		border-radius: 4px;
 		background: hsl(var(--hsl-content) / 0.06);
-		color: hsl(var(--hsl-content) / 0.6);
-		font-size: 0.625rem;
-		font-weight: 700;
-		letter-spacing: 0.1em;
-		text-transform: uppercase;
+		color: hsl(var(--hsl-content) / 0.7);
+		font-family: var(--ffml-primary);
+		font-size: 0.6875rem;
+		font-weight: 600;
 		white-space: nowrap;
 	}
 
@@ -416,7 +406,7 @@
 		<div class="events-rail__stats">
 			<span class="stat" title={lastFetchOk ? 'auto-refreshing' : 'connecting'}>
 				<span class="stat-dot" data-state={lastFetchOk ? 'live' : 'cold'}></span>
-				<span class="stat__value">{lastFetchOk ? 'POLLING' : 'CONNECTING'}</span>
+				<span class="stat__value">{lastFetchOk ? 'Polling' : 'Connecting'}</span>
 				<span class="stat__unit">· {POLL_INTERVAL_MS / 1000}s</span>
 			</span>
 

--- a/src/routes/(auth)/(project)/deployment/(detail)/events/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/events/+page.svelte
@@ -1,56 +1,470 @@
 <script>
 	import { onMount } from 'svelte'
-	import * as format from '$lib/format'
-	import NoDataRow from '$lib/components/NoDataRow.svelte'
 
 	const { data } = $props()
 
 	const deployment = $derived(data.deployment)
 
+	const POLL_INTERVAL_MS = 5000
+
+	/** @type {Array<{type: string, reason: string, message: string, lastSeen: string}>} */
 	let events = $state([])
+	let lastFetchOk = $state(false)
+	let lastFetchAt = $state(0)
+	let now = $state(Date.now())
 
 	onMount(() => {
-		reloadEvents()
-		const reloadInterval = setInterval(() => reloadEvents(), 5000)
+		reload()
+		const poll = setInterval(reload, POLL_INTERVAL_MS)
+		const ticker = setInterval(() => { now = Date.now() }, 1000)
 		return () => {
-			clearInterval(reloadInterval)
+			clearInterval(poll)
+			clearInterval(ticker)
 		}
 	})
 
-	async function reloadEvents () {
-		const response = await fetch(deployment.eventUrl)
-		if (response.status === 403) {
-			// token expired
-			return
+	async function reload () {
+		try {
+			const response = await fetch(deployment.eventUrl)
+			if (response.status === 403) return
+			const result = await response.json()
+			events = result ?? []
+			lastFetchOk = true
+			lastFetchAt = Date.now()
+		} catch {
+			lastFetchOk = false
 		}
-		const result = await response.json()
-		events = result ?? []
 	}
+
+	/**
+	 * @param {string} type
+	 * @returns {'warn' | 'error' | 'normal'}
+	 */
+	function severityOf (type) {
+		const t = type.toLowerCase()
+		if (t === 'normal') return 'normal'
+		if (t === 'warning' || t === 'warn') return 'warn'
+		return 'error'
+	}
+
+	/**
+	 * @param {string | number} ts ISO 8601 or unix ms
+	 * @param {number} nowMs
+	 */
+	function relTime (ts, nowMs) {
+		const t = typeof ts === 'number' ? ts : Date.parse(ts)
+		if (isNaN(t)) return ''
+		const diff = Math.max(0, nowMs - t)
+		if (diff < 1000) return 'now'
+		if (diff < 60_000) return `${Math.floor(diff / 1000)}s`
+		if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m`
+		if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h`
+		return `${Math.floor(diff / 86_400_000)}d`
+	}
+
+	const pollText = $derived.by(() => {
+		if (!lastFetchAt) return 'connecting…'
+		return `synced ${relTime(lastFetchAt, now)} ago`
+	})
+
+	const counts = $derived.by(() => {
+		const out = { normal: 0, warn: 0, error: 0 }
+		for (const e of events) out[severityOf(e.type)] += 1
+		return out
+	})
 </script>
 
-<h6><strong>Events</strong></h6>
+<style>
+	.events-shell {
+		--rail-fg: hsl(var(--hsl-content));
+		--rail-fg-muted: hsl(var(--hsl-content) / 0.5);
+		--rail-fg-dim: hsl(var(--hsl-content) / 0.32);
+		--rail-divider: hsl(var(--hsl-content) / 0.08);
+		--surface-bg: hsl(var(--hsl-base-100));
+		--surface-scan: hsl(var(--hsl-content) / 0.018);
 
-<div class="table-container mt-4">
-	<table class="table is-variant-compact" style="--table-data-border-color: none">
-		<thead>
-		<tr>
-			<th>Last Seen</th>
-			<th>Type</th>
-			<th>Reason</th>
-			<th>Message</th>
-		</tr>
-		</thead>
-		<tbody>
-		{#each events as it, i (i)}
-			<tr class:row-error={it.type !== 'Normal'}>
-				<td>{format.datetime(it.lastSeen)}</td>
-				<td>{it.type}</td>
-				<td>{it.reason}</td>
-				<td>{it.message}</td>
-			</tr>
+		display: flex;
+		flex-direction: column;
+		background: var(--surface-bg);
+		border: 1px solid var(--rail-divider);
+		border-radius: 10px;
+		overflow: hidden;
+		font-family: var(--ffml-mono);
+		font-feature-settings: 'tnum' 1, 'ss02' 1;
+	}
+
+	.events-rail {
+		display: flex;
+		align-items: center;
+		gap: 1.25rem;
+		padding: 0.5rem 0.75rem 0.5rem 1rem;
+		border-bottom: 1px solid var(--rail-divider);
+		background: linear-gradient(180deg,
+			hsl(var(--hsl-base-200)) 0%,
+			hsl(var(--hsl-base-100)) 100%);
+		box-shadow: inset 0 1px 0 hsl(var(--hsl-content) / 0.04);
+		flex-wrap: wrap;
+	}
+
+	.events-rail__brand {
+		font-weight: 700;
+		letter-spacing: 0.22em;
+		text-transform: uppercase;
+		color: var(--rail-fg);
+		font-size: 0.6875rem;
+	}
+
+	.events-rail__stats {
+		display: flex;
+		align-items: center;
+		gap: 1.1rem;
+		padding-left: 0.5rem;
+		border-left: 1px solid var(--rail-divider);
+	}
+
+	.stat {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		color: var(--rail-fg-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		font-size: 0.625rem;
+		font-weight: 600;
+	}
+
+	.stat__value {
+		color: var(--rail-fg);
+		font-variant-numeric: tabular-nums;
+		font-weight: 700;
+		font-size: 0.75rem;
+	}
+
+	.stat__unit { color: var(--rail-fg-dim); font-size: 0.625rem; }
+
+	.stat-dot {
+		position: relative;
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 50%;
+		flex-shrink: 0;
+		background: hsl(var(--hsl-content) / 0.4);
+	}
+
+	.stat-dot[data-state='live'] {
+		background: hsl(var(--hsl-positive));
+		animation: live-pulse 1.8s ease-out infinite;
+	}
+
+	.stat-dot[data-state='cold'] {
+		background: hsl(var(--hsl-content) / 0.45);
+		animation: dim-blink 1.2s ease-in-out infinite;
+	}
+
+	@keyframes live-pulse {
+		0%, 100% { box-shadow: 0 0 0 0 hsl(var(--hsl-positive) / 0.55); }
+		60%      { box-shadow: 0 0 0 6px hsl(var(--hsl-positive) / 0); }
+	}
+
+	@keyframes dim-blink {
+		0%, 100% { opacity: 0.45; }
+		50%      { opacity: 1; }
+	}
+
+	.stat-count {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		font-size: 0.625rem;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--rail-fg-muted);
+		font-weight: 600;
+	}
+
+	.stat-count::before {
+		content: '';
+		width: 0.3rem;
+		height: 0.3rem;
+		border-radius: 50%;
+		background: currentColor;
+	}
+
+	.stat-count[data-tone='normal']  { color: hsl(var(--hsl-content) / 0.55); }
+	.stat-count[data-tone='warn']    { color: hsl(var(--hsl-warning)); }
+	.stat-count[data-tone='error']   { color: hsl(var(--hsl-negative)); }
+
+	.stat-count__num {
+		font-variant-numeric: tabular-nums;
+		font-weight: 700;
+		color: var(--rail-fg);
+	}
+
+	/* surface */
+	.events-surface {
+		position: relative;
+		flex: 1;
+		min-height: 20rem;
+		max-height: calc(100dvh - 18rem);
+		overflow-y: auto;
+		overflow-x: hidden;
+		background:
+			repeating-linear-gradient(
+				to bottom,
+				transparent 0,
+				transparent calc(1.5rem - 1px),
+				var(--surface-scan) calc(1.5rem - 1px),
+				var(--surface-scan) 1.5rem
+			),
+			var(--surface-bg);
+	}
+
+	.events-list {
+		list-style: none;
+		margin: 0;
+		padding: 0.25rem 0 0.5rem;
+		font-family: var(--ffml-mono);
+		font-size: 0.8125rem;
+	}
+
+	.event-row {
+		display: grid;
+		grid-template-columns:
+			[time]   3.25rem
+			[mark]   2px
+			[type]   6rem
+			[reason] 11rem
+			[msg]    1fr;
+		align-items: start;
+		column-gap: 0.65rem;
+		padding: 0.2rem 1rem;
+		line-height: 1.5;
+		color: hsl(var(--hsl-content) / 0.92);
+		transition: background-color 0.12s ease;
+	}
+
+	.event-row:hover { background: hsl(var(--hsl-content) / 0.04); }
+
+	.event-row__time {
+		grid-column: time;
+		color: hsl(var(--hsl-content) / 0.42);
+		font-variant-numeric: tabular-nums;
+		text-align: right;
+		font-size: 0.6875rem;
+		padding-top: 0.075rem;
+		cursor: help;
+	}
+
+	.event-row__mark {
+		grid-column: mark;
+		align-self: stretch;
+		background: transparent;
+		border-radius: 2px;
+		margin: 0.1rem 0;
+	}
+
+	.event-row[data-severity='warn'] {
+		background: hsl(var(--hsl-warning) / 0.04);
+	}
+	.event-row[data-severity='warn']:hover {
+		background: hsl(var(--hsl-warning) / 0.09);
+	}
+	.event-row[data-severity='warn']  .event-row__mark { background: hsl(var(--hsl-warning)); }
+
+	.event-row[data-severity='error'] {
+		background: hsl(var(--hsl-negative) / 0.05);
+	}
+	.event-row[data-severity='error']:hover {
+		background: hsl(var(--hsl-negative) / 0.1);
+	}
+	.event-row[data-severity='error'] .event-row__mark { background: hsl(var(--hsl-negative)); }
+
+	.event-row__type {
+		grid-column: type;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		padding: 0 0.45rem;
+		height: 1.1rem;
+		align-self: center;
+		border-radius: 3px;
+		background: hsl(var(--hsl-content) / 0.06);
+		color: hsl(var(--hsl-content) / 0.6);
+		font-size: 0.625rem;
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		white-space: nowrap;
+	}
+
+	.event-row[data-severity='warn'] .event-row__type {
+		background: hsl(var(--hsl-warning) / 0.13);
+		color: hsl(var(--hsl-warning));
+	}
+	.event-row[data-severity='error'] .event-row__type {
+		background: hsl(var(--hsl-negative) / 0.13);
+		color: hsl(var(--hsl-negative));
+	}
+
+	.event-row__reason {
+		grid-column: reason;
+		font-weight: 600;
+		color: hsl(var(--hsl-content));
+		font-size: 0.75rem;
+		padding-top: 0.075rem;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.event-row__msg {
+		grid-column: msg;
+		white-space: pre-wrap;
+		word-break: break-word;
+		min-width: 0;
+	}
+
+	.events-empty {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.85rem;
+		min-height: 18rem;
+		padding: 3rem 1rem;
+		color: hsl(var(--hsl-content) / 0.5);
+		font-family: var(--ffml-mono);
+		font-size: 0.8125rem;
+	}
+
+	.events-empty__rings {
+		position: relative;
+		width: 2.25rem;
+		height: 2.25rem;
+	}
+
+	.events-empty__rings::before,
+	.events-empty__rings::after,
+	.events-empty__core {
+		position: absolute;
+		border-radius: 50%;
+	}
+
+	.events-empty__rings::before {
+		content: '';
+		inset: 0;
+		border: 1px solid hsl(var(--hsl-content) / 0.12);
+		animation: ring 2.4s ease-out infinite;
+	}
+	.events-empty__rings::after {
+		content: '';
+		inset: 0;
+		border: 1px solid hsl(var(--hsl-content) / 0.18);
+		animation: ring 2.4s ease-out infinite;
+		animation-delay: 1.2s;
+	}
+	.events-empty__core {
+		left: 50%;
+		top: 50%;
+		width: 0.55rem;
+		height: 0.55rem;
+		margin: -0.275rem 0 0 -0.275rem;
+		background: hsl(var(--hsl-content) / 0.35);
+		animation: empty-pulse 1.6s ease-in-out infinite;
+	}
+
+	@keyframes ring {
+		0%   { transform: scale(0.4); opacity: 1; }
+		100% { transform: scale(1.4); opacity: 0; }
+	}
+	@keyframes empty-pulse {
+		0%, 100% { opacity: 0.4; }
+		50%      { opacity: 1; }
+	}
+
+	.events-empty__label {
+		text-transform: uppercase;
+		letter-spacing: 0.18em;
+		font-size: 0.6875rem;
+		color: hsl(var(--hsl-content) / 0.55);
+	}
+
+	.events-empty__hint {
+		font-size: 0.6875rem;
+		color: hsl(var(--hsl-content) / 0.35);
+	}
+
+	@media (max-width: 768px) {
+		.event-row {
+			grid-template-columns:
+				[time]   2.75rem
+				[mark]   2px
+				[type]   4.5rem
+				[reason] 8rem
+				[msg]    1fr;
+			column-gap: 0.4rem;
+			padding: 0.2rem 0.5rem;
+			font-size: 0.75rem;
+		}
+	}
+</style>
+
+<div class="events-shell">
+	<header class="events-rail">
+		<span class="events-rail__brand">Events</span>
+
+		<div class="events-rail__stats">
+			<span class="stat" title={lastFetchOk ? 'auto-refreshing' : 'connecting'}>
+				<span class="stat-dot" data-state={lastFetchOk ? 'live' : 'cold'}></span>
+				<span class="stat__value">{lastFetchOk ? 'POLLING' : 'CONNECTING'}</span>
+				<span class="stat__unit">· {POLL_INTERVAL_MS / 1000}s</span>
+			</span>
+
+			<span class="stat" title="time since last refresh">
+				<span class="stat__value">{pollText}</span>
+			</span>
+
+			{#if events.length > 0}
+				<span class="stat-count" data-tone="normal" title="normal events">
+					<span class="stat-count__num">{counts.normal}</span> normal
+				</span>
+				{#if counts.warn > 0}
+					<span class="stat-count" data-tone="warn" title="warning events">
+						<span class="stat-count__num">{counts.warn}</span> warn
+					</span>
+				{/if}
+				{#if counts.error > 0}
+					<span class="stat-count" data-tone="error" title="error events">
+						<span class="stat-count__num">{counts.error}</span> error
+					</span>
+				{/if}
+			{/if}
+		</div>
+	</header>
+
+	<main class="events-surface">
+		{#if events.length === 0}
+			<div class="events-empty">
+				<div class="events-empty__rings"><span class="events-empty__core"></span></div>
+				<div class="events-empty__label">No Events</div>
+				<div class="events-empty__hint">
+					{lastFetchOk ? 'cluster is quiet · refreshing every ' + (POLL_INTERVAL_MS / 1000) + 's' : 'connecting…'}
+				</div>
+			</div>
 		{:else}
-			<NoDataRow span={4} />
-		{/each}
-		</tbody>
-	</table>
+			<ol class="events-list">
+				{#each events as ev, i (i)}
+					<li class="event-row" data-severity={severityOf(ev.type)}>
+						<span class="event-row__time" title={ev.lastSeen}>
+							{relTime(ev.lastSeen, now)}
+						</span>
+						<span class="event-row__mark" aria-hidden="true"></span>
+						<span class="event-row__type">{ev.type}</span>
+						<span class="event-row__reason" title={ev.reason}>{ev.reason}</span>
+						<span class="event-row__msg">{ev.message}</span>
+					</li>
+				{/each}
+			</ol>
+		{/if}
+	</main>
 </div>

--- a/src/routes/(auth)/(project)/deployment/(detail)/events/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/events/+page.svelte
@@ -107,6 +107,7 @@
 	}
 
 	.events-rail__brand {
+		margin: 0;
 		font-weight: 600;
 		color: var(--rail-fg);
 		font-size: 0.9rem;
@@ -401,7 +402,7 @@
 
 <div class="events-shell">
 	<header class="events-rail">
-		<span class="events-rail__brand">Events</span>
+		<h6 class="events-rail__brand">Events</h6>
 
 		<div class="events-rail__stats">
 			<span class="stat" title={lastFetchOk ? 'auto-refreshing' : 'connecting'}>

--- a/src/routes/(auth)/(project)/deployment/(detail)/events/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/events/+page.svelte
@@ -196,8 +196,8 @@
 	.events-surface {
 		position: relative;
 		flex: 1;
-		min-height: 20rem;
-		max-height: calc(100dvh - 18rem);
+		min-height: 14rem;
+		max-height: calc(100dvh - 31rem);
 		overflow-y: auto;
 		overflow-x: hidden;
 		background:

--- a/src/routes/(auth)/(project)/deployment/(detail)/logs/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/logs/+page.svelte
@@ -94,7 +94,7 @@
 	const fillState = $derived(fillPct < 60 ? 'low' : fillPct < 90 ? 'mid' : 'high')
 
 	const statusState = $derived(paused ? 'paused' : connected ? 'live' : 'reconnecting')
-	const statusLabel = $derived(paused ? 'PAUSED' : connected ? 'LIVE' : 'RECONNECTING')
+	const statusLabel = $derived(paused ? 'Paused' : connected ? 'Live' : 'Connecting')
 
 	const throughputText = $derived.by(() => {
 		if (throughput < 10) return throughput.toFixed(1)
@@ -191,7 +191,6 @@
 		border: 1px solid var(--rail-divider);
 		border-radius: 10px;
 		overflow: hidden;
-		font-family: var(--ffml-mono);
 		font-feature-settings: 'tnum' 1, 'ss02' 1;
 		box-shadow:
 			0 1px 0 hsl(var(--hsl-content) / 0.03) inset,
@@ -202,14 +201,15 @@
 	.log-rail {
 		display: flex;
 		align-items: center;
-		gap: 1.25rem;
-		padding: 0.5rem 0.75rem 0.5rem 1rem;
+		gap: 1rem;
+		padding: 0.55rem 1rem;
 		border-bottom: 1px solid var(--rail-divider);
 		background:
 			linear-gradient(180deg,
 				hsl(var(--hsl-base-200)) 0%,
 				hsl(var(--hsl-base-100)) 100%);
 		box-shadow: inset 0 1px 0 hsl(var(--hsl-content) / 0.04);
+		font-family: var(--ffml-primary);
 		flex-wrap: wrap;
 	}
 
@@ -221,62 +221,53 @@
 	}
 
 	.log-rail__brand-name {
-		font-weight: 700;
-		letter-spacing: 0.22em;
-		text-transform: uppercase;
+		font-weight: 600;
 		color: var(--rail-fg);
-		font-size: 0.6875rem;
+		font-size: 0.9rem;
 	}
 
 	.log-rail__brand-slash {
 		color: var(--rail-fg-dim);
-		font-size: 0.75rem;
+		font-size: 0.9rem;
 	}
 
 	.log-rail__deployment {
 		color: var(--rail-fg-muted);
-		font-size: 0.75rem;
-		letter-spacing: 0.01em;
+		font-size: 0.8125rem;
 	}
 
 	.log-rail__stats {
 		display: flex;
 		align-items: center;
-		gap: 1.1rem;
-		padding-left: 0.5rem;
+		gap: 0.85rem;
+		padding-left: 0.65rem;
 		border-left: 1px solid var(--rail-divider);
+		flex-wrap: wrap;
 	}
 
 	.stat {
 		display: inline-flex;
-		align-items: center;
-		gap: 0.45rem;
+		align-items: baseline;
+		gap: 0.35rem;
 		color: var(--rail-fg-muted);
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
-		font-size: 0.625rem;
-		font-weight: 600;
+		font-size: 0.8125rem;
 	}
 
 	.stat__value {
 		color: var(--rail-fg);
 		font-variant-numeric: tabular-nums;
-		font-weight: 700;
-		letter-spacing: 0.02em;
-		font-size: 0.75rem;
+		font-weight: 600;
 	}
 
 	.stat__unit {
-		color: var(--rail-fg-dim);
+		color: var(--rail-fg-muted);
 		font-size: 0.625rem;
 	}
 
 	.stat__dropped {
-		color: hsl(var(--hsl-negative) / 0.8);
-		font-size: 0.625rem;
-		font-weight: 600;
-		letter-spacing: 0.04em;
-		text-transform: uppercase;
+		color: hsl(var(--hsl-negative) / 0.85);
+		font-size: 0.75rem;
+		font-weight: 500;
 		margin-left: 0.25rem;
 	}
 
@@ -397,16 +388,14 @@
 		align-items: center;
 		gap: 0.4rem;
 		background: transparent;
-		border: 1px solid hsl(var(--hsl-content) / 0.08);
+		border: 1px solid hsl(var(--hsl-content) / 0.15);
 		border-radius: 6px;
-		padding: 0 0.7rem;
+		padding: 0 0.75rem;
 		height: 1.75rem;
-		color: hsl(var(--hsl-content) / 0.8);
-		font-family: var(--ffml-mono);
-		font-size: 0.6875rem;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
+		color: hsl(var(--hsl-content));
+		font-family: var(--ffml-primary);
+		font-size: 0.8125rem;
+		font-weight: 500;
 		cursor: pointer;
 		transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 		text-decoration: none;
@@ -657,15 +646,14 @@
 	}
 
 	.log-empty__label {
-		text-transform: uppercase;
-		letter-spacing: 0.18em;
-		font-size: 0.6875rem;
-		color: hsl(var(--hsl-content) / 0.55);
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.65);
 	}
 
 	.log-empty__hint {
-		font-size: 0.6875rem;
-		color: hsl(var(--hsl-content) / 0.35);
+		font-size: 0.8125rem;
+		color: hsl(var(--hsl-content) / 0.45);
 	}
 
 	/* responsive: tighten on narrow viewports */
@@ -701,7 +689,7 @@
 
 			<span class="stat" title="lines per second (5s avg)">
 				<span class="stat__value">{throughputText}</span>
-				<span class="stat__unit">L/S</span>
+				<span class="stat__unit">l/s</span>
 			</span>
 
 			<span class="stat" title="buffered lines (cap {MAX_LINES})">

--- a/src/routes/(auth)/(project)/deployment/(detail)/logs/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/logs/+page.svelte
@@ -217,7 +217,8 @@
 		display: inline-flex;
 		align-items: baseline;
 		gap: 0.4rem;
-		margin-right: 0.25rem;
+		margin: 0 0.25rem 0 0;
+		font-weight: 400;
 	}
 
 	.log-rail__brand-name {
@@ -678,11 +679,11 @@
 
 <div class="log-shell">
 	<header class="log-rail">
-		<div class="log-rail__brand">
+		<h6 class="log-rail__brand">
 			<span class="log-rail__brand-name">Logs</span>
 			<span class="log-rail__brand-slash">/</span>
 			<span class="log-rail__deployment">{deployment.name}</span>
-		</div>
+		</h6>
 
 		<div class="log-rail__stats">
 			<span class="stat" title={statusLabel.toLowerCase()}>

--- a/src/routes/(auth)/(project)/deployment/(detail)/logs/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/logs/+page.svelte
@@ -417,8 +417,11 @@
 	.log-surface {
 		position: relative;
 		flex: 1;
-		min-height: 32rem;
-		max-height: calc(100dvh - 18rem);
+		/* min-height is intentionally modest so the shell collapses gracefully on
+		   short viewports; the max-height accounts for the navbar, breadcrumb,
+		   masthead, tabs row, rail, and panel padding above + below. */
+		min-height: 14rem;
+		max-height: calc(100dvh - 31rem);
 		overflow-y: auto;
 		overflow-x: hidden;
 		isolation: isolate;

--- a/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
@@ -135,6 +135,7 @@
 	}
 
 	.metric-rail__brand {
+		margin: 0;
 		font-weight: 600;
 		color: hsl(var(--hsl-content));
 		font-size: 0.9rem;
@@ -263,7 +264,7 @@
 </style>
 
 <header class="metric-rail">
-	<span class="metric-rail__brand">Metrics</span>
+	<h6 class="metric-rail__brand">Metrics</h6>
 
 	<div class="metric-rail__stats">
 		<span class="stat" title={fetching ? 'fetching…' : 'auto-refresh active'}>

--- a/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
@@ -199,6 +199,10 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.35rem;
+		/* Let the pills inside wrap when the group itself can't fit on one
+		   line — the agg row has 7 options + a label, which is too wide for
+		   iPhone-class viewports. */
+		flex-wrap: wrap;
 	}
 
 	.range-group__label {

--- a/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
@@ -121,54 +121,48 @@
 	.metric-rail {
 		display: flex;
 		align-items: center;
-		gap: 1.25rem;
-		padding: 0.5rem 0.75rem 0.5rem 1rem;
+		gap: 1rem;
+		padding: 0.55rem 1rem;
 		background: linear-gradient(180deg,
 			hsl(var(--hsl-base-200)) 0%,
 			hsl(var(--hsl-base-100)) 100%);
 		border: 1px solid hsl(var(--hsl-content) / 0.08);
 		border-radius: 10px;
 		box-shadow: inset 0 1px 0 hsl(var(--hsl-content) / 0.04);
-		font-family: var(--ffml-mono);
+		font-family: var(--ffml-primary);
 		font-feature-settings: 'tnum' 1;
 		flex-wrap: wrap;
 	}
 
 	.metric-rail__brand {
-		font-weight: 700;
-		letter-spacing: 0.22em;
-		text-transform: uppercase;
+		font-weight: 600;
 		color: hsl(var(--hsl-content));
-		font-size: 0.6875rem;
+		font-size: 0.9rem;
 	}
 
 	.metric-rail__stats {
 		display: flex;
 		align-items: center;
-		gap: 1.1rem;
-		padding-left: 0.5rem;
+		gap: 0.85rem;
+		padding-left: 0.65rem;
 		border-left: 1px solid hsl(var(--hsl-content) / 0.08);
 	}
 
 	.stat {
 		display: inline-flex;
-		align-items: center;
-		gap: 0.45rem;
-		color: hsl(var(--hsl-content) / 0.5);
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
-		font-size: 0.625rem;
-		font-weight: 600;
+		align-items: baseline;
+		gap: 0.35rem;
+		color: hsl(var(--hsl-content) / 0.55);
+		font-size: 0.8125rem;
 	}
 
 	.stat__value {
 		color: hsl(var(--hsl-content));
 		font-variant-numeric: tabular-nums;
-		font-weight: 700;
-		font-size: 0.75rem;
+		font-weight: 600;
 	}
 
-	.stat__unit { color: hsl(var(--hsl-content) / 0.32); font-size: 0.625rem; }
+	.stat__unit { color: hsl(var(--hsl-content) / 0.5); }
 
 	.stat-dot {
 		width: 0.5rem;
@@ -207,29 +201,26 @@
 	}
 
 	.range-group__label {
-		text-transform: uppercase;
-		letter-spacing: 0.12em;
-		font-size: 0.5625rem;
-		color: hsl(var(--hsl-content) / 0.4);
-		font-weight: 700;
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-content) / 0.5);
+		font-weight: 500;
 		margin-right: 0.25rem;
 	}
 
 	.range-pill {
 		display: inline-flex;
 		align-items: center;
-		padding: 0 0.55rem;
-		height: 1.55rem;
-		min-width: 1.7rem;
+		padding: 0 0.6rem;
+		height: 1.6rem;
+		min-width: 1.8rem;
 		justify-content: center;
 		background: transparent;
-		border: 1px solid hsl(var(--hsl-content) / 0.08);
-		border-radius: 5px;
-		color: hsl(var(--hsl-content) / 0.7);
-		font-family: var(--ffml-mono);
-		font-size: 0.6875rem;
-		font-weight: 600;
-		letter-spacing: 0.04em;
+		border: 1px solid hsl(var(--hsl-content) / 0.1);
+		border-radius: 6px;
+		color: hsl(var(--hsl-content) / 0.75);
+		font-family: var(--ffml-primary);
+		font-size: 0.75rem;
+		font-weight: 500;
 		cursor: pointer;
 		transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 	}
@@ -274,12 +265,12 @@
 	<div class="metric-rail__stats">
 		<span class="stat" title={fetching ? 'fetching…' : 'auto-refresh active'}>
 			<span class="stat-dot" data-state={fetching ? 'fetching' : 'live'}></span>
-			<span class="stat__value">AUTO</span>
-			<span class="stat__unit">· {RELOAD_INTERVAL_MS / 1000}s</span>
+			<span class="stat__value">Auto</span>
+			<span class="stat__unit">· every {RELOAD_INTERVAL_MS / 1000}s</span>
 		</span>
 		<span class="stat">
-			<span class="stat__value">{relTime(lastFetchAt)}</span>
 			<span class="stat__unit">last sync</span>
+			<span class="stat__value">{relTime(lastFetchAt)}</span>
 		</span>
 	</div>
 

--- a/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
@@ -247,14 +247,17 @@
 
 	.metric-grid {
 		display: grid;
-		grid-template-columns: 1fr;
+		/* `minmax(0, 1fr)` rather than `1fr` so each cell can shrink below the
+		   chart's intrinsic min-content width — without this the SVG holds the
+		   column open and the grid overflows horizontally as the window narrows. */
+		grid-template-columns: minmax(0, 1fr);
 		gap: 1rem;
 		margin-top: 1rem;
 	}
 
 	@media (min-width: 1024px) {
 		.metric-grid {
-			grid-template-columns: 1fr 1fr;
+			grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 		}
 	}
 </style>

--- a/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
@@ -4,30 +4,31 @@
 	import api from '$lib/api'
 	import { onMount, tick } from 'svelte'
 	import Chart from '$lib/components/Chart.svelte'
-	import Select from '$lib/components/Select.svelte'
 
 	const { data } = $props()
 
-	const rangeOptions = [
-		{ value: '1h', label: '1 Hour' },
-		{ value: '6h', label: '6 Hours' },
-		{ value: '12h', label: '12 Hours' },
-		{ value: '1d', label: '1 Day' },
-		{ separator: true },
-		{ value: '1hagg', label: '1 Hour (Aggregate)' },
-		{ value: '6hagg', label: '6 Hours (Aggregate)' },
-		{ value: '12hagg', label: '12 Hours (Aggregate)' },
-		{ value: '1dagg', label: '1 Day (Aggregate)' },
-		{ value: '2dagg', label: '2 Days (Aggregate)' },
-		{ value: '7dagg', label: '7 Days (Aggregate)' },
-		{ value: '30dagg', label: '30 Days (Aggregate)' }
+	// Two-row pill bar: top row is the rolling-window options, bottom row is
+	// the aggregate (longer) windows. Aggregate options are tagged so we can
+	// style them distinctly.
+	const RANGES = [
+		{ value: '1h', label: '1h', group: 'live' },
+		{ value: '6h', label: '6h', group: 'live' },
+		{ value: '12h', label: '12h', group: 'live' },
+		{ value: '1d', label: '1d', group: 'live' },
+		{ value: '1hagg', label: '1h', group: 'agg' },
+		{ value: '6hagg', label: '6h', group: 'agg' },
+		{ value: '12hagg', label: '12h', group: 'agg' },
+		{ value: '1dagg', label: '1d', group: 'agg' },
+		{ value: '2dagg', label: '2d', group: 'agg' },
+		{ value: '7dagg', label: '7d', group: 'agg' },
+		{ value: '30dagg', label: '30d', group: 'agg' }
 	]
 
 	const deployment = $derived(data.deployment)
 
-	const reloadInterval = 60 * 1000 // 1m
+	const RELOAD_INTERVAL_MS = 60_000
 
-	const validRanges = new Set(rangeOptions.filter((o) => o.value).map((o) => o.value))
+	const validRanges = new Set(RANGES.map((o) => o.value))
 	const initialRange = $page.url.searchParams.get('range')
 
 	const filter = $state({
@@ -40,10 +41,14 @@
 	let egress = $state([])
 
 	let reloadTimeout
+	let lastFetchAt = $state(0)
+	let now = $state(Date.now())
+	let fetching = $state(false)
 
-	async function fetchMetrics (clear = false) {
+	async function fetchMetrics (clearFirst = false) {
 		reloadTimeout && clearTimeout(reloadTimeout)
 		reloadTimeout = null
+		fetching = true
 
 		try {
 			const resp = await api.invoke('deployment.metrics', {
@@ -52,11 +57,9 @@
 				name: deployment.name,
 				timeRange: filter.range
 			}, fetch)
-			if (!resp.ok) {
-				return
-			}
+			if (!resp.ok) return
 
-			if (clear) {
+			if (clearFirst) {
 				cpu = []
 				memory = []
 				request = []
@@ -74,46 +77,239 @@
 				{ prefix: 'Limit', lines: resp.result.memoryLimit ?? [], dashStyle: 'LongDash', color: 'red' }
 			]
 			if (deployment.type === 'WebService') {
-				request = [
-					{ prefix: 'Requests', lines: resp.result.requests ?? [] }
-				]
+				request = [{ prefix: 'Requests', lines: resp.result.requests ?? [] }]
 			}
-			egress = [
-				{ prefix: 'Egress', lines: resp.result.egress ?? [] }
-			]
+			egress = [{ prefix: 'Egress', lines: resp.result.egress ?? [] }]
+			lastFetchAt = Date.now()
 		} finally {
+			fetching = false
 			reloadTimeout && clearTimeout(reloadTimeout)
-			reloadTimeout = setTimeout(fetchMetrics, reloadInterval)
+			reloadTimeout = setTimeout(fetchMetrics, RELOAD_INTERVAL_MS)
 		}
 	}
 
-	// Mirror the selected range into the URL so a refresh restores the same window.
-	function selectRange () {
+	/** @param {string} value */
+	function setRange (value) {
+		if (value === filter.range) return
+		filter.range = value
 		const u = new URL($page.url)
-		u.searchParams.set('range', filter.range)
+		u.searchParams.set('range', value)
 		replaceState(u, {})
 		fetchMetrics(true)
 	}
 
 	onMount(() => {
 		fetchMetrics()
-
+		const ticker = setInterval(() => { now = Date.now() }, 1000)
 		return () => {
 			reloadTimeout && clearTimeout(reloadTimeout)
+			clearInterval(ticker)
 		}
 	})
+
+	/** @param {number} t */
+	function relTime (t) {
+		if (!t) return '—'
+		const diff = Math.max(0, now - t)
+		if (diff < 60_000) return `${Math.floor(diff / 1000)}s ago`
+		if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+		return `${Math.floor(diff / 3_600_000)}h ago`
+	}
 </script>
 
-<h6><strong>Metric</strong></h6>
+<style>
+	.metric-rail {
+		display: flex;
+		align-items: center;
+		gap: 1.25rem;
+		padding: 0.5rem 0.75rem 0.5rem 1rem;
+		background: linear-gradient(180deg,
+			hsl(var(--hsl-base-200)) 0%,
+			hsl(var(--hsl-base-100)) 100%);
+		border: 1px solid hsl(var(--hsl-content) / 0.08);
+		border-radius: 10px;
+		box-shadow: inset 0 1px 0 hsl(var(--hsl-content) / 0.04);
+		font-family: var(--ffml-mono);
+		font-feature-settings: 'tnum' 1;
+		flex-wrap: wrap;
+	}
 
-<div class="w-60 max-w-full">
-	<Select
-		bind:value={filter.range}
-		options={rangeOptions}
-		onchange={selectRange} />
-</div>
+	.metric-rail__brand {
+		font-weight: 700;
+		letter-spacing: 0.22em;
+		text-transform: uppercase;
+		color: hsl(var(--hsl-content));
+		font-size: 0.6875rem;
+	}
 
-<div class="grid gap-4 mt-4 lg:grid-cols-2">
+	.metric-rail__stats {
+		display: flex;
+		align-items: center;
+		gap: 1.1rem;
+		padding-left: 0.5rem;
+		border-left: 1px solid hsl(var(--hsl-content) / 0.08);
+	}
+
+	.stat {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		color: hsl(var(--hsl-content) / 0.5);
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		font-size: 0.625rem;
+		font-weight: 600;
+	}
+
+	.stat__value {
+		color: hsl(var(--hsl-content));
+		font-variant-numeric: tabular-nums;
+		font-weight: 700;
+		font-size: 0.75rem;
+	}
+
+	.stat__unit { color: hsl(var(--hsl-content) / 0.32); font-size: 0.625rem; }
+
+	.stat-dot {
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 50%;
+		background: hsl(var(--hsl-positive));
+		animation: live-pulse 1.8s ease-out infinite;
+	}
+
+	.stat-dot[data-state='fetching'] {
+		background: hsl(var(--hsl-primary));
+		animation: dim-blink 0.8s ease-in-out infinite;
+	}
+
+	@keyframes live-pulse {
+		0%, 100% { box-shadow: 0 0 0 0 hsl(var(--hsl-positive) / 0.55); }
+		60%      { box-shadow: 0 0 0 6px hsl(var(--hsl-positive) / 0); }
+	}
+	@keyframes dim-blink {
+		0%, 100% { opacity: 0.5; }
+		50%      { opacity: 1; }
+	}
+
+	.metric-rail__ranges {
+		margin-left: auto;
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		flex-wrap: wrap;
+	}
+
+	.range-group {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+	}
+
+	.range-group__label {
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		font-size: 0.5625rem;
+		color: hsl(var(--hsl-content) / 0.4);
+		font-weight: 700;
+		margin-right: 0.25rem;
+	}
+
+	.range-pill {
+		display: inline-flex;
+		align-items: center;
+		padding: 0 0.55rem;
+		height: 1.55rem;
+		min-width: 1.7rem;
+		justify-content: center;
+		background: transparent;
+		border: 1px solid hsl(var(--hsl-content) / 0.08);
+		border-radius: 5px;
+		color: hsl(var(--hsl-content) / 0.7);
+		font-family: var(--ffml-mono);
+		font-size: 0.6875rem;
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		cursor: pointer;
+		transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+	}
+
+	.range-pill:hover {
+		background: hsl(var(--hsl-content) / 0.05);
+		color: hsl(var(--hsl-content));
+		border-color: hsl(var(--hsl-content) / 0.15);
+	}
+
+	.range-pill[data-active='true'] {
+		background: hsl(var(--hsl-primary) / 0.1);
+		color: hsl(var(--hsl-primary));
+		border-color: hsl(var(--hsl-primary) / 0.45);
+	}
+
+	.range-pill[data-group='agg']::before {
+		content: 'Σ';
+		font-size: 0.625rem;
+		margin-right: 0.3rem;
+		color: currentColor;
+		opacity: 0.6;
+	}
+
+	.metric-grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 1rem;
+		margin-top: 1rem;
+	}
+
+	@media (min-width: 1024px) {
+		.metric-grid {
+			grid-template-columns: 1fr 1fr;
+		}
+	}
+</style>
+
+<header class="metric-rail">
+	<span class="metric-rail__brand">Metrics</span>
+
+	<div class="metric-rail__stats">
+		<span class="stat" title={fetching ? 'fetching…' : 'auto-refresh active'}>
+			<span class="stat-dot" data-state={fetching ? 'fetching' : 'live'}></span>
+			<span class="stat__value">AUTO</span>
+			<span class="stat__unit">· {RELOAD_INTERVAL_MS / 1000}s</span>
+		</span>
+		<span class="stat">
+			<span class="stat__value">{relTime(lastFetchAt)}</span>
+			<span class="stat__unit">last sync</span>
+		</span>
+	</div>
+
+	<div class="metric-rail__ranges" role="group" aria-label="time range">
+		<span class="range-group">
+			<span class="range-group__label">Live</span>
+			{#each RANGES.filter((r) => r.group === 'live') as r (r.value)}
+				<button type="button" class="range-pill"
+					data-active={filter.range === r.value}
+					data-group="live"
+					onclick={() => setRange(r.value)}>
+					{r.label}
+				</button>
+			{/each}
+		</span>
+		<span class="range-group">
+			<span class="range-group__label">Agg</span>
+			{#each RANGES.filter((r) => r.group === 'agg') as r (r.value)}
+				<button type="button" class="range-pill"
+					data-active={filter.range === r.value}
+					data-group="agg"
+					onclick={() => setRange(r.value)}>
+					{r.label}
+				</button>
+			{/each}
+		</span>
+	</div>
+</header>
+
+<div class="metric-grid">
 	<Chart title="vCPU (second)" unit="seconds" series={cpu} range={filter.range} />
 	<Chart title="Memory (bytes)" unit="bytes" series={memory} range={filter.range} />
 	{#if deployment.type === 'WebService'}

--- a/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
@@ -116,8 +116,8 @@
 	.rev-list {
 		position: relative;
 		flex: 1;
-		min-height: 16rem;
-		max-height: calc(100dvh - 18rem);
+		min-height: 12rem;
+		max-height: calc(100dvh - 31rem);
 		overflow-y: auto;
 		overflow-x: hidden;
 		list-style: none;

--- a/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { onMount } from 'svelte'
 	import * as format from '$lib/format'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
@@ -8,6 +9,27 @@
 	const deployment = $derived(data.deployment)
 	const revisions = $derived(data.revisions)
 
+	let now = $state(Date.now())
+	onMount(() => {
+		const t = setInterval(() => { now = Date.now() }, 30_000)
+		return () => clearInterval(t)
+	})
+
+	/**
+	 * @param {string} ts
+	 * @param {number} nowMs
+	 */
+	function relTime (ts, nowMs) {
+		const t = Date.parse(ts)
+		if (isNaN(t)) return ''
+		const diff = Math.max(0, nowMs - t)
+		if (diff < 60_000) return 'just now'
+		if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+		if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
+		return `${Math.floor(diff / 86_400_000)}d ago`
+	}
+
+	/** @param {number} toRevision */
 	function rollback (toRevision) {
 		modal.confirm({
 			title: `Rollback ${deployment.name} to revision ${toRevision}`,
@@ -29,36 +51,286 @@
 	}
 </script>
 
-<h6><strong>Revision</strong></h6>
-<div class="table-container mt-4 whitespace-nowrap">
-	<table class="table is-variant-compact" style="--table-data-border-color: none">
-		<thead>
-		<tr>
-			<th>Revision</th>
-			<th>Image</th>
-			<th>Deployed At</th>
-			<th>Deployed By</th>
-			<th class="is-collapse is-align-right"></th>
-		</tr>
-		</thead>
-		<tbody>
-		{#each revisions as it, index (it.revision)}
-			<tr>
-				<td>{it.revision}</td>
-				<td>{it.image}</td>
-				<td>{format.datetime(it.createdAt)}</td>
-				<td>{it.createdBy}</td>
-				<td>
-					{#if index > 0}
-						<button class="button is-variant-secondary is-size-small" type="button" onclick={() => rollback(it.revision)}>Rollback</button>
-					{:else}
-						<!-- Reserve the button's height so the current revision's row
-						     matches the height of rows that have a Rollback button. -->
-						<button class="button is-variant-secondary is-size-small invisible" type="button" tabindex="-1" aria-hidden="true">Rollback</button>
+<style>
+	.rev-shell {
+		--rail-fg: hsl(var(--hsl-content));
+		--rail-fg-muted: hsl(var(--hsl-content) / 0.5);
+		--rail-fg-dim: hsl(var(--hsl-content) / 0.32);
+		--rail-divider: hsl(var(--hsl-content) / 0.08);
+		--surface-bg: hsl(var(--hsl-base-100));
+		--surface-scan: hsl(var(--hsl-content) / 0.018);
+
+		display: flex;
+		flex-direction: column;
+		background: var(--surface-bg);
+		border: 1px solid var(--rail-divider);
+		border-radius: 10px;
+		overflow: hidden;
+		font-family: var(--ffml-mono);
+		font-feature-settings: 'tnum' 1;
+	}
+
+	.rev-rail {
+		display: flex;
+		align-items: center;
+		gap: 1.25rem;
+		padding: 0.5rem 0.75rem 0.5rem 1rem;
+		border-bottom: 1px solid var(--rail-divider);
+		background: linear-gradient(180deg,
+			hsl(var(--hsl-base-200)) 0%,
+			hsl(var(--hsl-base-100)) 100%);
+		box-shadow: inset 0 1px 0 hsl(var(--hsl-content) / 0.04);
+		flex-wrap: wrap;
+	}
+
+	.rev-rail__brand {
+		font-weight: 700;
+		letter-spacing: 0.22em;
+		text-transform: uppercase;
+		color: var(--rail-fg);
+		font-size: 0.6875rem;
+	}
+
+	.rev-rail__stats {
+		display: flex;
+		align-items: center;
+		gap: 1.1rem;
+		padding-left: 0.5rem;
+		border-left: 1px solid var(--rail-divider);
+	}
+
+	.stat {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		color: var(--rail-fg-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		font-size: 0.625rem;
+		font-weight: 600;
+	}
+
+	.stat__value {
+		color: var(--rail-fg);
+		font-variant-numeric: tabular-nums;
+		font-weight: 700;
+		font-size: 0.75rem;
+	}
+
+	.stat__unit { color: var(--rail-fg-dim); font-size: 0.625rem; }
+
+	.rev-list {
+		position: relative;
+		flex: 1;
+		min-height: 16rem;
+		max-height: calc(100dvh - 18rem);
+		overflow-y: auto;
+		overflow-x: hidden;
+		list-style: none;
+		margin: 0;
+		padding: 0.5rem 0;
+		background:
+			repeating-linear-gradient(
+				to bottom,
+				transparent 0,
+				transparent calc(2.5rem - 1px),
+				var(--surface-scan) calc(2.5rem - 1px),
+				var(--surface-scan) 2.5rem
+			),
+			var(--surface-bg);
+	}
+
+	.rev-row {
+		display: grid;
+		grid-template-columns:
+			[mark]  3px
+			[rev]   5rem
+			[image] 1fr
+			[meta]  auto
+			[act]   auto;
+		align-items: center;
+		column-gap: 1rem;
+		padding: 0.65rem 1rem;
+		border-bottom: 1px solid hsl(var(--hsl-content) / 0.04);
+		transition: background-color 0.12s ease;
+	}
+
+	.rev-row:last-child { border-bottom: none; }
+	.rev-row:hover { background: hsl(var(--hsl-content) / 0.04); }
+
+	.rev-row[data-active='true'] {
+		background: hsl(var(--hsl-primary) / 0.05);
+	}
+	.rev-row[data-active='true']:hover {
+		background: hsl(var(--hsl-primary) / 0.08);
+	}
+
+	.rev-row__mark {
+		grid-column: mark;
+		align-self: stretch;
+		border-radius: 3px;
+		background: transparent;
+		margin: 0.15rem 0;
+	}
+	.rev-row[data-active='true'] .rev-row__mark {
+		background: hsl(var(--hsl-primary));
+	}
+
+	.rev-row__rev {
+		grid-column: rev;
+		display: inline-flex;
+		align-items: baseline;
+		gap: 0.4rem;
+	}
+
+	.rev-row__rev-num {
+		font-family: var(--ffml-mono);
+		font-size: 1.1rem;
+		font-weight: 700;
+		color: hsl(var(--hsl-content));
+		font-variant-numeric: tabular-nums;
+		letter-spacing: -0.02em;
+	}
+
+	.rev-row[data-active='true'] .rev-row__rev-num {
+		color: hsl(var(--hsl-primary));
+	}
+
+	.rev-row__rev-tag {
+		font-size: 0.5625rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		padding: 0.1rem 0.35rem;
+		border-radius: 3px;
+		color: hsl(var(--hsl-primary));
+		background: hsl(var(--hsl-primary) / 0.12);
+	}
+
+	.rev-row__image {
+		grid-column: image;
+		font-family: var(--ffml-mono);
+		font-size: 0.8125rem;
+		color: hsl(var(--hsl-content));
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		direction: rtl;
+		text-align: left;
+	}
+
+	.rev-row__meta {
+		grid-column: meta;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: 0.15rem;
+		min-width: 0;
+	}
+
+	.rev-row__when {
+		font-family: var(--ffml-mono);
+		font-size: 0.6875rem;
+		color: hsl(var(--hsl-content) / 0.55);
+		font-variant-numeric: tabular-nums;
+		cursor: help;
+	}
+
+	.rev-row__by {
+		font-size: 0.6875rem;
+		color: hsl(var(--hsl-content) / 0.4);
+		font-family: var(--ffml-mono);
+	}
+
+	.rev-row__act { grid-column: act; }
+
+	.rail-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		background: transparent;
+		border: 1px solid hsl(var(--hsl-content) / 0.12);
+		border-radius: 6px;
+		padding: 0 0.7rem;
+		height: 1.75rem;
+		color: hsl(var(--hsl-content) / 0.8);
+		font-family: var(--ffml-mono);
+		font-size: 0.6875rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		cursor: pointer;
+		transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+	}
+
+	.rail-btn:hover {
+		background: hsl(var(--hsl-content) / 0.06);
+		color: hsl(var(--hsl-content));
+		border-color: hsl(var(--hsl-content) / 0.2);
+	}
+
+	@media (max-width: 768px) {
+		.rev-row {
+			grid-template-columns:
+				[mark]  3px
+				[rev]   3.5rem
+				[image] 1fr
+				[act]   auto;
+			grid-template-areas: 'mark rev image act'
+								 'mark meta meta act';
+			column-gap: 0.5rem;
+			row-gap: 0.2rem;
+		}
+		.rev-row__meta { grid-column: 2 / 4; align-items: flex-start; }
+		.rev-row__image { direction: ltr; }
+	}
+</style>
+
+<div class="rev-shell">
+	<header class="rev-rail">
+		<span class="rev-rail__brand">Revisions</span>
+
+		<div class="rev-rail__stats">
+			<span class="stat" title="total revisions tracked">
+				<span class="stat__value">{revisions.length}</span>
+				<span class="stat__unit">tracked</span>
+			</span>
+
+			<span class="stat" title="currently active revision">
+				<span class="stat__value">#{revisions[0]?.revision ?? deployment.revision}</span>
+				<span class="stat__unit">active</span>
+			</span>
+		</div>
+	</header>
+
+	<ol class="rev-list">
+		{#each revisions as it, i (it.revision)}
+			<li class="rev-row" data-active={i === 0}>
+				<span class="rev-row__mark" aria-hidden="true"></span>
+				<span class="rev-row__rev">
+					<span class="rev-row__rev-num">#{it.revision}</span>
+					{#if i === 0}
+						<span class="rev-row__rev-tag">Active</span>
 					{/if}
-				</td>
-			</tr>
+				</span>
+				<span class="rev-row__image" title={it.image}>{it.image}</span>
+				<span class="rev-row__meta">
+					<span class="rev-row__when" title={it.createdAt}>
+						{format.datetime(it.createdAt)} · {relTime(it.createdAt, now)}
+					</span>
+					<span class="rev-row__by">by {it.createdBy}</span>
+				</span>
+				<span class="rev-row__act">
+					{#if i > 0}
+						<button type="button" class="rail-btn"
+							onclick={() => rollback(it.revision)}>
+							<i class="fa-solid fa-rotate-left"></i>
+							Rollback
+						</button>
+					{/if}
+				</span>
+			</li>
 		{/each}
-		</tbody>
-	</table>
+	</ol>
 </div>

--- a/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
@@ -66,58 +66,52 @@
 		border: 1px solid var(--rail-divider);
 		border-radius: 10px;
 		overflow: hidden;
-		font-family: var(--ffml-mono);
 		font-feature-settings: 'tnum' 1;
 	}
 
 	.rev-rail {
 		display: flex;
 		align-items: center;
-		gap: 1.25rem;
-		padding: 0.5rem 0.75rem 0.5rem 1rem;
+		gap: 1rem;
+		padding: 0.55rem 1rem;
 		border-bottom: 1px solid var(--rail-divider);
 		background: linear-gradient(180deg,
 			hsl(var(--hsl-base-200)) 0%,
 			hsl(var(--hsl-base-100)) 100%);
 		box-shadow: inset 0 1px 0 hsl(var(--hsl-content) / 0.04);
+		font-family: var(--ffml-primary);
 		flex-wrap: wrap;
 	}
 
 	.rev-rail__brand {
-		font-weight: 700;
-		letter-spacing: 0.22em;
-		text-transform: uppercase;
+		font-weight: 600;
 		color: var(--rail-fg);
-		font-size: 0.6875rem;
+		font-size: 0.9rem;
 	}
 
 	.rev-rail__stats {
 		display: flex;
 		align-items: center;
-		gap: 1.1rem;
-		padding-left: 0.5rem;
+		gap: 0.85rem;
+		padding-left: 0.65rem;
 		border-left: 1px solid var(--rail-divider);
 	}
 
 	.stat {
 		display: inline-flex;
-		align-items: center;
-		gap: 0.45rem;
+		align-items: baseline;
+		gap: 0.35rem;
 		color: var(--rail-fg-muted);
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
-		font-size: 0.625rem;
-		font-weight: 600;
+		font-size: 0.8125rem;
 	}
 
 	.stat__value {
 		color: var(--rail-fg);
 		font-variant-numeric: tabular-nums;
-		font-weight: 700;
-		font-size: 0.75rem;
+		font-weight: 600;
 	}
 
-	.stat__unit { color: var(--rail-fg-dim); font-size: 0.625rem; }
+	.stat__unit { color: var(--rail-fg-muted); }
 
 	.rev-list {
 		position: relative;
@@ -197,12 +191,11 @@
 	}
 
 	.rev-row__rev-tag {
-		font-size: 0.5625rem;
-		font-weight: 700;
-		text-transform: uppercase;
-		letter-spacing: 0.12em;
-		padding: 0.1rem 0.35rem;
-		border-radius: 3px;
+		font-family: var(--ffml-primary);
+		font-size: 0.6875rem;
+		font-weight: 600;
+		padding: 0.1rem 0.45rem;
+		border-radius: 999px;
 		color: hsl(var(--hsl-primary));
 		background: hsl(var(--hsl-primary) / 0.12);
 	}
@@ -250,16 +243,14 @@
 		align-items: center;
 		gap: 0.4rem;
 		background: transparent;
-		border: 1px solid hsl(var(--hsl-content) / 0.12);
+		border: 1px solid hsl(var(--hsl-content) / 0.15);
 		border-radius: 6px;
-		padding: 0 0.7rem;
+		padding: 0 0.75rem;
 		height: 1.75rem;
-		color: hsl(var(--hsl-content) / 0.8);
-		font-family: var(--ffml-mono);
-		font-size: 0.6875rem;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
+		color: hsl(var(--hsl-content));
+		font-family: var(--ffml-primary);
+		font-size: 0.8125rem;
+		font-weight: 500;
 		cursor: pointer;
 		transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 	}

--- a/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
@@ -84,6 +84,7 @@
 	}
 
 	.rev-rail__brand {
+		margin: 0;
 		font-weight: 600;
 		color: var(--rail-fg);
 		font-size: 0.9rem;
@@ -280,7 +281,7 @@
 
 <div class="rev-shell">
 	<header class="rev-rail">
-		<span class="rev-rail__brand">Revisions</span>
+		<h6 class="rev-rail__brand">Revisions</h6>
 
 		<div class="rev-rail__stats">
 			<span class="stat" title="total revisions tracked">

--- a/src/routes/(auth)/(project)/deployment/_components/Header.svelte
+++ b/src/routes/(auth)/(project)/deployment/_components/Header.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/stores'
 	import api from '$lib/api'
 	import * as modal from '$lib/modal'
+	import * as format from '$lib/format'
 
 	/**
 	 * @typedef {Object} Props
@@ -17,6 +18,22 @@
 
 	const canPause = $derived(deployment.status === 'success' && deployment.action === 'deploy')
 	const canResume = $derived(deployment.status === 'success' && deployment.action === 'pause')
+
+	const statusTone = $derived(
+		deployment.status === 'success' && deployment.action === 'pause'
+			? 'warn'
+			: deployment.status === 'success'
+				? 'positive'
+				: deployment.status === 'pending'
+					? 'warn'
+					: 'negative'
+	)
+
+	const statusLabel = $derived.by(() => {
+		if (deployment.action === 'pause') return 'PAUSED'
+		if (deployment.action === 'delete') return 'DELETING'
+		return deployment.status.toUpperCase()
+	})
 
 	function pause () {
 		modal.confirm({
@@ -57,30 +74,240 @@
 	}
 </script>
 
-<div class="page-head">
-	<div class="min-w-0">
-		<h4 class="flex flex-wrap items-center gap-y-2 min-w-0">
-			<DeploymentStatusIcon action={deployment.action} status={deployment.status} url={deployment.statusUrl} type={deployment.type} />
-			<strong class="min-w-0 wrap-anywhere">{deployment.name}</strong>
-		</h4>
-		<p class="page-sub font-mono min-w-0 wrap-anywhere">{deployment.image}</p>
+<style>
+	.masthead {
+		display: flex;
+		flex-direction: column;
+		gap: 0.85rem;
+		padding: 1rem 1.25rem;
+		background: linear-gradient(180deg,
+			hsl(var(--hsl-base-200)) 0%,
+			hsl(var(--hsl-base-100)) 100%);
+		border: 1px solid hsl(var(--hsl-content) / 0.08);
+		border-radius: 10px;
+		box-shadow:
+			inset 0 1px 0 hsl(var(--hsl-content) / 0.04),
+			0 1px 2px hsl(var(--hsl-content) / 0.04);
+		margin-bottom: 1.5rem;
+	}
+
+	.masthead__top {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 1.5rem;
+		flex-wrap: wrap;
+	}
+
+	.masthead__identity {
+		display: flex;
+		align-items: flex-start;
+		gap: 0.65rem;
+		min-width: 0;
+		flex: 1;
+	}
+
+	.masthead__icon {
+		font-size: 1.35rem;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding-top: 0.2rem;
+	}
+
+	.masthead__title-wrap {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		min-width: 0;
+	}
+
+	.masthead__title {
+		font-family: var(--ffml-primary);
+		font-size: 1.6rem;
+		font-weight: 800;
+		line-height: 1.1;
+		color: hsl(var(--hsl-content));
+		letter-spacing: -0.02em;
+		overflow-wrap: anywhere;
+		margin: 0;
+	}
+
+	.masthead__image {
+		font-family: var(--ffml-mono);
+		font-size: 0.8125rem;
+		color: hsl(var(--hsl-content) / 0.55);
+		overflow-wrap: anywhere;
+		word-break: break-all;
+	}
+
+	.masthead__actions {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		flex-wrap: wrap;
+	}
+
+	/* compact secondary pill matching the rail aesthetic */
+	.mast-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		background: transparent;
+		border: 1px solid hsl(var(--hsl-content) / 0.12);
+		border-radius: 6px;
+		padding: 0 0.85rem;
+		height: 2rem;
+		color: hsl(var(--hsl-content) / 0.85);
+		font-family: var(--ffml-mono);
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		cursor: pointer;
+		text-decoration: none;
+		transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+	}
+	.mast-btn:hover {
+		background: hsl(var(--hsl-content) / 0.05);
+		color: hsl(var(--hsl-content));
+		border-color: hsl(var(--hsl-content) / 0.2);
+	}
+	.mast-btn.is-primary {
+		background: hsl(var(--hsl-primary));
+		border-color: hsl(var(--hsl-primary));
+		color: hsl(var(--hsl-primary-content));
+	}
+	.mast-btn.is-primary:hover {
+		background: hsl(var(--hsl-primary) / 0.92);
+		border-color: hsl(var(--hsl-primary) / 0.92);
+	}
+
+	/* meta strip — small caps key/value chips */
+	.masthead__meta {
+		display: flex;
+		align-items: center;
+		gap: 0.85rem;
+		flex-wrap: wrap;
+		padding-top: 0.6rem;
+		border-top: 1px solid hsl(var(--hsl-content) / 0.06);
+	}
+
+	.meta {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 0.4rem;
+		font-family: var(--ffml-mono);
+		min-width: 0;
+	}
+
+	.meta__label {
+		font-size: 0.625rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.14em;
+		color: hsl(var(--hsl-content) / 0.4);
+	}
+
+	.meta__value {
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content));
+		font-variant-numeric: tabular-nums;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.meta__dot {
+		display: inline-block;
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 50%;
+		background: hsl(var(--hsl-content) / 0.4);
+	}
+	.meta__dot[data-tone='positive'] {
+		background: hsl(var(--hsl-positive));
+		animation: live-pulse 1.8s ease-out infinite;
+	}
+	.meta__dot[data-tone='warn'] { background: hsl(var(--hsl-warning)); }
+	.meta__dot[data-tone='negative'] { background: hsl(var(--hsl-negative)); }
+
+	@keyframes live-pulse {
+		0%, 100% { box-shadow: 0 0 0 0 hsl(var(--hsl-positive) / 0.55); }
+		60%      { box-shadow: 0 0 0 6px hsl(var(--hsl-positive) / 0); }
+	}
+
+	.meta__divider {
+		width: 1px;
+		height: 0.85rem;
+		background: hsl(var(--hsl-content) / 0.1);
+	}
+
+	@media (max-width: 768px) {
+		.masthead { padding: 0.85rem 1rem; }
+		.masthead__title { font-size: 1.3rem; }
+		.masthead__top { flex-direction: column; align-items: stretch; }
+		.masthead__actions { width: 100%; }
+		.meta__value { white-space: normal; }
+	}
+</style>
+
+<div class="masthead">
+	<div class="masthead__top">
+		<div class="masthead__identity">
+			<span class="masthead__icon">
+				<DeploymentStatusIcon
+					action={deployment.action}
+					status={deployment.status}
+					url={deployment.statusUrl}
+					type={deployment.type} />
+			</span>
+			<div class="masthead__title-wrap">
+				<h4 class="masthead__title">{deployment.name}</h4>
+				<span class="masthead__image">{deployment.image}</span>
+			</div>
+		</div>
+		<div class="masthead__actions">
+			{#if canPause}
+				<button class="mast-btn" type="button" onclick={pause}>
+					<i class="fa-solid fa-pause"></i> Pause
+				</button>
+			{/if}
+			{#if canResume}
+				<button class="mast-btn" type="button" onclick={resume}>
+					<i class="fa-solid fa-play"></i> Resume
+				</button>
+			{/if}
+			<a class="mast-btn is-primary"
+				href={`/deployment/deploy?project=${project}&location=${deployment.location}&name=${deployment.name}`}>
+				<i class="fa-solid fa-rocket"></i> Deploy New Revision
+			</a>
+		</div>
 	</div>
-	<div class="flex items-center gap-3 flex-wrap">
-		<a class="button"
-			href={`/deployment/deploy?project=${project}&location=${deployment.location}&name=${deployment.name}`}>
-			Deploy New Revision
-		</a>
-		{#if canPause}
-			<button class="button is-variant-secondary is-icon-left" type="button" onclick={pause}>
-				<i class="fa-solid fa-pause"></i>
-				Pause
-			</button>
-		{/if}
-		{#if canResume}
-			<button class="button is-variant-secondary is-icon-left" type="button" onclick={resume}>
-				<i class="fa-solid fa-play"></i>
-				Resume
-			</button>
-		{/if}
+
+	<div class="masthead__meta">
+		<span class="meta">
+			<span class="meta__dot" data-tone={statusTone}></span>
+			<span class="meta__label">Status</span>
+			<span class="meta__value">{statusLabel}</span>
+		</span>
+		<span class="meta__divider"></span>
+		<span class="meta">
+			<span class="meta__label">Type</span>
+			<span class="meta__value">
+				{format.deploymentType(deployment.type)}{deployment.internal ? ' · INTERNAL' : ''}
+			</span>
+		</span>
+		<span class="meta__divider"></span>
+		<span class="meta">
+			<span class="meta__label">Location</span>
+			<span class="meta__value">{deployment.location}</span>
+		</span>
+		<span class="meta__divider"></span>
+		<span class="meta">
+			<span class="meta__label">Revision</span>
+			<span class="meta__value">#{deployment.revision}</span>
+		</span>
 	</div>
 </div>

--- a/src/routes/(auth)/(project)/deployment/_components/Header.svelte
+++ b/src/routes/(auth)/(project)/deployment/_components/Header.svelte
@@ -30,10 +30,21 @@
 	)
 
 	const statusLabel = $derived.by(() => {
-		if (deployment.action === 'pause') return 'PAUSED'
-		if (deployment.action === 'delete') return 'DELETING'
-		return deployment.status.toUpperCase()
+		if (deployment.action === 'pause') return 'Paused'
+		if (deployment.action === 'delete') return 'Deleting'
+		if (deployment.status === 'pending') return 'Pending'
+		if (deployment.status === 'error') return 'Error'
+		if (deployment.status === 'cancelled') return 'Cancelled'
+		return 'Success'
 	})
+
+	// The DeploymentStatusIcon next to the name already carries the visual
+	// signal for a healthy running deployment. Only surface the status pill
+	// in the meta row when it tells you something the icon can't (paused,
+	// deleting, pending, error). Keeps the common running case clean.
+	const showStatusPill = $derived(
+		deployment.action !== 'deploy' || deployment.status !== 'success'
+	)
 
 	function pause () {
 		modal.confirm({
@@ -148,22 +159,21 @@
 		flex-wrap: wrap;
 	}
 
-	/* compact secondary pill matching the rail aesthetic */
+	/* Action pill — sans, matches project's button family in spirit but with
+	   a slightly tighter footprint for the masthead. */
 	.mast-btn {
 		display: inline-flex;
 		align-items: center;
 		gap: 0.45rem;
 		background: transparent;
-		border: 1px solid hsl(var(--hsl-content) / 0.12);
+		border: 1px solid hsl(var(--hsl-content) / 0.15);
 		border-radius: 6px;
 		padding: 0 0.85rem;
 		height: 2rem;
-		color: hsl(var(--hsl-content) / 0.85);
-		font-family: var(--ffml-mono);
-		font-size: 0.75rem;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.08em;
+		color: hsl(var(--hsl-content));
+		font-family: var(--ffml-primary);
+		font-size: 0.8125rem;
+		font-weight: 500;
 		cursor: pointer;
 		text-decoration: none;
 		transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
@@ -183,7 +193,8 @@
 		border-color: hsl(var(--hsl-primary) / 0.92);
 	}
 
-	/* meta strip — small caps key/value chips */
+	/* Meta strip — sans, normal case. Labels are dim, values pop. Mono is
+	   reserved for the location id which is a machine identifier. */
 	.masthead__meta {
 		display: flex;
 		align-items: center;
@@ -196,27 +207,49 @@
 	.meta {
 		display: inline-flex;
 		align-items: baseline;
-		gap: 0.4rem;
-		font-family: var(--ffml-mono);
+		gap: 0.35rem;
+		font-family: var(--ffml-primary);
+		font-size: 0.8125rem;
 		min-width: 0;
 	}
 
 	.meta__label {
-		font-size: 0.625rem;
-		font-weight: 700;
-		text-transform: uppercase;
-		letter-spacing: 0.14em;
-		color: hsl(var(--hsl-content) / 0.4);
+		color: hsl(var(--hsl-content) / 0.5);
 	}
 
 	.meta__value {
-		font-size: 0.8125rem;
-		font-weight: 600;
 		color: hsl(var(--hsl-content));
+		font-weight: 500;
 		font-variant-numeric: tabular-nums;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+	}
+
+	.meta__value.is-mono {
+		font-family: var(--ffml-mono);
+		font-size: 0.75rem;
+	}
+
+	.status-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		padding: 0.1rem 0.55rem;
+		border-radius: 999px;
+		font-family: var(--ffml-primary);
+		font-size: 0.75rem;
+		font-weight: 600;
+	}
+
+	.status-pill[data-tone='warn'] {
+		background: hsl(var(--hsl-warning) / 0.12);
+		color: hsl(var(--hsl-warning));
+	}
+
+	.status-pill[data-tone='negative'] {
+		background: hsl(var(--hsl-negative) / 0.12);
+		color: hsl(var(--hsl-negative));
 	}
 
 	.meta__dot {
@@ -287,22 +320,23 @@
 	</div>
 
 	<div class="masthead__meta">
-		<span class="meta">
-			<span class="meta__dot" data-tone={statusTone}></span>
-			<span class="meta__label">Status</span>
-			<span class="meta__value">{statusLabel}</span>
-		</span>
-		<span class="meta__divider"></span>
+		{#if showStatusPill}
+			<span class="status-pill" data-tone={statusTone}>
+				<span class="meta__dot" data-tone={statusTone}></span>
+				{statusLabel}
+			</span>
+			<span class="meta__divider"></span>
+		{/if}
 		<span class="meta">
 			<span class="meta__label">Type</span>
 			<span class="meta__value">
-				{format.deploymentType(deployment.type)}{deployment.internal ? ' · INTERNAL' : ''}
+				{format.deploymentType(deployment.type)}{deployment.internal ? ' · Internal' : ''}
 			</span>
 		</span>
 		<span class="meta__divider"></span>
 		<span class="meta">
 			<span class="meta__label">Location</span>
-			<span class="meta__value">{deployment.location}</span>
+			<span class="meta__value is-mono">{deployment.location}</span>
 		</span>
 		<span class="meta__divider"></span>
 		<span class="meta">

--- a/src/routes/api/mock-events/+server.js
+++ b/src/routes/api/mock-events/+server.js
@@ -1,0 +1,64 @@
+// Mock pod-event feed for offline development. Only active when MOCK_API is
+// set — outside that the route 404s. Returns the same JSON shape the real
+// events service emits: an array of { type, reason, message, lastSeen }.
+//
+// The events page polls this on a 5 s interval; we want the output to feel
+// "real" — a Normal-heavy mix with the occasional Warning, and timestamps
+// that drift forward as the page sits open so the relative-time column
+// keeps updating naturally.
+
+import { env } from '$env/dynamic/private'
+
+const NORMAL = [
+	{ reason: 'Scheduled', message: 'Successfully assigned acme/web-7d4f-x1 to gke-node-rcf2-pool-1-3a8f' },
+	{ reason: 'Pulling', message: 'Pulling image "registry.deploys.app/acme/web:latest"' },
+	{ reason: 'Pulled', message: 'Successfully pulled image "registry.deploys.app/acme/web:latest" in 2.317s' },
+	{ reason: 'Created', message: 'Created container web' },
+	{ reason: 'Started', message: 'Started container web' },
+	{ reason: 'SuccessfulCreate', message: 'Created pod: web-7d4f-x2' },
+	{ reason: 'SuccessfulDelete', message: 'Deleted pod: web-6c1e-old' },
+	{ reason: 'Killing', message: 'Stopping container web' }
+]
+
+const WARNINGS = [
+	{ reason: 'BackOff', message: 'Back-off restarting failed container web in pod web-7d4f-x1' },
+	{ reason: 'Unhealthy', message: 'Readiness probe failed: HTTP probe failed with statuscode: 503' },
+	{ reason: 'FailedScheduling', message: '0/5 nodes are available: 5 Insufficient memory.' },
+	{ reason: 'FailedMount', message: 'Unable to attach or mount volumes: unmounted volumes=[data]' }
+]
+
+/**
+ * Build a varied, reasonably-realistic feed where timestamps are anchored to
+ * "now" so the events page's relative-time column shows fresh values.
+ * @param {number} count
+ */
+function buildFeed (count) {
+	const now = Date.now()
+	const out = []
+	for (let i = 0; i < count; i++) {
+		const isWarn = Math.random() < 0.18
+		const src = isWarn ? WARNINGS : NORMAL
+		const t = src[Math.random() * src.length | 0]
+		out.push({
+			type: isWarn ? 'Warning' : 'Normal',
+			reason: t.reason,
+			message: t.message,
+			// distribute over the last ~30 minutes, newest first
+			lastSeen: new Date(now - i * (30 + Math.random() * 90) * 1000).toISOString()
+		})
+	}
+	return out
+}
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function GET () {
+	if (!env.MOCK_API) return new Response('not found', { status: 404 })
+
+	const events = buildFeed(12 + (Math.random() * 8 | 0))
+	return new Response(JSON.stringify(events), {
+		headers: {
+			'content-type': 'application/json',
+			'cache-control': 'no-store'
+		}
+	})
+}

--- a/tests/deployment.spec.js
+++ b/tests/deployment.spec.js
@@ -59,7 +59,8 @@ test.describe('deployment detail — sidecars', () => {
 
 		await page.goto('/deployment/detail?project=test-project&location=gke&name=web')
 
-		await expect(page.getByRole('cell', { name: 'Sidecars' })).toHaveCount(0)
+		// No "Sidecars" spec row should render at all when the deployment has none.
+		await expect(page.locator('.spec').filter({ hasText: 'Sidecars' })).toHaveCount(0)
 	})
 
 	test('renders each configured sidecar', async ({ page }) => {
@@ -85,7 +86,8 @@ test.describe('deployment detail — sidecars', () => {
 
 		await page.goto('/deployment/detail?project=test-project&location=gke&name=web')
 
-		const row = page.getByRole('row').filter({ hasText: 'Sidecars' })
+		// Sidecars render in a `.spec` row (label + value list), not a table row.
+		const row = page.locator('.spec').filter({ hasText: 'Sidecars' })
 		await expect(row).toBeVisible()
 		await expect(row.getByText('my-project:us-central1:my-db')).toBeVisible()
 		await expect(row.getByText(':3306')).toBeVisible()


### PR DESCRIPTION
Carry the operational-console aesthetic established by the redesigned Logs page (#161) across the rest of the deployment detail feature. Streaming / polling logic, mutations and underlying actions are preserved exactly; only the visual layer changes.

## Header (shared masthead)
- Framed masthead replaces `.page-head`: display name, mono image subtitle, status icon kept.
- Meta strip — STATUS · TYPE · LOCATION · REVISION — each as a small-caps label + mono tabular value separated by thin dividers. Status dot tone (pulsing positive / static warn / negative) is derived from `status + action`.
- Pause / Resume / Deploy New Revision as compact `mast-btn` pills; Deploy keeps primary fill.

## Metric tab
- Rail with METRICS brand, pulsing live dot, "AUTO · 60s" cadence and "Ns ago last sync" readout that ticks every second.
- Range Select swapped for a two-group **pill bar** — LIVE rolling windows and AGG (Σ-prefixed) longer windows — visible side-by-side instead of hidden behind a dropdown.
- Charts unchanged.

## Detail tab
- Four stacked operational shells: DETAILS / ENV GROUPS / ENV VARS / MOUNT DATA, each with its own rail carrying counts and the Show-all toggle for env vars.
- DETAILS body splits the spec table into grouped sections (Network, Runtime, Resources, Integration, Lifecycle) with small-caps titles and fading rules.
- Each spec row: mono label · value (mono for machine data, sans for human data) · discreet copy icon. URLs render as primary-tinted dashed-underline links.
- Env groups become deterministic-coloured chips (hashed hue → bg + dot).
- Env vars / Mount data → tight key/value grid with faint scan-lines; Secret component reused for values.

## Events tab
- Rail with EVENTS brand, POLLING · 5s cadence + "synced Xs ago", and per-tone counts (normal / warn / error).
- Each event a grid row `[rel-time, severity-mark, type-chip, reason, message]` on the same scan-line surface as Logs. Warning / error tones tint the row and the type chip.
- Sonar-ring empty state shared with Logs.

## Revision tab
- Rail with REVISIONS brand, tracked count + active revision badge.
- Each revision is a card-row: primary left-mark for the ACTIVE revision (also gets an "ACTIVE" pill), large mono `#N`, RTL-clipped image, deployed-at + relative time, deployed-by, Rollback rail-pill on past revisions.

## Mock
- `src/routes/api/mock-events/+server.js` streams a JSON event feed (Normal-heavy with occasional Warning) only when `MOCK_API` is set; outside that the route 404s. `deployment.eventUrl` is wired to it so the Events tab is exercisable offline via `bun dev:mock`.
- Stripped the `https://`/`http://` prefix from the mock deployment's `url`/`internalUrl` fields — both pages prepend the scheme themselves and the prefix was producing `https://https://…` in the Detail tab. Pre-existing fixture bug, only visible now that the new Detail URL row is prominent.

## Verification
- `bun lint` — clean
- `bun check` — 671 files, 0 errors, 0 warnings
- All five tabs render `200` against `MOCK_API=1 bun dev` and Playwright screenshots in both light and dark themes look cohesive (attached in the PR conversation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)