### PR TITLE
feat(project): allow searching by project number

### DIFF
--- a/src/lib/search/index.js
+++ b/src/lib/search/index.js
@@ -10,6 +10,7 @@ import { projectMenu } from '$lib/nav'
  * @property {string} icon      Font Awesome class, e.g. `fa-rocket`
  * @property {string} label     primary text (the thing you'd type)
  * @property {string} [sublabel] secondary text (location, target, …)
+ * @property {string} [keywords] extra text folded into search only, never shown
  * @property {string} href      navigation target
  */
 
@@ -177,6 +178,8 @@ export function projectEntries (projects, currentProject, page) {
 				icon: 'fa-folder-open',
 				label: p.name,
 				sublabel: p.project,
+				// `p.id` is the numeric project number — searchable but not shown.
+				keywords: p.id,
 				href: `${overrideRedirect}?${q.toString()}`
 			})
 		})
@@ -244,7 +247,7 @@ export function filterEntries (entries, query) {
 	const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
 	if (!tokens.length) return entries
 	return entries.filter((e) => {
-		const haystack = `${e.label} ${e.sublabel ?? ''} ${e.group}`.toLowerCase()
+		const haystack = `${e.label} ${e.sublabel ?? ''} ${e.keywords ?? ''} ${e.group}`.toLowerCase()
 		return tokens.every((t) => haystack.includes(t))
 	})
 }

--- a/src/routes/(auth)/ModalSelectProject.svelte
+++ b/src/routes/(auth)/ModalSelectProject.svelte
@@ -24,7 +24,8 @@
 		const tokens = search.trim().toLowerCase().split(/\s+/).filter(Boolean)
 		if (!tokens.length) return projects
 		return projects.filter((it) => {
-			const haystack = `${it.name} ${it.project}`.toLowerCase()
+			// `it.id` is the numeric project number — searchable but not shown.
+			const haystack = `${it.name} ${it.project} ${it.id}`.toLowerCase()
 			return tokens.every((t) => haystack.includes(t))
 		})
 	})


### PR DESCRIPTION
## Summary
Both project searches now match on the **numeric project number** (`it.id`) in addition to the project name and slug, while keeping the number hidden from the result lists.

- **`ModalSelectProject.svelte`** — `it.id` folded into the filter haystack. The table still shows only Name + the `it.project` slug ("ID" column); the project number is not displayed.
- **Command palette (`SearchModal` / `lib/search`)** — added a search-only `keywords` field to `SearchEntry`, populated it with `p.id` in `projectEntries`, and included it in the `filterEntries` haystack. Rendered rows still show only `label` (name) and `sublabel` (slug).

## Test plan
- `bun lint` — passes, zero errors
- `bun check` — passes, zero errors
- Manually: type a project number into the project picker (`/`) and the command palette → the matching project appears without the number showing in the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)