### PR TITLE
billing: add line-number column to invoice line items

### DIFF
--- a/src/routes/(auth)/billing/invoice/+page.svelte
+++ b/src/routes/(auth)/billing/invoice/+page.svelte
@@ -187,6 +187,7 @@
 			<table class="table">
 				<thead>
 					<tr>
+						<th>#</th>
 						<th>Project</th>
 						<th class="is-align-right">Amount</th>
 					</tr>
@@ -194,12 +195,13 @@
 				<tbody>
 					{#each invoice.lineItems as it, i (i)}
 						<tr>
+							<td class="text-content/60">{i + 1}</td>
 							<td>{it.description || it.project}</td>
 							<td class="is-align-right">{money(it.amount)}</td>
 						</tr>
 					{:else}
 						<tr>
-							<td colspan="2" class="text-content/60">No line items</td>
+							<td colspan="3" class="text-content/60">No line items</td>
 						</tr>
 					{/each}
 				</tbody>

--- a/tests/billing.spec.js
+++ b/tests/billing.spec.js
@@ -40,12 +40,12 @@ test.describe('invoice detail', () => {
 
 		await page.goto('/billing/invoice?id=inv-1')
 
-		// Each line is one project: name in the first column, gross amount in the second.
+		// Each line is one project: # | project name | gross amount (right-aligned).
 		const webRow = page.locator('table tbody tr', { hasText: 'Web frontend' })
-		await expect(webRow.locator('td').nth(1)).toHaveText('9.00 USD')
+		await expect(webRow.locator('td').nth(2)).toHaveText('9.00 USD')
 
 		const apiRow = page.locator('table tbody tr', { hasText: 'API service' })
-		await expect(apiRow.locator('td').nth(1)).toHaveText('1.70 USD')
+		await expect(apiRow.locator('td').nth(2)).toHaveText('1.70 USD')
 	})
 
 	test('surfaces a clear message when PDF download fails with an empty 500', async ({ page }) => {


### PR DESCRIPTION
Mirrors the invoice-PDF change (apiserver #91): add a left-side **#** column (1-based, muted) to the invoice line-item table, before Project. Amount stays right-aligned.

- `billing/invoice/+page.svelte`: `#` header + numbered cell; empty-state `colspan` → 3.
- `billing.spec.js`: the project-grouping test now reads the amount cell at its new index (a `#` column shifted it).

Follow-up to #184 (group-by-project), which is merged.

`bun lint` + `bun check` clean; all 5 billing Playwright tests pass.