### PR TITLE
feat(route): add External server (HTTP) route type

### DIFF
--- a/src/routes/(auth)/(project)/route/create/+page.svelte
+++ b/src/routes/(auth)/(project)/route/create/+page.svelte
@@ -27,7 +27,12 @@
 	})
 
 	const targetPlaceholder = $derived({
-		'redirect://': 'https://example.com'
+		'redirect://': 'https://example.com',
+		'http://': '203.0.113.10:8080'
+	}[form.targetPrefix] || '')
+
+	const targetHint = $derived({
+		'http://': 'Your server’s public IP address, with an optional port (defaults to 80). Private, loopback, and link-local addresses are not allowed.'
 	}[form.targetPrefix] || '')
 
 	/** @type {Api.Domain[]} */
@@ -189,7 +194,8 @@
 					placeholder="Select Type"
 					options={[
 						{ value: 'deployment://', label: 'Deployment' },
-						{ value: 'redirect://', label: 'Redirect' }
+						{ value: 'redirect://', label: 'Redirect' },
+						{ value: 'http://', label: 'External server (HTTP)' }
 					]} />
 			</div>
 
@@ -209,6 +215,9 @@
 					<div class="input">
 						<input id="input-target_value" bind:value={form.targetValue} placeholder={targetPlaceholder} required>
 					</div>
+					{#if targetHint}
+						<p class="page-sub">{targetHint}</p>
+					{/if}
 				</div>
 			{/if}
 

--- a/src/routes/(auth)/(project)/route/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/route/edit/+page.svelte
@@ -15,10 +15,11 @@
 		`&domain=${encodeURIComponent(route.domain)}` +
 		`&path=${encodeURIComponent(route.path)}`)
 
-	// Known target schemes (mirrors api.RouteTargetPrefix). Only deployment +
-	// redirect are creatable in-console; the rest are parsed so an existing
-	// route round-trips unchanged even though they aren't offered in the picker.
-	const targetPrefixes = ['deployment://', 'redirect://', 'ipfs://', 'ipns://', 'dnslink://']
+	// Known target schemes. deployment + redirect + http (external server) are
+	// creatable in-console; the ipfs/ipns/dnslink schemes are parsed so an
+	// existing route round-trips unchanged even though they aren't offered in
+	// the picker. http:// is validated server-side (api.validExternalTarget).
+	const targetPrefixes = ['deployment://', 'redirect://', 'http://', 'ipfs://', 'ipns://', 'dnslink://']
 
 	/** @param {string | undefined} target */
 	function splitTarget (target) {
@@ -75,7 +76,8 @@
 	const typeOptions = $derived.by(() => {
 		const base = [
 			{ value: 'deployment://', label: 'Deployment' },
-			{ value: 'redirect://', label: 'Redirect' }
+			{ value: 'redirect://', label: 'Redirect' },
+			{ value: 'http://', label: 'External server (HTTP)' }
 		]
 		if (!base.some((o) => o.value === form.targetPrefix)) {
 			base.unshift({ value: form.targetPrefix, label: form.targetPrefix })
@@ -84,7 +86,12 @@
 	})
 
 	const targetPlaceholder = $derived({
-		'redirect://': 'https://example.com'
+		'redirect://': 'https://example.com',
+		'http://': '203.0.113.10:8080'
+	}[form.targetPrefix] || '')
+
+	const targetHint = $derived({
+		'http://': 'Your server’s public IP address, with an optional port (defaults to 80). Private, loopback, and link-local addresses are not allowed.'
 	}[form.targetPrefix] || '')
 
 	/** @type {string[]} */
@@ -239,6 +246,9 @@
 				<div class="input">
 					<input id="input-target_value" bind:value={form.targetValue} placeholder={targetPlaceholder} required>
 				</div>
+				{#if targetHint}
+					<p class="page-sub">{targetHint}</p>
+				{/if}
 			</div>
 		{/if}
 

--- a/src/routes/(auth)/(project)/route/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/route/manage/+page.svelte
@@ -20,7 +20,7 @@
 	const fullUrl = $derived(`https://${route.domain}${route.path}`)
 
 	// Known target schemes (mirrors api.RouteTargetPrefix).
-	const targetPrefixes = ['deployment://', 'redirect://', 'ipfs://', 'ipns://', 'dnslink://']
+	const targetPrefixes = ['deployment://', 'redirect://', 'http://', 'ipfs://', 'ipns://', 'dnslink://']
 
 	/** @param {string | undefined} target */
 	function splitTarget (target) {
@@ -35,6 +35,7 @@
 		{
 			'deployment://': 'Deployment',
 			'redirect://': 'Redirect',
+			'http://': 'External server (HTTP)',
 			'ipfs://': 'IPFS',
 			'ipns://': 'IPNS',
 			'dnslink://': 'DNSLink'
@@ -44,6 +45,7 @@
 		{
 			'deployment://': 'fa-cube',
 			'redirect://': 'fa-arrow-right-arrow-left',
+			'http://': 'fa-server',
 			'ipfs://': 'fa-cubes',
 			'ipns://': 'fa-cubes',
 			'dnslink://': 'fa-link'


### PR DESCRIPTION
## What

Adds an **"External server (HTTP)"** route type so users can point a verified domain at their **own server by IP**, fronted by our edge + WAF, instead of an in-cluster deployment ("bring your own server").

## Changes

- **create + edit** pages — new type that submits an `http://<ip>[:port]` target, with an IP[:port] value field, placeholder (`203.0.113.10:8080`), and an inline hint about the public-IP / SSRF restriction.
- **edit + manage** pages — recognize the `http://` scheme in `splitTarget` (and the redesigned detail page's type label + `fa-server` icon) so external routes display correctly and round-trip through edit instead of mis-parsing as a deployment.

The form only composes `scheme + value`; the backend validates the address ([deploys-app/api#31](https://github.com/deploys-app/api/pull/31) `validExternalTarget`, merged).

## Test plan
- `bun lint` and `bun check` pass (0 errors).
- All 8 `route.spec.js` Playwright tests pass against the redesigned detail page.
- Verified end-to-end create flow (mock API) submits `target: "http://203.0.113.10:8080"`.

| | |
|---|---|
| Type picker | "External server (HTTP)" |
| Value | `203.0.113.10:8080` |
| Hint | public IP only; private/loopback/link-local rejected |

🤖 Generated with [Claude Code](https://claude.com/claude-code)