### PR TITLE
feat(route): flag paused deployments in the route picker

### DIFF
--- a/src/lib/components/Select.svelte
+++ b/src/lib/components/Select.svelte
@@ -1,10 +1,17 @@
 <script>
 	/**
+	 * @typedef {'positive' | 'warning' | 'negative' | 'muted'} Tone
+	 */
+
+	/**
 	 * @typedef {Object} Option
 	 * @property {string | number} [value]
 	 * @property {string} [label]
 	 * @property {boolean} [disabled]
 	 * @property {boolean} [separator]
+	 * @property {Tone} [dot] leading status dot, colored by tone
+	 * @property {string} [badge] trailing pill text
+	 * @property {Tone} [badgeTone] pill color (defaults to muted)
 	 */
 
 	/**
@@ -298,7 +305,15 @@
 			{disabled}
 			onclick={() => (open ? close() : openMenu())}
 			onkeydown={onKeydown}>
-			<span class="select-value" class:is-placeholder={!hasSelection}>{displayLabel}</span>
+			<span class="select-value" class:is-placeholder={!hasSelection}>
+				{#if selectedOption?.dot}
+					<span class="select-dot" data-tone={selectedOption.dot}></span>
+				{/if}
+				<span class="truncate">{displayLabel}</span>
+				{#if selectedOption?.badge}
+					<span class="select-badge" data-tone={selectedOption.badgeTone ?? 'muted'}>{selectedOption.badge}</span>
+				{/if}
+			</span>
 			<i class="fa-solid fa-chevron-down select-chevron" class:is-open={open}></i>
 		</button>
 	{/if}
@@ -323,7 +338,13 @@
 						class:is-disabled={opt.disabled}
 						onmouseenter={() => { if (isSelectable(i)) activeIndex = i }}
 						onclick={() => commit(opt)}>
+						{#if opt.dot}
+							<span class="select-dot" data-tone={opt.dot}></span>
+						{/if}
 						<span class="truncate">{opt.label}</span>
+						{#if opt.badge}
+							<span class="select-badge" data-tone={opt.badgeTone ?? 'muted'}>{opt.badge}</span>
+						{/if}
 						{#if (opt.value ?? '') === value}
 							<i class="fa-solid fa-check select-check"></i>
 						{/if}
@@ -453,9 +474,54 @@
 	.select-value {
 		flex: 1;
 		min-width: 0;
-		overflow: hidden;
-		white-space: nowrap;
-		text-overflow: ellipsis;
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.select-value .truncate,
+	.select-option .truncate {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.select-dot {
+		flex-shrink: 0;
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 9999px;
+		background: hsl(var(--hsl-content) / 0.35);
+	}
+
+	.select-dot[data-tone='positive'] { background: hsl(var(--hsl-positive)); }
+	.select-dot[data-tone='warning'] { background: hsl(var(--hsl-warning)); }
+	.select-dot[data-tone='negative'] { background: hsl(var(--hsl-negative)); }
+
+	.select-badge {
+		flex-shrink: 0;
+		padding: 0.05rem 0.4rem;
+		border-radius: 9999px;
+		font-size: 0.7rem;
+		font-weight: 600;
+		line-height: 1.25;
+		letter-spacing: 0.01em;
+		color: hsl(var(--hsl-content) / 0.7);
+		background: hsl(var(--hsl-content) / 0.1);
+	}
+
+	.select-badge[data-tone='warning'] {
+		color: hsl(var(--hsl-warning));
+		background: hsl(var(--hsl-warning) / 0.14);
+	}
+
+	.select-badge[data-tone='positive'] {
+		color: hsl(var(--hsl-positive));
+		background: hsl(var(--hsl-positive) / 0.14);
+	}
+
+	.select-badge[data-tone='negative'] {
+		color: hsl(var(--hsl-negative));
+		background: hsl(var(--hsl-negative) / 0.14);
 	}
 
 	.select-value.is-placeholder {

--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -178,6 +178,12 @@ const deployments = [
 	deployment('acme'),
 	{
 		...deployment('acme'),
+		name: 'web-paused',
+		status: 'success',
+		action: 'pause'
+	},
+	{
+		...deployment('acme'),
 		name: 'cron-cleanup',
 		type: 'CronJob',
 		schedule: '0 * * * *',

--- a/src/routes/(auth)/(project)/route/create/+page.svelte
+++ b/src/routes/(auth)/(project)/route/create/+page.svelte
@@ -37,9 +37,26 @@
 
 	/** @type {Api.Domain[]} */
 	let domains = $state([])
+	/** @type {{ name: string, paused: boolean }[]} */
 	let deployments = $state([])
 
 	const selectedDomain = $derived(domains.find((x) => x.domain === form.domain))
+
+	// Paused deployments stay selectable so a route can be wired up ahead of a
+	// resume, but the picker flags them and we warn that traffic won't flow until
+	// the deployment is running again.
+	const deploymentOptions = $derived(deployments.map((d) => ({
+		value: d.name,
+		label: d.name,
+		dot: /** @type {'warning' | 'positive'} */ (d.paused ? 'warning' : 'positive'),
+		badge: d.paused ? 'Paused' : undefined,
+		badgeTone: /** @type {'warning'} */ ('warning')
+	})))
+
+	const selectedDeploymentPaused = $derived(
+		form.targetPrefix === 'deployment://' &&
+		deployments.some((d) => d.name === form.targetValue && d.paused)
+	)
 
 	async function fetchDomains () {
 		domains = []
@@ -70,7 +87,7 @@
 			.filter((x) => x.location === form.location)
 			.filter((x) => x.type === 'WebService')
 			.filter((x) => x.ttl === 0)
-			.map((x) => x.name)
+			.map((x) => ({ name: x.name, paused: x.action === 'pause' }))
 	}
 
 	function fetchLocationData () {
@@ -207,7 +224,13 @@
 						bind:value={form.targetValue}
 						required
 						placeholder="Select Deployment"
-						options={deployments.map((it) => ({ value: it, label: it }))} />
+						options={deploymentOptions} />
+					{#if selectedDeploymentPaused}
+						<p class="page-sub text-warning flex items-center gap-2">
+							<i class="fa-solid fa-triangle-exclamation"></i>
+							This deployment is paused — the route won’t serve traffic until you resume it.
+						</p>
+					{/if}
 				</div>
 			{:else if form.targetPrefix}
 				<div class="field">

--- a/src/routes/(auth)/(project)/route/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/route/edit/+page.svelte
@@ -94,8 +94,24 @@
 		'http://': 'Your server’s public IP address, with an optional port (defaults to 80). Private, loopback, and link-local addresses are not allowed.'
 	}[form.targetPrefix] || '')
 
-	/** @type {string[]} */
+	/** @type {{ name: string, paused: boolean }[]} */
 	let deployments = $state([])
+
+	// Paused deployments stay selectable so a route can be wired up ahead of a
+	// resume, but the picker flags them and we warn that traffic won't flow until
+	// the deployment is running again.
+	const deploymentOptions = $derived(deployments.map((d) => ({
+		value: d.name,
+		label: d.name,
+		dot: /** @type {'warning' | 'positive'} */ (d.paused ? 'warning' : 'positive'),
+		badge: d.paused ? 'Paused' : undefined,
+		badgeTone: /** @type {'warning'} */ ('warning')
+	})))
+
+	const selectedDeploymentPaused = $derived(
+		form.targetPrefix === 'deployment://' &&
+		deployments.some((d) => d.name === form.targetValue && d.paused)
+	)
 
 	async function fetchDeployments () {
 		deployments = []
@@ -109,7 +125,7 @@
 			.filter((/** @type {Api.Deployment} */ x) => x.location === route.location)
 			.filter((/** @type {Api.Deployment} */ x) => x.type === 'WebService')
 			.filter((/** @type {Api.Deployment} */ x) => x.ttl === 0)
-			.map((/** @type {Api.Deployment} */ x) => x.name)
+			.map((/** @type {Api.Deployment} */ x) => ({ name: x.name, paused: x.action === 'pause' }))
 	}
 
 	$effect(() => {
@@ -238,7 +254,13 @@
 					bind:value={form.targetValue}
 					required
 					placeholder="Select Deployment"
-					options={deployments.map((it) => ({ value: it, label: it }))} />
+					options={deploymentOptions} />
+				{#if selectedDeploymentPaused}
+					<p class="page-sub text-warning flex items-center gap-2">
+						<i class="fa-solid fa-triangle-exclamation"></i>
+						This deployment is paused — the route won’t serve traffic until you resume it.
+					</p>
+				{/if}
 			</div>
 		{:else}
 			<div class="field">

--- a/tests/route.spec.js
+++ b/tests/route.spec.js
@@ -182,4 +182,79 @@ test.describe('route edit', () => {
 		await page.locator('#input-target_deployment').click()
 		await expect(page.getByRole('option', { name: 'web' })).toBeVisible()
 	})
+
+	test('flags a paused deployment and warns once it is selected', async ({ page }) => {
+		await setMocks({
+			'route.get': { ok: true, result: sampleRoute },
+			'deployment.list': {
+				ok: true,
+				result: {
+					items: [
+						sampleDeployment,
+						{ ...sampleDeployment, name: 'web-paused', action: 'pause' }
+					]
+				}
+			}
+		})
+
+		await page.goto(editUrl)
+
+		await page.locator('#input-target_deployment').click()
+		// The paused deployment stays selectable but carries a Paused badge.
+		const pausedOption = page.getByRole('option', { name: /web-paused/ })
+		await expect(pausedOption.getByText('Paused', { exact: true })).toBeVisible()
+
+		// Selecting it surfaces the inline warning; a running deployment doesn't.
+		const warning = page.getByText(/won.t serve traffic until you resume it/)
+		await pausedOption.click()
+		await expect(warning).toBeVisible()
+
+		await page.locator('#input-target_deployment').click()
+		await page.getByRole('option', { name: 'web', exact: true }).click()
+		await expect(warning).toHaveCount(0)
+	})
+})
+
+test.describe('route create — deployment picker', () => {
+	const createUrl = '/route/create?project=test-project'
+
+	/** @param {import('@playwright/test').Page} page */
+	async function pickDeploymentTarget (page) {
+		await page.goto(createUrl)
+		await page.locator('#input-location').click()
+		await page.getByRole('option', { name: 'gke' }).click()
+		await page.locator('#input-target_prefix').click()
+		await page.getByRole('option', { name: 'Deployment', exact: true }).click()
+		await page.locator('#input-target_deployment').click()
+	}
+
+	test('badges paused deployments and warns when one is chosen', async ({ page }) => {
+		await setMocks({
+			'deployment.list': {
+				ok: true,
+				result: {
+					items: [
+						sampleDeployment,
+						{ ...sampleDeployment, name: 'web-paused', action: 'pause' }
+					]
+				}
+			}
+		})
+
+		await pickDeploymentTarget(page)
+
+		const runningOption = page.getByRole('option', { name: 'web', exact: true })
+		const pausedOption = page.getByRole('option', { name: /web-paused/ })
+		await expect(runningOption).toBeVisible()
+		await expect(pausedOption.getByText('Paused', { exact: true })).toBeVisible()
+
+		const warning = page.getByText(/won.t serve traffic until you resume it/)
+
+		await runningOption.click()
+		await expect(warning).toHaveCount(0)
+
+		await page.locator('#input-target_deployment').click()
+		await pausedOption.click()
+		await expect(warning).toBeVisible()
+	})
 })


### PR DESCRIPTION
## Problem

Creating a route to a **paused** deployment silently serves no traffic. The create/edit deployment pickers mapped deployments to bare names (`.map(x => x.name)`), so a paused deployment (`action === 'pause'`) looked identical to a running one — easy to pick by mistake.

## Solution

The deployment picker now surfaces state at a glance and warns rather than blocks:

- **Running** → green status dot.
- **Paused** → amber dot + `Paused` badge. Stays **selectable** so a route can be wired up ahead of a resume.
- Selecting a paused deployment shows an inline warning: _"This deployment is paused — the route won't serve traffic until you resume it."_

|  picker open | paused selected |
| --- | --- |
| green dots for running, amber dot + Paused badge | amber warning below the field |

## Changes

- `Select.svelte`: optional per-option `dot` / `badge` / `badgeTone` (backward-compatible — existing plain `Select`s untouched).
- `route/create` + `route/edit`: deployments carry `{ name, paused }`, build status-aware options, render the warning.
- `mock.js`: added a paused `WebService` so `bun dev:mock` exercises the flow.
- `route.spec.js`: +2 e2e tests covering the badge and the warning toggling on/off in both create and edit.

## Verification

- `bun lint` ✅  `bun check` ✅
- `bun run test tests/route.spec.js` → 10 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)