### PR TITLE
fix(invoice): drop the Discount column; quantity is the billed usage

### DIFF
--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -517,10 +517,10 @@ const invoices = [
 		voidedAt: '',
 		createdAt: '2026-06-01T00:00:00Z',
 		lineItems: [
-			// unitPrice is the list rate; amount = unitPrice*quantity - discount.
-			{ sku: 'cpu', description: 'vCPU-hours', quantity: 600, unit: 'hour', unitPrice: 1.5, discount: 0, amount: 900 },
-			{ sku: 'mem', description: 'GiB-hours', quantity: 600, unit: 'hour', unitPrice: 0.5, discount: 50, amount: 250 },
-			{ sku: 'cpu-sec', description: 'vCPU-seconds', quantity: 2160000, unit: 'second', unitPrice: 0.0000125, discount: 0, amount: 27 }
+			// quantity is the billed usage (free tier already deducted); amount = unitPrice*quantity.
+			{ sku: 'cpu', description: 'vCPU-hours', quantity: 600, unit: 'hour', unitPrice: 1.5, amount: 900 },
+			{ sku: 'mem', description: 'GiB-hours', quantity: 500, unit: 'hour', unitPrice: 0.5, amount: 250 },
+			{ sku: 'cpu-sec', description: 'vCPU-seconds', quantity: 2160000, unit: 'second', unitPrice: 0.0000125, amount: 27 }
 		]
 	},
 	{

--- a/src/routes/(auth)/billing/invoice/+page.svelte
+++ b/src/routes/(auth)/billing/invoice/+page.svelte
@@ -213,7 +213,6 @@
 						<th class="is-align-right">Quantity</th>
 						<th>Unit</th>
 						<th class="is-align-right">Unit price</th>
-						<th class="is-align-right">Discount</th>
 						<th class="is-align-right">Amount</th>
 					</tr>
 				</thead>
@@ -224,12 +223,11 @@
 							<td class="is-align-right">{quantity(it.quantity)}</td>
 							<td>{it.unit}</td>
 							<td class="is-align-right">{unitPrice(it.unitPrice)}</td>
-							<td class="is-align-right">{it.discount ? `-${money(it.discount)}` : '—'}</td>
 							<td class="is-align-right">{money(it.amount)}</td>
 						</tr>
 					{:else}
 						<tr>
-							<td colspan="6" class="text-content/60">No line items</td>
+							<td colspan="5" class="text-content/60">No line items</td>
 						</tr>
 					{/each}
 				</tbody>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -428,12 +428,11 @@ declare namespace Api {
     export type InvoiceLineItem = {
         sku: string
         description: string
+        // quantity is the billed usage, free-tier units already deducted.
         quantity: number
         unit: string
-        // unitPrice is the SKU list rate per unit (before discount).
+        // unitPrice is the per-unit rate; amount = unitPrice*quantity.
         unitPrice: number
-        // discount, in the invoice currency: amount = unitPrice*quantity - discount.
-        discount: number
         amount: number
     }
 

--- a/tests/billing.spec.js
+++ b/tests/billing.spec.js
@@ -50,25 +50,6 @@ test.describe('invoice detail', () => {
 		await expect(memRow.locator('td').nth(3)).toHaveText('0.50 USD')
 	})
 
-	test('shows the discount column as a negative currency value (em dash when zero)', async ({ page }) => {
-		await setMocks({
-			'billing.getInvoice': { ok: true, result: sampleInvoice },
-			'billing.get': { ok: true, result: sampleBillingAccount }
-		})
-
-		await page.goto('/billing/invoice?id=inv-1')
-
-		// Columns: Description, Quantity, Unit, Unit price, Discount, Amount.
-		const memRow = page.locator('table tbody tr', { hasText: 'GiB-hours' })
-		await expect(memRow.locator('td').nth(3)).toHaveText('0.50 USD') // list rate
-		await expect(memRow.locator('td').nth(4)).toHaveText('-0.25 USD') // discount
-		await expect(memRow.locator('td').nth(5)).toHaveText('0.75 USD') // amount
-
-		// No discount → em dash, not "0.00".
-		const cpuRow = page.locator('table tbody tr', { hasText: 'vCPU-seconds' })
-		await expect(cpuRow.locator('td').nth(4)).toHaveText('—')
-	})
-
 	test('surfaces a clear message when PDF download fails with an empty 500', async ({ page }) => {
 		await setMocks({
 			'billing.getInvoice': { ok: true, result: sampleInvoice },

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -307,10 +307,9 @@ export const sampleInvoice = {
 	lineItems: [
 		// A tiny per-second rate: rounds to 0.00 at 2 decimals, so the detail
 		// page must widen precision to keep it visible.
-		{ sku: 'cpu', description: 'vCPU-seconds', quantity: 720000, unit: 'second', unitPrice: 0.0000125, discount: 0, amount: 9 },
-		// unitPrice is the list rate; the free-tier discount lowers amount:
-		// 0.5*2 - 0.25 = 0.75.
-		{ sku: 'mem', description: 'GiB-hours', quantity: 2, unit: 'hour', unitPrice: 0.5, discount: 0.25, amount: 0.75 }
+		{ sku: 'cpu', description: 'vCPU-seconds', quantity: 720000, unit: 'second', unitPrice: 0.0000125, amount: 9 },
+		// quantity is the billed usage (free tier deducted); amount = unitPrice*quantity.
+		{ sku: 'mem', description: 'GiB-hours', quantity: 2, unit: 'hour', unitPrice: 0.5, amount: 1 }
 	]
 }
 


### PR DESCRIPTION
Console side of removing the discount concept. The backend now deducts the free tier from the billed **quantity** instead of modeling it as a per-line discount, so a line is simply `amount = unitPrice * quantity` (deploys-app/api removes `InvoiceLineItem.discount`; apiserver bills the free tier as reduced quantity in deploys-app/apiserver#84).

This removes the Discount column added in #172. The **resilient PDF-download error handling** from that same PR is kept (the `invoke()` non-JSON guard, the `downloadPDF()` try/catch + fallback message, and both download-error tests).

## Changes
- `src/types/api.d.ts` — drop `InvoiceLineItem.discount`; document `quantity` as the billed usage and `unitPrice` as the per-unit rate.
- `src/routes/(auth)/billing/invoice/+page.svelte` — remove the Discount column header + cell; empty-state colspan 6 → 5.
- `src/lib/server/mock.js`, `tests/fixtures/mocks.js` — drop `discount`; quantities are billed (free tier deducted) and the rows foot.
- `tests/billing.spec.js` — remove the discount-column assertion; keep the sub-cent unit-price test and both PDF-download-error tests.

## Testing
- `bun lint` and `bun check` clean (0 errors).
- `playwright test tests/billing.spec.js` — 5 passed (sub-cent unit price + both PDF-download paths).
- Rendered `bun dev:mock` invoice detail: columns are Description · Quantity · Unit · Unit price · Amount (no Discount), and every row foots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)