### PR TITLE
billing: invoice line items group by project

### DIFF
--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -516,10 +516,9 @@ const invoices = [
 		voidedAt: '',
 		createdAt: '2026-06-01T00:00:00Z',
 		lineItems: [
-			// quantity is the billed usage (free tier already deducted); amount = unitPrice*quantity.
-			{ sku: 'cpu', description: 'vCPU-hours', quantity: 600, unit: 'hour', unitPrice: 1.5, amount: 900 },
-			{ sku: 'mem', description: 'GiB-hours', quantity: 500, unit: 'hour', unitPrice: 0.5, amount: 250 },
-			{ sku: 'cpu-sec', description: 'vCPU-seconds', quantity: 2160000, unit: 'second', unitPrice: 0.0000125, amount: 27 }
+			// One line per project: amount is the project's gross (VAT-inclusive) total.
+			{ projectId: '1001', project: 'web-frontend', description: 'Web frontend', amount: 900 },
+			{ projectId: '1002', project: 'api-service', description: 'API service', amount: 384 }
 		]
 	},
 	{
@@ -542,7 +541,7 @@ const invoices = [
 		voidedAt: '',
 		createdAt: '2026-05-01T00:00:00Z',
 		lineItems: [
-			{ sku: 'cpu', description: 'vCPU-hours', quantity: 100, unit: 'hour', unitPrice: 1.5, amount: 150 }
+			{ projectId: '1001', project: 'web-frontend', description: 'Web frontend', amount: 160.5 }
 		]
 	},
 	{
@@ -565,8 +564,8 @@ const invoices = [
 		voidedAt: '',
 		createdAt: '2026-05-01T00:00:00Z',
 		lineItems: [
-			{ sku: 'cpu', description: 'vCPU-hours', quantity: 720, unit: 'hour', unitPrice: 1.5, amount: 1080 },
-			{ sku: 'mem', description: 'GiB-hours', quantity: 720, unit: 'hour', unitPrice: 0.583, amount: 420 }
+			{ projectId: '1001', project: 'web-frontend', description: 'Web frontend', amount: 1080 },
+			{ projectId: '1003', project: 'worker', description: 'Background worker', amount: 525 }
 		]
 	},
 	{
@@ -589,7 +588,7 @@ const invoices = [
 		voidedAt: '2026-04-05T00:00:00Z',
 		createdAt: '2026-04-01T00:00:00Z',
 		lineItems: [
-			{ sku: 'cpu', description: 'vCPU-hours', quantity: 720, unit: 'hour', unitPrice: 1.5, amount: 1080 }
+			{ projectId: '1001', project: 'web-frontend', description: 'Web frontend', amount: 1155.6 }
 		]
 	},
 	{
@@ -612,8 +611,8 @@ const invoices = [
 		voidedAt: '',
 		createdAt: '2026-03-01T00:00:00Z',
 		lineItems: [
-			{ sku: 'cpu', description: 'vCPU-hours', quantity: 200, unit: 'hour', unitPrice: 0.04, amount: 8 },
-			{ sku: 'mem', description: 'GiB-hours', quantity: 200, unit: 'hour', unitPrice: 0.016, amount: 3.2 }
+			{ projectId: '1001', project: 'web-frontend', description: 'Web frontend', amount: 8 },
+			{ projectId: '1002', project: 'api-service', description: 'API service', amount: 3.2 }
 		]
 	},
 	{
@@ -636,7 +635,7 @@ const invoices = [
 		voidedAt: '',
 		createdAt: '2026-01-21T00:00:00Z',
 		lineItems: [
-			{ sku: 'cpu', description: 'vCPU-hours', quantity: 50, unit: 'hour', unitPrice: 1.5, amount: 75 }
+			{ projectId: '1001', project: 'web-frontend', description: 'Web frontend', amount: 80.25 }
 		]
 	}
 ]

--- a/src/routes/(auth)/billing/invoice/+page.svelte
+++ b/src/routes/(auth)/billing/invoice/+page.svelte
@@ -59,28 +59,6 @@
 		return `${v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${invoice.currency}`
 	}
 
-	/**
-	 * Unit prices can be a tiny per-unit rate (e.g. a per-hour or per-second
-	 * compute price) that rounds to 0.00 at the 2-decimal precision used for
-	 * currency totals. Keep a 2-decimal floor, but for sub-cent values widen the
-	 * precision enough to keep the rate's significant digits visible.
-	 * @param {number} v
-	 */
-	function unitPrice (v) {
-		const abs = Math.abs(v)
-		const decimals = abs > 0 && abs < 0.01
-			? Math.min(10, Math.ceil(-Math.log10(abs)) + 3)
-			: 2
-		return `${v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: decimals })} ${invoice.currency}`
-	}
-
-	/**
-	 * @param {number} v
-	 */
-	function quantity (v) {
-		return v.toLocaleString(undefined, { maximumFractionDigits: 4 })
-	}
-
 	const taxRatePct = $derived(`${(invoice.taxRate * 100).toLocaleString(undefined, { maximumFractionDigits: 2 })}%`)
 </script>
 
@@ -209,25 +187,19 @@
 			<table class="table">
 				<thead>
 					<tr>
-						<th>Description</th>
-						<th class="is-align-right">Quantity</th>
-						<th>Unit</th>
-						<th class="is-align-right">Unit price</th>
+						<th>Project</th>
 						<th class="is-align-right">Amount</th>
 					</tr>
 				</thead>
 				<tbody>
 					{#each invoice.lineItems as it, i (i)}
 						<tr>
-							<td>{it.description || it.sku}</td>
-							<td class="is-align-right">{quantity(it.quantity)}</td>
-							<td>{it.unit}</td>
-							<td class="is-align-right">{unitPrice(it.unitPrice)}</td>
+							<td>{it.description || it.project}</td>
 							<td class="is-align-right">{money(it.amount)}</td>
 						</tr>
 					{:else}
 						<tr>
-							<td colspan="5" class="text-content/60">No line items</td>
+							<td colspan="2" class="text-content/60">No line items</td>
 						</tr>
 					{/each}
 				</tbody>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -428,14 +428,15 @@ declare namespace Api {
         createdAt: string
     }
 
+    // One summary line per project: invoices are grouped by project (not SKU),
+    // so each line is a project's total charge for the period. projectId /
+    // project / description are snapshotted at issue time.
     export type InvoiceLineItem = {
-        sku: string
+        projectId: string
+        // project is the project's sid (stable slug).
+        project: string
+        // description is the project's display name (falls back to the sid).
         description: string
-        // quantity is the billed usage, free-tier units already deducted.
-        quantity: number
-        unit: string
-        // unitPrice is the per-unit rate; amount = unitPrice*quantity.
-        unitPrice: number
         amount: number
     }
 

--- a/tests/billing.spec.js
+++ b/tests/billing.spec.js
@@ -32,7 +32,7 @@ test.describe('billing accounts', () => {
 })
 
 test.describe('invoice detail', () => {
-	test('shows a tiny unit price with enough decimals instead of 0.00', async ({ page }) => {
+	test('lists line items grouped by project (project + amount)', async ({ page }) => {
 		await setMocks({
 			'billing.getInvoice': { ok: true, result: sampleInvoice },
 			'billing.get': { ok: true, result: sampleBillingAccount }
@@ -40,14 +40,12 @@ test.describe('invoice detail', () => {
 
 		await page.goto('/billing/invoice?id=inv-1')
 
-		const row = page.locator('table tbody tr', { hasText: 'vCPU-seconds' })
-		const unitPriceCell = row.locator('td').nth(3)
-		// The sub-cent rate keeps its significant digits rather than rounding away.
-		await expect(unitPriceCell).toHaveText('0.0000125 USD')
+		// Each line is one project: name in the first column, gross amount in the second.
+		const webRow = page.locator('table tbody tr', { hasText: 'Web frontend' })
+		await expect(webRow.locator('td').nth(1)).toHaveText('9.00 USD')
 
-		// A normal-magnitude rate still reads at the 2-decimal currency floor.
-		const memRow = page.locator('table tbody tr', { hasText: 'GiB-hours' })
-		await expect(memRow.locator('td').nth(3)).toHaveText('0.50 USD')
+		const apiRow = page.locator('table tbody tr', { hasText: 'API service' })
+		await expect(apiRow.locator('td').nth(1)).toHaveText('1.70 USD')
 	})
 
 	test('surfaces a clear message when PDF download fails with an empty 500', async ({ page }) => {

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -304,12 +304,12 @@ export const sampleInvoice = {
 	paidAt: '0001-01-01T00:00:00Z',
 	voidedAt: '0001-01-01T00:00:00Z',
 	createdAt: now,
+	// Invoices group by project: one summary line per project, amount is the
+	// project's gross (VAT-inclusive) total. projectId is numeric (int64 wire
+	// contract); project is the sid, description the display name.
 	lineItems: [
-		// A tiny per-second rate: rounds to 0.00 at 2 decimals, so the detail
-		// page must widen precision to keep it visible.
-		{ sku: 'cpu', description: 'vCPU-seconds', quantity: 720000, unit: 'second', unitPrice: 0.0000125, amount: 9 },
-		// quantity is the billed usage (free tier deducted); amount = unitPrice*quantity.
-		{ sku: 'mem', description: 'GiB-hours', quantity: 2, unit: 'hour', unitPrice: 0.5, amount: 1 }
+		{ projectId: '1001', project: 'web-frontend', description: 'Web frontend', amount: 9 },
+		{ projectId: '1002', project: 'api-service', description: 'API service', amount: 1.7 }
 	]
 }
 


### PR DESCRIPTION
## What

Render invoices grouped by **project** instead of by resource/SKU — the frontend slice of the group-by-project change.

- `InvoiceLineItem` type → `{ projectId, project, description, amount }` (drops `sku`, `quantity`, `unit`, `unitPrice`).
- The single-invoice view's line-item table is now **Project / Amount** (was Description / Quantity / Unit / Unit price / Amount); removed the now-unused `unitPrice()` / `quantity()` formatter helpers.
- Mock fixtures (`mock.js`) updated to the new shape, with numeric `projectId` strings matching the `int64`-as-string wire contract.

The line label shows the project's display name, falling back to its sid (`it.description || it.project`).

## Companion PRs

- **api #37** — `InvoiceLineItem` contract (merged)
- **apiserver #90** — issuance grouping, schema, PDF (merged)

## Verification

`bun lint` and `bun check` clean. Rendered the invoice page in mock mode and screenshot-verified the Project/Amount table (light + dark).