### PR TITLE
fix(table): align row heights across list tables

### DIFF
--- a/src/style/app.css
+++ b/src/style/app.css
@@ -981,6 +981,12 @@
 		padding-top: 1rem;
 		padding-bottom: 1rem;
 		white-space: nowrap;
+		/* Floor the cell content at the icon-button height (2rem) so rows in
+		   tables without an actions column line up with rows that have one.
+		   content-box keeps this a content-height minimum (independent of the
+		   global border-box) and taller content still grows the row. */
+		box-sizing: content-box;
+		height: 2rem;
 	}
 
 	.table td p {


### PR DESCRIPTION
List pages looked inconsistent side by side: tables with an **actions column** got ~52px rows (the 2rem-tall `.icon-button` set the row height), while **text-only** tables (pull-secret, workload-identity, email) rendered ~38px rows.

## Fix
Floor every `.table td` content at **2rem** — the icon-button height — so rows match whether or not the table has an actions column:

```css
.table td {
    box-sizing: content-box;  /* min is a content height, independent of the global border-box */
    height: 2rem;
}
```

`height` on a table cell is a **minimum**, so taller content still grows the row (e.g. the deployment list's two-line cells are unaffected).

## Measured (compact tables, devicePixelRatio 2 → CSS px)
| Table | Before | After |
|---|---|---|
| pull-secret (no actions) | 38px | **52px** |
| disk (actions) | 52px | 52px |
| role (actions) | 53px | 53px |
| deployment (2-line cells) | 61px | 61px |

## Verification
- `bun lint` ✅ · `bun check` ✅
- Screenshotted text-only vs actions tables (now aligned) and the multi-line deployment table (unchanged).
- Ran domain / disk / role / pull-secret / workload-identity / email specs — 13 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)