### PR TITLE
feat(billing): show loading state on report when range changes

### DIFF
--- a/src/routes/(auth)/billing/report/+page.svelte
+++ b/src/routes/(auth)/billing/report/+page.svelte
@@ -253,7 +253,7 @@
 		{/if}
 	</div>
 
-	<div class="summary-grid">
+	<div class="summary-grid" class:is-loading={loading}>
 		<div class="summary-card is-primary">
 			<div class="summary-label">Total billing</div>
 			<div class="summary-value">
@@ -276,7 +276,7 @@
 				<i class="fa-solid fa-spinner-third fa-spin text-content/60"></i>
 			{/if}
 		</div>
-		{#if !report}
+		{#if loading || !report}
 			<div class="chart-loading">
 				<i class="fa-solid fa-spinner-third fa-spin"></i>
 			</div>
@@ -301,7 +301,7 @@
 
 	<div class="panel is-level-300">
 		<h5 class="mb-4"><strong>Breakdown</strong></h5>
-		<div class="table-container">
+		<div class="table-container" class:is-loading={loading}>
 			<table class="table">
 				<thead>
 					<tr>
@@ -556,6 +556,12 @@
 		font-size: 0.9375rem;
 		font-weight: 600;
 		color: hsl(var(--hsl-content) / 0.7);
+	}
+
+	.is-loading {
+		opacity: 0.45;
+		pointer-events: none;
+		transition: opacity 0.15s ease;
 	}
 
 	.chart-loading {


### PR DESCRIPTION
## Summary

The billing report page only rendered a loading state on the **very first** load. When you changed the date range (via `selectRange`) or the project filter, it refetched in the background while the summary cards, chart, and breakdown table all kept showing **stale data** — the only hint of a refresh was a tiny spinner icon in the chart header.

This adds a clear, cohesive loading state for any refetch:

- **Chart** now shows the full loading spinner during any refetch (`{#if loading || !report}`), not just the initial load.
- **Summary cards** and the **breakdown table** dim to 45% opacity with pointer events disabled while loading, fading via a 0.15s transition.

## Testing

- `bun lint` — passes, zero errors
- `bun check` — passes, zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)