### PR TITLE
feat(domain): show the blocking routes when a domain delete is rejected

### DIFF
--- a/src/lib/api/index.js
+++ b/src/lib/api/index.js
@@ -58,7 +58,24 @@ async function invoke (fn, args, fetch, opts) {
 			body.error.validate = body.error.items
 			break
 		default:
-			if (msg.includes('api: ') && msg.includes('not found')) {
+			if (msg.startsWith('api: domain in used')) {
+				// "api: domain in used by route(s): a/, b/api (+3 more)" — surface
+				// the blocking routes so the UI can tell the user what to delete.
+				body.error.domainInUsed = true
+				const m = msg.match(/by route\(s\): (.+)$/)
+				if (m) {
+					const more = m[1].match(/\(\+(\d+) more\)\s*$/)
+					body.error.routesMore = more ? Number(more[1]) : 0
+					body.error.routes = m[1]
+						.replace(/\s*\(\+\d+ more\)\s*$/, '')
+						.split(', ')
+						.map((s) => s.trim())
+						.filter(Boolean)
+				} else {
+					body.error.routes = []
+					body.error.routesMore = 0
+				}
+			} else if (msg.includes('api: ') && msg.includes('not found')) {
 				body.error.notFound = true
 			}
 			break

--- a/src/lib/modal/index.js
+++ b/src/lib/modal/index.js
@@ -2,6 +2,17 @@ import Swal from 'sweetalert2'
 import 'sweetalert2/dist/sweetalert2.min.css'
 
 /**
+ * Escape a string for safe interpolation into a SweetAlert `html` body.
+ * @param {string} s
+ * @returns {string}
+ */
+function escapeHtml (s) {
+	return s.replace(/[&<>"']/g, (c) => (
+		{ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] ?? c
+	))
+}
+
+/**
  * @typedef {Object} ModalConfirmOptions
  * @property {string} [title]
  * @property {string} [html]
@@ -65,6 +76,22 @@ export async function error ({ error, callback }) {
 		}
 		if ('validate' in error && Array.isArray(error.validate)) {
 			msg = error.validate.join('<br>')
+		}
+		// Domain delete blocked by routes — render the blockers as a list with a
+		// clear next step instead of the raw "api: domain in used by route(s): …".
+		if ('domainInUsed' in error && error.domainInUsed) {
+			const routes = 'routes' in error && Array.isArray(error.routes) ? error.routes : []
+			const more = 'routesMore' in error && typeof error.routesMore === 'number' ? error.routesMore : 0
+			if (routes.length) {
+				const items = routes.map((r) => `<li>${escapeHtml(String(r))}</li>`).join('')
+				const list = `<ul style="text-align:left; margin:0.75rem auto 0; padding-left:1.25rem; max-width:24rem;">${items}</ul>`
+				const moreLine = more ? `<p style="margin-top:0.5rem; opacity:0.7;">…and ${more} more.</p>` : ''
+				const verb = routes.length === 1 ? 'it' : 'them'
+				const noun = routes.length === 1 ? 'route' : 'routes'
+				msg = `This domain is still used by the following ${noun}. Delete ${verb} first:${list}${moreLine}`
+			} else {
+				msg = 'This domain is still in use by one or more routes. Delete its routes first.'
+			}
 		}
 	}
 

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -10,6 +10,12 @@ declare namespace Api {
         forbidden?: boolean
         notFound?: boolean
         validate?: string[]
+        // set when the API rejects a domain delete because routes still depend
+        // on it; routes lists the blocking "<host><path>" identifiers and
+        // routesMore is the count elided past the server's cap.
+        domainInUsed?: boolean
+        routes?: string[]
+        routesMore?: number
     }
 
     export type Response<T> =

--- a/tests/domain.spec.js
+++ b/tests/domain.spec.js
@@ -32,4 +32,32 @@ test.describe('domains', () => {
 		const main = page.locator('.content-wrapper')
 		await expect(main.getByText('Nothing here yet')).toBeVisible()
 	})
+
+	test('delete blocked by routes lists the blocking routes', async ({ page }) => {
+		await setMocks({
+			'domain.list': { ok: true, result: { items: [sampleDomain] } },
+			'domain.delete': {
+				ok: false,
+				error: {
+					message: 'api: domain in used by route(s): api.example.com/, example.com/admin (+2 more)'
+				}
+			}
+		})
+
+		await page.goto('/domain?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await main.getByRole('button', { name: 'Remove' }).first().click()
+
+		// Confirm dialog → Delete triggers the (mocked) failing delete.
+		await page.getByRole('button', { name: 'Delete' }).click()
+
+		// The error modal turns the raw "domain in used by route(s): …" message
+		// into a readable list with a next step.
+		const dialog = page.locator('.swal2-popup')
+		await expect(dialog.getByText('Delete them first:')).toBeVisible()
+		await expect(dialog.getByText('api.example.com/')).toBeVisible()
+		await expect(dialog.getByText('example.com/admin')).toBeVisible()
+		await expect(dialog.getByText('and 2 more')).toBeVisible()
+	})
 })


### PR DESCRIPTION
When a domain delete is rejected because routes still depend on it, the console now lists exactly which routes to delete instead of showing the raw `api: domain in used …` string.

Part of a 3-repo change:
- **deploys-app/api#36** — `DomainInUsedError(routes)` defines the wire message (single source of truth).
- **deploys-app/apiserver#89** — returns it, naming the blocking routes.
- **this PR** — parses + renders it.

## Changes
- `src/lib/api/index.js` — when the error message starts with `api: domain in used`, set `error.domainInUsed` and parse `error.routes` / `error.routesMore` from `by route(s): … (+N more)`.
- `src/lib/modal/index.js` — `modal.error` renders those routes as a list with a next step. Adds an `escapeHtml` helper for the SweetAlert `html` body (the routes are interpolated as HTML).
- `src/types/api.d.ts` — `Api.Error` gains `domainInUsed` / `routes` / `routesMore`.

## Result

> This domain is still used by the following routes. Delete them first:
> - api.example.com/
> - example.com/admin
>
> …and 2 more.

## Verification
- `bun lint` ✅ · `bun check` ✅
- New e2e test drives delete → confirm → error modal and asserts the routes are listed (`domain.spec.js`); full domain spec green.
- Screenshotted the rendered modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)