### PR TITLE
fix(invoice): show sub-cent unit prices instead of 0.00

### DIFF
--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -518,7 +518,8 @@ const invoices = [
 		createdAt: '2026-06-01T00:00:00Z',
 		lineItems: [
 			{ sku: 'cpu', description: 'vCPU-hours', quantity: 600, unit: 'hour', unitPrice: 1.5, amount: 900 },
-			{ sku: 'mem', description: 'GiB-hours', quantity: 600, unit: 'hour', unitPrice: 0.5, amount: 300 }
+			{ sku: 'mem', description: 'GiB-hours', quantity: 600, unit: 'hour', unitPrice: 0.5, amount: 300 },
+			{ sku: 'cpu-sec', description: 'vCPU-seconds', quantity: 2160000, unit: 'second', unitPrice: 0.0000125, amount: 27 }
 		]
 	},
 	{

--- a/src/routes/(auth)/billing/invoice/+page.svelte
+++ b/src/routes/(auth)/billing/invoice/+page.svelte
@@ -53,6 +53,21 @@
 	}
 
 	/**
+	 * Unit prices can be a tiny per-unit rate (e.g. a per-hour or per-second
+	 * compute price) that rounds to 0.00 at the 2-decimal precision used for
+	 * currency totals. Keep a 2-decimal floor, but for sub-cent values widen the
+	 * precision enough to keep the rate's significant digits visible.
+	 * @param {number} v
+	 */
+	function unitPrice (v) {
+		const abs = Math.abs(v)
+		const decimals = abs > 0 && abs < 0.01
+			? Math.min(10, Math.ceil(-Math.log10(abs)) + 3)
+			: 2
+		return `${v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: decimals })} ${invoice.currency}`
+	}
+
+	/**
 	 * @param {number} v
 	 */
 	function quantity (v) {
@@ -200,7 +215,7 @@
 							<td>{it.description || it.sku}</td>
 							<td class="is-align-right">{quantity(it.quantity)}</td>
 							<td>{it.unit}</td>
-							<td class="is-align-right">{money(it.unitPrice)}</td>
+							<td class="is-align-right">{unitPrice(it.unitPrice)}</td>
 							<td class="is-align-right">{money(it.amount)}</td>
 						</tr>
 					{:else}

--- a/tests/billing.spec.js
+++ b/tests/billing.spec.js
@@ -1,5 +1,5 @@
 import { test, expect, setMocks } from './helpers.js'
-import { sampleBillingAccount } from './fixtures/mocks.js'
+import { sampleBillingAccount, sampleInvoice } from './fixtures/mocks.js'
 
 test.describe('billing accounts', () => {
 	test('lists billing accounts', async ({ page }) => {
@@ -28,5 +28,25 @@ test.describe('billing accounts', () => {
 		await page.goto('/billing')
 		const main = page.locator('.content-wrapper')
 		await expect(main.getByText('Nothing here yet')).toBeVisible()
+	})
+})
+
+test.describe('invoice detail', () => {
+	test('shows a tiny unit price with enough decimals instead of 0.00', async ({ page }) => {
+		await setMocks({
+			'billing.getInvoice': { ok: true, result: sampleInvoice },
+			'billing.get': { ok: true, result: sampleBillingAccount }
+		})
+
+		await page.goto('/billing/invoice?id=inv-1')
+
+		const row = page.locator('table tbody tr', { hasText: 'vCPU-seconds' })
+		const unitPriceCell = row.locator('td').nth(3)
+		// The sub-cent rate keeps its significant digits rather than rounding away.
+		await expect(unitPriceCell).toHaveText('0.0000125 USD')
+
+		// A normal-magnitude rate still reads at the 2-decimal currency floor.
+		const memRow = page.locator('table tbody tr', { hasText: 'GiB-hours' })
+		await expect(memRow.locator('td').nth(3)).toHaveText('0.50 USD')
 	})
 })

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -285,6 +285,33 @@ export const sampleBillingAccount = {
 	active: true
 }
 
+export const sampleInvoice = {
+	id: 'inv-1',
+	billingAccountId: 'ba-1',
+	number: 'INV-2024-001',
+	currency: 'USD',
+	periodStart: '2024-01-01T00:00:00Z',
+	periodEnd: '2024-02-01T00:00:00Z',
+	subtotal: 10,
+	taxRate: 0.07,
+	taxAmount: 0.7,
+	total: 10.7,
+	status: 'open',
+	taxId: '',
+	taxName: 'Acme Co',
+	taxAddress: '',
+	issuedAt: now,
+	paidAt: '0001-01-01T00:00:00Z',
+	voidedAt: '0001-01-01T00:00:00Z',
+	createdAt: now,
+	lineItems: [
+		// A tiny per-second rate: rounds to 0.00 at 2 decimals, so the detail
+		// page must widen precision to keep it visible.
+		{ sku: 'cpu', description: 'vCPU-seconds', quantity: 720000, unit: 'second', unitPrice: 0.0000125, amount: 9 },
+		{ sku: 'mem', description: 'GiB-hours', quantity: 2, unit: 'hour', unitPrice: 0.5, amount: 1 }
+	]
+}
+
 export const sampleRepository = {
 	name: 'web',
 	size: 12345678,


### PR DESCRIPTION
## Problem

On the invoice detail page, the **Unit price** column rounded tiny per-unit rates to `0.00`. The line-item table reused the same 2-decimal `money()` helper used for currency totals, so a small rate (e.g. a per-second compute price like `0.0000125`) lost its value entirely.

## Fix

Added a dedicated `unitPrice()` formatter for the Unit price column:

- Keeps the **2-decimal floor** for normal-magnitude rates (`0.50 USD`).
- For **sub-cent values**, widens precision to keep the rate's significant digits visible (`0.0000125 USD`).
- `Amount`, `Subtotal`, `Tax`, and `Total` are untouched — they stay at 2-decimal currency precision (those are real money totals).

| | Before | After |
| --- | --- | --- |
| `0.0000125` rate | `0.00 USD` | `0.0000125 USD` |
| `0.50` rate | `0.50 USD` | `0.50 USD` |

## Changes

- `billing/invoice/+page.svelte`: new `unitPrice()` formatter for the Unit price cell.
- `mock.js`: added a tiny per-second line item so `bun dev:mock` exercises the case.
- `billing.spec.js`: new invoice-detail test asserting a sub-cent rate renders with extra decimals while a normal rate still reads at the 2-decimal floor.

## Verification

- `bun lint` ✅  `bun check` ✅
- `bun run test tests/billing.spec.js` → 3 passed
- Visually confirmed in the rendered table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)