### PR TITLE
fix: keep OAuth state cookie across the cross-site redirect (Safari sign-in)

### DIFF
--- a/src/routes/auth/callback/+server.js
+++ b/src/routes/auth/callback/+server.js
@@ -36,13 +36,13 @@ export async function GET ({ cookies, url }) {
 	cookies.set('token', token, {
 		httpOnly: true,
 		maxAge: 60 * 60 * 24 * 7,
-		sameSite: 'lax',
+		sameSite: 'none',
 		path: '/',
 		secure: import.meta.env.PROD
 	})
 	cookies.delete('state', {
 		httpOnly: true,
-		sameSite: 'lax',
+		sameSite: 'none',
 		path: '/',
 		secure: import.meta.env.PROD
 	})
@@ -50,7 +50,8 @@ export async function GET ({ cookies, url }) {
 	return new Response(undefined, {
 		status: 302,
 		headers: {
-			location: '/'
+			location: '/',
+			'cache-control': 'no-store'
 		}
 	})
 }

--- a/src/routes/auth/signin/+server.js
+++ b/src/routes/auth/signin/+server.js
@@ -30,7 +30,7 @@ export async function GET ({ cookies, url }) {
 	cookies.set('state', state, {
 		httpOnly: true,
 		maxAge: 60 * 60,
-		sameSite: 'lax',
+		sameSite: 'none',
 		path: '/',
 		secure: import.meta.env.PROD
 	})
@@ -38,7 +38,8 @@ export async function GET ({ cookies, url }) {
 	return new Response(undefined, {
 		status: 302,
 		headers: {
-			location: `${authEndpoint}/?${q.toString()}`
+			location: `${authEndpoint}/?${q.toString()}`,
+			'cache-control': 'no-store'
 		}
 	})
 }


### PR DESCRIPTION
## Problem

Sign-in fails in **stable Safari** with `invalid state`. It works in Chromium, Firefox, and **Safari Technology Preview** — a browser-specific split that points at cookie semantics, not app logic.

The check is in `src/routes/auth/callback/+server.js`:

```js
if (state !== cookies.get('state')) {
    return new Response('invalid state', { status: 400 })
}
```

`/auth/signin` stores the `state` nonce as a **`SameSite=Lax`** cookie, then the flow round-trips through `auth.deploys.app`. The navigation back to `/auth/callback` is **initiated cross-site** by the auth host, and stable WebKit withholds `SameSite=Lax` cookies on a cross-site-initiated navigation. So Safari reaches the callback with **no `state` cookie** → `'' !== <state>` → `invalid state`. Other engines (and newer WebKit in Tech Preview) are more lenient, which is why only stable Safari breaks.

## Fix

Set the auth cookies (`state` in signin, `token` + the `state` deletion in callback) to **`SameSite=None`** so they survive the cross-site redirect. Also add `Cache-Control: no-store` to both redirect responses so a cached redirect can't replay a stale `state`.

## Not related to the recent auth fixes

This is an independent, pre-existing cookie issue. console#169 and apiserver#77 don't touch the sign-in / OAuth-state flow, and a logic change there would fail in every browser, not just Safari.

## Test

- `bun lint` — clean
- `bun check` — 0 errors / 0 warnings

`SameSite=None` requires `Secure`, which is gated on `import.meta.env.PROD` — so confirm with a manual sign-in in stable Safari against a deployed/HTTPS preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)