### PR TITLE
fix: don't log users out on a transient unauthorized during search

### DIFF
--- a/src/lib/api/index.js
+++ b/src/lib/api/index.js
@@ -10,9 +10,13 @@ let onUnauth
  * @param {string} fn
  * @param {Object} args
  * @param {fetch} fetch
+ * @param {{ silent?: boolean }} [opts] when `silent`, an unauthorized response
+ *   is flagged on the result but the global `onUnauth` handler is NOT fired.
+ *   Use it for best-effort / background fan-outs (e.g. the search palette) where
+ *   a single transient unauthorized must not reload the whole app.
  * @returns {Promise<Api.Response<T>>}
  */
-async function invoke (fn, args, fetch) {
+async function invoke (fn, args, fetch, opts) {
 	const resp = await fetch(`${endpoint}/${fn}`, {
 		method: 'POST',
 		body: JSON.stringify(args || {}),
@@ -27,7 +31,9 @@ async function invoke (fn, args, fetch) {
 		switch (msg) {
 		case 'api: unauthorized':
 			body.error.unauth = true
-			onUnauth?.()
+			if (!opts?.silent) {
+				onUnauth?.()
+			}
 			break
 		case 'api: forbidden':
 			body.error.forbidden = true

--- a/src/lib/search/index.js
+++ b/src/lib/search/index.js
@@ -207,6 +207,11 @@ export function navEntries (project) {
  * results into search entries. Endpoints that fail (e.g. no permission) are
  * skipped silently so one forbidden resource never blanks the whole palette.
  *
+ * Calls go through `invoke` with `{ silent: true }`: this is a best-effort
+ * background fan-out, so a single transient `api: unauthorized` (e.g. one of the
+ * parallel requests hitting a momentary backend/DB blip) must NOT fire the
+ * global `onUnauth` handler and reload the whole app out from under the user.
+ *
  * @param {string} project
  * @param {typeof fetch} fetch
  * @returns {Promise<SearchEntry[]>}
@@ -215,7 +220,7 @@ export async function fetchResourceEntries (project, fetch) {
 	const settled = await Promise.all(resourceSources.map(async (src) => {
 		try {
 			/** @type {Api.Response<Api.List<any>>} */
-			const res = await api.invoke(src.fn, { project }, fetch)
+			const res = await api.invoke(src.fn, { project }, fetch, { silent: true })
 			const items = res.result?.items ?? []
 			return items.map((it) => {
 				const m = src.map(it, project)


### PR DESCRIPTION
## Problem

Opening the search palette sometimes logs the user out.

`SearchModal` fans out ~11 parallel `*.list` requests on open (`fetchResourceEntries` in `src/lib/search/index.js`). `api.invoke` (`src/lib/api/index.js`) fires the **global** `onUnauth` handler — registered in `(auth)/+layout.svelte` as `location.reload()` — on **any** `api: unauthorized` response. It does so as a side effect *before returning*, so the `try/catch` around each call in `fetchResourceEntries` cannot suppress it (the comment there claims failing endpoints are "skipped silently" — true for `forbidden`, but **not** for `unauthorized`).

Net effect: a single transient unauthorized among the 11 parallel requests — e.g. one request hitting a momentary backend/DB blip — reloads the whole app and reads as a spurious logout. The fan-out is what makes search the place it shows up: 1 user action → 11 chances to trip it.

## Fix

Add a `{ silent: true }` option to `api.invoke` that still flags `error.unauth` on the result but does **not** fire the global `onUnauth`. The search fan-out passes it, so an unauthorized `*.list` is simply treated as an empty result (exactly what the existing `catch` intends). A genuinely expired session is still caught by the normal (non-silent) calls on the next navigation, which reload as before.

## Server-side companion

The matching root-cause fix — the API treating transient verification failures as `unauthorized` — is in apiserver PR (`fix/auth-transient-verify-error`). This console change stands on its own and is the smaller, safer half.

## Test

- `bun lint` — clean
- `bun check` — 0 errors / 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)