### PR TITLE
billing: download receipt button for paid invoices

### DIFF
--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -721,6 +721,17 @@ const handlers = {
 			expiresAt: '2026-06-02T00:00:00Z'
 		})
 	},
+	// Receipt is paid-only — mirror the API's typed error for other statuses.
+	'billing.downloadReceipt': (args) => {
+		const inv = invoices.find((i) => i.id === args?.invoiceId) ?? invoices[0]
+		if (inv.status !== 'paid') {
+			return { ok: false, error: { message: 'api: invoice is not paid' } }
+		}
+		return ok({
+			downloadUrl: `https://dropbox.deploys.app/files/mock-${inv.id}-receipt.pdf`,
+			expiresAt: '2026-06-02T00:00:00Z'
+		})
+	},
 	// Multipart upload: the proxy can't JSON-parse the body in mock mode, so
 	// args is empty here — just acknowledge the upload.
 	'billing.uploadTransferSlip': () => ok({

--- a/src/routes/(auth)/billing/invoice/+page.svelte
+++ b/src/routes/(auth)/billing/invoice/+page.svelte
@@ -12,23 +12,27 @@
 	const billingAccount = $derived(data.billingAccount)
 
 	let downloading = $state(false)
+	let downloadingReceipt = $state(false)
 	let payModal = $state(/** @type {?ReturnType<typeof PayInvoiceModal>} */ (null))
 
 	function onSlipUploaded () {
 		modal.success({ content: 'Payment slip uploaded. We\'ll verify it and mark the invoice as paid.' })
 	}
 
-	async function downloadPDF () {
-		if (downloading) return
-		downloading = true
+	/**
+	 * Shared download flow for the invoice and receipt PDFs.
+	 * @param {string} fn api function name
+	 * @param {string} fallbackError message when the API returns a blank error
+	 */
+	async function download (fn, fallbackError) {
 		try {
 			/** @type {Api.Response<Api.InvoiceDownloadResult>} */
-			const resp = await api.invoke('billing.downloadInvoice', { invoiceId: invoice.id }, fetch)
+			const resp = await api.invoke(fn, { invoiceId: invoice.id }, fetch)
 			if (!resp.ok || !resp.result) {
 				// Show the API's message when present (e.g. the PDF-unavailable
 				// error), else a clear fallback — arpc returns a blank `{}` for
 				// unexpected 500s, which would otherwise be an empty modal.
-				modal.error({ error: resp.error?.message ? resp.error : 'Could not download the invoice PDF. Please try again.' })
+				modal.error({ error: resp.error?.message ? resp.error : fallbackError })
 				return
 			}
 			// The dropbox link serves the file as an attachment, so navigating
@@ -38,8 +42,26 @@
 			// Defensive: a network failure (fetch rejection) shouldn't leave the
 			// button stuck spinning with no feedback.
 			modal.error({ error: err })
+		}
+	}
+
+	async function downloadPDF () {
+		if (downloading) return
+		downloading = true
+		try {
+			await download('billing.downloadInvoice', 'Could not download the invoice PDF. Please try again.')
 		} finally {
 			downloading = false
+		}
+	}
+
+	async function downloadReceipt () {
+		if (downloadingReceipt) return
+		downloadingReceipt = true
+		try {
+			await download('billing.downloadReceipt', 'Could not download the receipt PDF. Please try again.')
+		} finally {
+			downloadingReceipt = false
 		}
 	}
 
@@ -139,6 +161,17 @@
 				<i class="fa-solid fa-download"></i>
 				Download PDF
 			</button>
+			{#if invoice.status === 'paid'}
+				<button
+					class="button is-variant-secondary is-icon-left"
+					class:is-loading={downloadingReceipt}
+					disabled={downloadingReceipt}
+					onclick={downloadReceipt}
+				>
+					<i class="fa-solid fa-file-invoice"></i>
+					Download receipt
+				</button>
+			{/if}
 			{#if invoice.status === 'open'}
 				<button class="button is-icon-left" onclick={() => payModal?.open(invoice)}>
 					<i class="fa-solid fa-receipt"></i>

--- a/tests/billing.spec.js
+++ b/tests/billing.spec.js
@@ -48,6 +48,35 @@ test.describe('invoice detail', () => {
 		await expect(apiRow.locator('td').nth(1)).toHaveText('1.70 USD')
 	})
 
+	test('hides the receipt button on unpaid invoices', async ({ page }) => {
+		await setMocks({
+			'billing.getInvoice': { ok: true, result: sampleInvoice }, // status: open
+			'billing.get': { ok: true, result: sampleBillingAccount }
+		})
+
+		await page.goto('/billing/invoice?id=inv-1')
+
+		await expect(page.getByRole('button', { name: 'Download PDF' })).toBeVisible()
+		await expect(page.getByRole('button', { name: 'Download receipt' })).toHaveCount(0)
+	})
+
+	test('shows the receipt button on paid invoices and calls billing.downloadReceipt', async ({ page }) => {
+		await setMocks({
+			'billing.getInvoice': { ok: true, result: { ...sampleInvoice, status: 'paid', paidAt: '2026-05-03T00:00:00Z' } },
+			'billing.get': { ok: true, result: sampleBillingAccount },
+			// Error response proves the click reaches billing.downloadReceipt and
+			// its message surfaces (success would navigate away to the file URL).
+			'billing.downloadReceipt': { ok: false, error: { message: 'api: invoice pdf export is not available' } }
+		})
+
+		await page.goto('/billing/invoice?id=inv-1')
+
+		const btn = page.getByRole('button', { name: 'Download receipt' })
+		await expect(btn).toBeVisible()
+		await btn.click()
+		await expect(page.locator('#swal2-html-container')).toHaveText(/invoice pdf export is not available/)
+	})
+
 	test('surfaces a clear message when PDF download fails with an empty 500', async ({ page }) => {
 		await setMocks({
 			'billing.getInvoice': { ok: true, result: sampleInvoice },


### PR DESCRIPTION
## What

Adds a **Download receipt** button to the invoice page, shown only when the invoice is **paid**. It calls the new `billing.downloadReceipt` (api deploys-app/api#38, apiserver endpoint in its companion PR) through the same download flow as the invoice PDF — per-button loading state, typed API errors surfaced in the modal.

- Mock handler mirrors the paid-only gate (`api: invoice is not paid` for other statuses).
- Playwright: receipt button absent on open invoices; visible on paid and wired to `billing.downloadReceipt` (error-path assertion).

`bun lint` + `bun check` clean; all billing specs pass.

## Companions / order

1. api #38 (DownloadReceipt contract) — merge first
2. apiserver receipt endpoint + TH/EN template (PR opens once #38 is merged)
3. this PR — UI is status-gated, so it's safe to merge anytime; the button simply appears for paid invoices once the backend ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)