### PR TITLE
Add rate limits to the firewall UI

### DIFF
--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -290,6 +290,29 @@ const wafZone = {
 			priority: 30
 		}
 	],
+	limits: [
+		{
+			id: 'per-ip',
+			description: 'Baseline per-client limit',
+			key: ['ip'],
+			rate: 100,
+			window: '1m',
+			algorithm: 'sliding',
+			mode: 'enforce',
+			status: 429,
+			message: 'Too Many Requests',
+			exclude: ['203.0.113.0/24']
+		},
+		{
+			id: 'login-burst',
+			description: 'Protect login from credential stuffing',
+			key: ['ip', 'header:x-forwarded-user'],
+			rate: 10,
+			window: '10s',
+			algorithm: 'fixed',
+			mode: 'shadow'
+		}
+	],
 	status: 'success',
 	action: 'create',
 	createdAt: CREATED_AT,
@@ -366,6 +389,7 @@ function wafConfiguredZone (location, advance = false) {
 		location,
 		description: entry.description,
 		rules: [],
+		limits: [],
 		status,
 		action: 'create',
 		createdAt: CREATED_AT,

--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -300,8 +300,7 @@ const wafZone = {
 			algorithm: 'sliding',
 			mode: 'enforce',
 			status: 429,
-			message: 'Too Many Requests',
-			exclude: ['203.0.113.0/24']
+			message: 'Too Many Requests'
 		},
 		{
 			id: 'login-burst',

--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -359,6 +359,62 @@ function wafMetrics (timeRange) {
 	return { series, total }
 }
 
+// Bucket widths per range, matching waf.metrics / waf.limitMetrics server-side.
+/** @type {Record<string, number>} */
+const wafBucketSeconds = { '1h': 60, '6h': 300, '12h': 600, '1d': 1200, '7d': 3600, '30d': 14400 }
+
+// Synthetic rate-limit metrics for the seed zone's two limits, so the
+// "Rate limit activity" section has a trend to draw. Each limit gets an
+// `allowed` series with large counts and a `limited` series with small counts,
+// tuned so the limited share lands around the limit's target with some
+// time variation across the window.
+/** @param {string} [timeRange] */
+function wafLimitMetrics (timeRange) {
+	const now = Math.floor(Date.now() / 1000)
+	const range = timeRange ?? '1d'
+	const windowSeconds = wafRangeSeconds[range] ?? wafRangeSeconds['1d']
+	const bucket = wafBucketSeconds[range] ?? wafBucketSeconds['1d']
+	const from = now - windowSeconds
+
+	/**
+	 * @param {string} limitId
+	 * @param {number} base   typical allowed count per bucket
+	 * @param {number} share  typical limited share (0..1)
+	 */
+	const makeLimit = (limitId, base, share) => {
+		/** @type {[number, number][]} */
+		const allowed = []
+		/** @type {[number, number][]} */
+		const limited = []
+		let allowedTotal = 0
+		let limitedTotal = 0
+		for (let ts = from + bucket; ts <= now; ts += bucket) {
+			const a = Math.round(base * (0.7 + 0.6 * Math.random()))
+			allowed.push([ts, a])
+			allowedTotal += a
+			// Drift the share over the window (sinus + noise) so the trend line
+			// actually trends; sparse — calm buckets emit no `limited` point.
+			const wave = 0.6 + 0.4 * Math.sin(((ts - from) / windowSeconds) * Math.PI * 5) + 0.4 * Math.random()
+			const l = Math.round(a * share * wave)
+			if (l > 0) {
+				limited.push([ts, l])
+				limitedTotal += l
+			}
+		}
+		return [
+			{ limitId, result: 'allowed', total: allowedTotal, points: allowed },
+			{ limitId, result: 'limited', total: limitedTotal, points: limited }
+		]
+	}
+
+	const series = [
+		...makeLimit('per-ip', 450, 0.018), // share ~0.5–3%
+		...makeLimit('login-burst', 80, 0.07) // share ~4–10%
+	]
+	const total = series.reduce((acc, s) => acc + s.total, 0)
+	return { series, total }
+}
+
 // Locations (besides the seed LOCATION_ID) that have had a firewall created in
 // this dev session, mapped to { description, polls }. `polls` counts how many
 // times the zone has been read while pending; the deployer is simulated by
@@ -863,6 +919,11 @@ const handlers = {
 		// no-traffic state on the index).
 		const location = args?.location ?? LOCATION_ID
 		if (location === LOCATION_ID) return ok(wafMetrics(args?.timeRange))
+		return ok({ series: [], total: 0 })
+	},
+	'waf.limitMetrics': (args) => {
+		const location = args?.location ?? LOCATION_ID
+		if (location === LOCATION_ID) return ok(wafLimitMetrics(args?.timeRange))
 		return ok({ series: [], total: 0 })
 	},
 	'waf.delete': (args) => {

--- a/src/lib/waf/limits.js
+++ b/src/lib/waf/limits.js
@@ -21,7 +21,6 @@
  * @property {'enforce' | 'shadow'} mode
  * @property {number} status
  * @property {string} message
- * @property {string[]} exclude
  */
 
 export const DEFAULT_LIMIT_STATUS = 429
@@ -118,8 +117,7 @@ export function limitForm (limit) {
 		algorithm: limit?.algorithm ?? 'fixed',
 		mode: limit?.mode ?? 'enforce',
 		status: limit?.status ?? DEFAULT_LIMIT_STATUS,
-		message: limit?.message ?? DEFAULT_LIMIT_MESSAGE,
-		exclude: [...(limit?.exclude ?? [])]
+		message: limit?.message ?? DEFAULT_LIMIT_MESSAGE
 	}
 }
 
@@ -155,7 +153,7 @@ export function normalizeLimits (apiLimits) {
 /**
  * Map form rows back to the API limit shape. Key rows are deduped (and
  * incomplete header/cookie rows dropped), falling back to ['ip'] when nothing
- * valid remains; exclude keeps only non-empty entries.
+ * valid remains.
  * @param {LimitForm[]} limits
  * @returns {Api.WafLimit[]}
  */
@@ -169,8 +167,6 @@ export function toApiLimits (limits) {
 		}
 		if (key.length === 0) key.push('ip')
 
-		const exclude = l.exclude.map((s) => s.trim()).filter(Boolean)
-
 		return {
 			id: l.id,
 			description: l.description,
@@ -180,8 +176,7 @@ export function toApiLimits (limits) {
 			algorithm: l.algorithm === 'sliding' ? 'sliding' : 'fixed',
 			mode: l.mode === 'shadow' ? 'shadow' : 'enforce',
 			status: Number(l.status) === 503 ? 503 : DEFAULT_LIMIT_STATUS,
-			message: l.message || DEFAULT_LIMIT_MESSAGE,
-			...(exclude.length > 0 ? { exclude } : {})
+			message: l.message || DEFAULT_LIMIT_MESSAGE
 		}
 	})
 }

--- a/src/lib/waf/limits.js
+++ b/src/lib/waf/limits.js
@@ -1,0 +1,187 @@
+// Shared rate-limit helpers for the firewall manage + limit edit pages. Limit
+// ids are auto-generated and stable for the life of a limit (like rule ids),
+// but limits have no priority — order doesn't matter.
+
+/**
+ * One characteristic of the bucket key. Header/cookie carry a name; the rest
+ * round-trip as a bare keyword ('ip', 'host', 'country', 'asn').
+ * @typedef {Object} KeyRow
+ * @property {'ip' | 'host' | 'country' | 'asn' | 'header' | 'cookie'} type
+ * @property {string} name
+ */
+
+/**
+ * @typedef {Object} LimitForm
+ * @property {string} id
+ * @property {string} description
+ * @property {KeyRow[]} key
+ * @property {number} rate
+ * @property {string} window
+ * @property {'fixed' | 'sliding'} algorithm
+ * @property {'enforce' | 'shadow'} mode
+ * @property {number} status
+ * @property {string} message
+ * @property {string[]} exclude
+ */
+
+export const DEFAULT_LIMIT_STATUS = 429
+export const DEFAULT_LIMIT_MESSAGE = 'Too Many Requests'
+
+/** @type {Record<string, string>} */
+export const modeLabels = {
+	enforce: 'Enforce',
+	shadow: 'Shadow'
+}
+
+/** @type {Record<KeyRow['type'], string>} */
+export const keyTypeLabels = {
+	ip: 'IP address',
+	host: 'Host',
+	country: 'Country',
+	asn: 'ASN',
+	header: 'Header',
+	cookie: 'Cookie'
+}
+
+// Window presets covering the API's allowed 1s..1h range. Zones loaded with a
+// window outside this list still render — the edit page appends the loaded
+// value as an extra option.
+/** @type {{ value: string, label: string }[]} */
+export const windowOptions = [
+	{ value: '1s', label: '1 second' },
+	{ value: '10s', label: '10 seconds' },
+	{ value: '30s', label: '30 seconds' },
+	{ value: '1m', label: '1 minute' },
+	{ value: '5m', label: '5 minutes' },
+	{ value: '10m', label: '10 minutes' },
+	{ value: '30m', label: '30 minutes' },
+	{ value: '1h', label: '1 hour' }
+]
+
+/**
+ * Parse an API key part ('ip', 'header:x-api-key', …) into a form row.
+ * @param {string} part
+ * @returns {KeyRow}
+ */
+export function parseKeyPart (part) {
+	if (part.startsWith('header:')) return { type: 'header', name: part.slice('header:'.length) }
+	if (part.startsWith('cookie:')) return { type: 'cookie', name: part.slice('cookie:'.length) }
+	if (part === 'host' || part === 'country' || part === 'asn') return { type: part, name: '' }
+	return { type: 'ip', name: '' }
+}
+
+/**
+ * Render a form row back into the API key part shape. Header/cookie rows with
+ * an empty name are incomplete and yield ''. Header names are normalized to
+ * lowercase (HTTP headers are case-insensitive — parapet does the same);
+ * cookie names keep their spelling (cookies match case-sensitively).
+ * @param {KeyRow} row
+ * @returns {string}
+ */
+export function keyRowToApi (row) {
+	if (row.type === 'header' || row.type === 'cookie') {
+		const name = row.name.trim()
+		if (!name) return ''
+		return row.type === 'header' ? `header:${name.toLowerCase()}` : `cookie:${name}`
+	}
+	return row.type
+}
+
+/**
+ * Human label for an API key, e.g. ['ip', 'header:x-api-key'] →
+ * "IP + Header x-api-key".
+ * @param {string[]} [key]
+ * @returns {string}
+ */
+export function describeKey (key) {
+	const parts = (key && key.length > 0 ? key : ['ip']).map((part) => {
+		const row = parseKeyPart(part)
+		if (row.type === 'header' || row.type === 'cookie') {
+			return `${keyTypeLabels[row.type]} ${row.name}`
+		}
+		return row.type === 'ip' ? 'IP' : keyTypeLabels[row.type]
+	})
+	return parts.join(' + ')
+}
+
+/**
+ * @param {Api.WafLimit} [limit]
+ * @returns {LimitForm}
+ */
+export function limitForm (limit) {
+	return {
+		id: limit?.id ?? '',
+		description: limit?.description ?? '',
+		key: (limit?.key?.length ? limit.key : ['ip']).map(parseKeyPart),
+		rate: limit?.rate ?? 100,
+		window: limit?.window ?? '1m',
+		algorithm: limit?.algorithm ?? 'fixed',
+		mode: limit?.mode ?? 'enforce',
+		status: limit?.status ?? DEFAULT_LIMIT_STATUS,
+		message: limit?.message ?? DEFAULT_LIMIT_MESSAGE,
+		exclude: [...(limit?.exclude ?? [])]
+	}
+}
+
+/**
+ * Generate a stable, unique limit id that doesn't collide with `taken`.
+ * @param {string[]} taken
+ * @returns {string}
+ */
+export function genLimitId (taken) {
+	let id
+	do {
+		id = 'limit-' + Math.random().toString(36).slice(2, 8)
+	} while (taken.includes(id))
+	return id
+}
+
+/**
+ * Map API limits to form rows, giving every row a unique id.
+ * @param {Api.WafLimit[]} [apiLimits]
+ * @returns {LimitForm[]}
+ */
+export function normalizeLimits (apiLimits) {
+	/** @type {string[]} */
+	const taken = []
+	return (apiLimits ?? []).map((l) => {
+		const f = limitForm(l)
+		if (!f.id || taken.includes(f.id)) f.id = genLimitId(taken)
+		taken.push(f.id)
+		return f
+	})
+}
+
+/**
+ * Map form rows back to the API limit shape. Key rows are deduped (and
+ * incomplete header/cookie rows dropped), falling back to ['ip'] when nothing
+ * valid remains; exclude keeps only non-empty entries.
+ * @param {LimitForm[]} limits
+ * @returns {Api.WafLimit[]}
+ */
+export function toApiLimits (limits) {
+	return limits.map((l) => {
+		/** @type {string[]} */
+		const key = []
+		for (const row of l.key) {
+			const part = keyRowToApi(row)
+			if (part && !key.includes(part)) key.push(part)
+		}
+		if (key.length === 0) key.push('ip')
+
+		const exclude = l.exclude.map((s) => s.trim()).filter(Boolean)
+
+		return {
+			id: l.id,
+			description: l.description,
+			key,
+			rate: Number(l.rate) || 1,
+			window: l.window,
+			algorithm: l.algorithm === 'sliding' ? 'sliding' : 'fixed',
+			mode: l.mode === 'shadow' ? 'shadow' : 'enforce',
+			status: Number(l.status) === 503 ? 503 : DEFAULT_LIMIT_STATUS,
+			message: l.message || DEFAULT_LIMIT_MESSAGE,
+			...(exclude.length > 0 ? { exclude } : {})
+		}
+	})
+}

--- a/src/routes/(auth)/(project)/waf/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/+page.svelte
@@ -97,6 +97,7 @@
 					<th>Status</th>
 					<th>Description</th>
 					<th>Rules</th>
+					<th>Limits</th>
 					<th>Matches (24h)</th>
 					<th class="is-collapse is-align-right"></th>
 				</tr>
@@ -133,6 +134,7 @@
 							{/if}
 						</td>
 						<td>{fw.rules?.length ?? 0}</td>
+						<td>{fw.limits?.length ?? 0}</td>
 						<td>
 							<!-- Reserve the loaded size in every state so the row/column keeps
 							     its dimensions while the async sparkline fills in (no layout shift). -->
@@ -164,14 +166,14 @@
 					</tr>
 				{/each}
 				<NoDataRow
-					span={6}
+					span={7}
 					list={firewalls}
 					icon="fa-shield-halved"
 					message="No firewalls yet"
 					hint="Create a firewall to start filtering traffic in a location."
 					ctaLabel="Create firewall"
 					ctaHref={`/waf/create?project=${project}`} />
-				<ErrorRow span={6} {error} />
+				<ErrorRow span={7} {error} />
 			</tbody>
 		</table>
 	</div>

--- a/src/routes/(auth)/(project)/waf/create/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/create/+page.svelte
@@ -27,7 +27,8 @@
 				project,
 				location: form.location,
 				description: form.description,
-				rules: []
+				rules: [],
+				limits: []
 			}, fetch)
 			if (!resp.ok) {
 				modal.error({ error: resp.error })

--- a/src/routes/(auth)/(project)/waf/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/edit/+page.svelte
@@ -14,6 +14,7 @@
 		normalizeRules,
 		toApiRules
 	} from '$lib/waf/rules'
+	import { normalizeLimits, toApiLimits } from '$lib/waf/limits'
 
 	const { data } = $props()
 
@@ -29,6 +30,9 @@
 	// The whole loaded zone's rules (ordered) are held in memory so Save can
 	// rewrite the entire zone with the edited rule in place.
 	const rules = untrack(() => normalizeRules(data.zone?.rules))
+	// waf.set replaces the whole zone, so the zone's limits must be echoed back
+	// untouched — otherwise saving a rule would wipe them.
+	const limits = untrack(() => normalizeLimits(data.zone?.limits))
 	const description = untrack(() => data.zone?.description ?? '')
 	// Index of the rule being edited, or -1 when adding a brand-new rule.
 	const editIndex = untrack(() => (data.ruleId ? rules.findIndex((r) => r.id === data.ruleId) : -1))
@@ -102,7 +106,8 @@
 				project,
 				location,
 				description,
-				rules: toApiRules(nextRules)
+				rules: toApiRules(nextRules),
+				limits: toApiLimits(limits)
 			}, fetch)
 			if (!resp.ok) {
 				modal.error({ error: resp.error })

--- a/src/routes/(auth)/(project)/waf/limit/+page.js
+++ b/src/routes/(auth)/(project)/waf/limit/+page.js
@@ -1,0 +1,39 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+
+export async function load ({ url, parent, fetch }) {
+	const { project } = await parent()
+	const location = url.searchParams.get('location') ?? ''
+	const limitId = url.searchParams.get('limit')
+
+	if (!location) {
+		redirect(302, `/waf?project=${project}`)
+	}
+
+	const manageUrl = `/waf/manage?project=${project}&location=${encodeURIComponent(location)}`
+
+	/** @type {Api.Response<Api.WafZone>} */
+	const res = await api.invoke('waf.get', { project, location }, fetch)
+	// A missing zone is the normal "firewall not configured yet" state — render
+	// an empty editor (create mode). Surface anything else.
+	if (!res.ok && !res.error?.notFound) {
+		error(500, res.error?.message)
+	}
+	const zone = res.result ?? null
+
+	// Editing a specific limit requires its zone + limit to exist; otherwise
+	// send the user back to the list for this location.
+	if (limitId) {
+		const found = zone?.limits?.some((l) => l.id === limitId)
+		if (!found) {
+			redirect(302, manageUrl)
+		}
+	}
+
+	return {
+		project,
+		location,
+		limitId,
+		zone
+	}
+}

--- a/src/routes/(auth)/(project)/waf/limit/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/limit/+page.svelte
@@ -231,16 +231,18 @@
 			</div>
 
 			<div class="flex flex-wrap items-center gap-3">
-				<div class="field">
+				<div class="field w-40">
 					<label for="limit-rate">Requests</label>
 					<div class="input">
 						<input id="limit-rate" type="number" min="1" bind:value={draft.rate} placeholder="100">
 					</div>
 				</div>
 				<span class="text-content/60 text-sm mt-6">requests per</span>
-				<div class="field">
+				<!-- fixed width so the row doesn't reflow when the selected
+				     window label changes length (e.g. 1 second → 30 minutes) -->
+				<div class="field w-44">
 					<label for="limit-window">Window</label>
-					<Select id="limit-window" bind:value={draft.window} options={allWindowOptions} />
+					<Select id="limit-window" bind:value={draft.window} options={allWindowOptions} class="w-full" />
 				</div>
 			</div>
 		</div>

--- a/src/routes/(auth)/(project)/waf/limit/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/limit/+page.svelte
@@ -1,0 +1,354 @@
+<script>
+	import { untrack } from 'svelte'
+	import { goto } from '$app/navigation'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
+	import TagInput from '$lib/components/TagInput.svelte'
+	import { normalizeRules, toApiRules } from '$lib/waf/rules'
+	import {
+		DEFAULT_LIMIT_MESSAGE,
+		keyTypeLabels,
+		limitForm,
+		genLimitId,
+		normalizeLimits,
+		toApiLimits,
+		windowOptions
+	} from '$lib/waf/limits'
+
+	const { data } = $props()
+
+	const project = $derived(data.project)
+	const location = $derived(data.location)
+
+	const keyTypeOptions = Object.entries(keyTypeLabels)
+		.map(([value, label]) => ({ value, label }))
+
+	const algorithmOptions = [
+		{ value: 'fixed', label: 'Fixed window' },
+		{ value: 'sliding', label: 'Sliding window' }
+	]
+
+	const modeOptions = [
+		{ value: 'enforce', label: 'Enforce — reject over-limit requests' },
+		{ value: 'shadow', label: 'Shadow — only count, never reject' }
+	]
+
+	const statusOptions = [
+		{ value: 429, label: '429 Too Many Requests' },
+		{ value: 503, label: '503 Service Unavailable' }
+	]
+
+	// The whole loaded zone (rules + limits) is held in memory so Save can
+	// rewrite the entire zone with the edited limit in place — waf.set replaces
+	// the zone, so rules must be echoed back untouched.
+	const rules = untrack(() => normalizeRules(data.zone?.rules))
+	const limits = untrack(() => normalizeLimits(data.zone?.limits))
+	const description = untrack(() => data.zone?.description ?? '')
+	// Index of the limit being edited, or -1 when adding a brand-new limit.
+	const editIndex = untrack(() => (data.limitId ? limits.findIndex((l) => l.id === data.limitId) : -1))
+	const isCreate = editIndex === -1
+
+	// Working-copy draft — Cancel discards it without touching the server.
+	const draft = $state(untrack(() => {
+		if (isCreate) {
+			const taken = limits.map((l) => l.id)
+			return { ...limitForm(), id: genLimitId(taken) }
+		}
+		// Deep-copy the key rows + exclusions so edits don't leak into `limits`.
+		const seed = limits[editIndex]
+		return { ...seed, key: seed.key.map((k) => ({ ...k })), exclude: [...seed.exclude] }
+	}))
+
+	let saving = $state(false)
+
+	// A loaded zone may carry a window outside the presets (the API accepts any
+	// 1s..1h Go duration) — keep it selectable so editing preserves it.
+	const allWindowOptions = $derived(
+		windowOptions.some((o) => o.value === draft.window)
+			? windowOptions
+			: [...windowOptions, { value: draft.window, label: draft.window }]
+	)
+
+	// Save gates: a positive rate, a window, and every header/cookie key row
+	// must carry a name (the other key types are complete on their own).
+	const keysComplete = $derived(
+		draft.key.length > 0 &&
+		draft.key.every((row) => (row.type !== 'header' && row.type !== 'cookie') || !!row.name.trim())
+	)
+	const canSave = $derived(Number(draft.rate) >= 1 && !!draft.window && keysComplete)
+
+	function addKeyRow () {
+		draft.key = [...draft.key, /** @type {import('$lib/waf/limits').KeyRow} */ ({ type: 'ip', name: '' })]
+	}
+
+	/** @param {number} i */
+	function removeKeyRow (i) {
+		draft.key = draft.key.filter((_, idx) => idx !== i)
+	}
+
+	function backToManage () {
+		return goto(`/waf/manage?project=${project}&location=${encodeURIComponent(location)}`)
+	}
+
+	/** @param {Event} e */
+	async function save (e) {
+		e.preventDefault()
+		if (saving || !canSave) return
+
+		saving = true
+		try {
+			// Rebuild the zone's limit list with the edited limit replaced by id (or
+			// appended for create), then write the whole zone.
+			let nextLimits
+			if (isCreate) {
+				nextLimits = [...limits, { ...draft }]
+			} else {
+				nextLimits = limits.map((l) => (l.id === draft.id ? { ...draft } : l))
+			}
+
+			const resp = await api.invoke('waf.set', {
+				project,
+				location,
+				description,
+				rules: toApiRules(rules),
+				limits: toApiLimits(nextLimits)
+			}, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+			await backToManage()
+		} finally {
+			saving = false
+		}
+	}
+
+	function cancel () {
+		backToManage()
+	}
+
+	// Enter inside a text field (description/rate/message, the key name inputs,
+	// the exclusion chips) must not implicitly submit the limit — in the
+	// TagInput it means "add this CIDR", elsewhere nothing. Saving is
+	// deliberate, via the Save button (a <button>, where Enter still works).
+	/** @param {HTMLFormElement} node */
+	function blockEnterSubmit (node) {
+		/** @param {KeyboardEvent} e */
+		function onKeydown (e) {
+			if (e.key === 'Enter' && e.target instanceof HTMLInputElement) e.preventDefault()
+		}
+		node.addEventListener('keydown', onKeydown)
+		return { destroy: () => node.removeEventListener('keydown', onKeydown) }
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/waf?project=${project}`} class="link"><h6>Firewall</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<a href={`/waf/manage?project=${project}&location=${encodeURIComponent(location)}`} class="link"><h6 class="font-mono">{location}</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<h6>{isCreate ? 'Add limit' : 'Edit limit'}</h6>
+	</div>
+</div>
+
+<br>
+<div class="panel is-level-300 grid gap-6">
+	<div class="grid grid-cols-1 gap-3">
+		<div class="flex items-center">
+			<h3 class="mr-6 mb-4 xl:mb-0"><strong>{isCreate ? 'Add limit' : 'Edit limit'}</strong></h3>
+		</div>
+		<p class="page-sub">Rate limit in <span class="font-mono">{location}</span></p>
+	</div>
+
+	<hr>
+
+	<form class="grid gap-6 w-full" onsubmit={save} use:blockEnterSubmit>
+		<div class="field">
+			<label for="limit-description">Description</label>
+			<div class="input">
+				<input id="limit-description" bind:value={draft.description} placeholder="Optional description">
+			</div>
+		</div>
+
+		<hr>
+
+		<div class="grid gap-4">
+			<div>
+				<h6><strong>Count requests by</strong></h6>
+				<p class="text-content/50 text-sm mt-1">
+					Requests sharing every characteristic below share one counter bucket.
+					Defaults to client IP.
+				</p>
+			</div>
+
+			<div class="grid gap-3">
+				{#each draft.key as row, i (i)}
+					<div class="key-row">
+						<div class="grid gap-3 sm:grid-cols-2 flex-1 min-w-0">
+							<div class="field">
+								<label for={`limit-key-type-${i}`}>Characteristic</label>
+								<Select id={`limit-key-type-${i}`} bind:value={row.type} options={keyTypeOptions}
+									onchange={() => (row.name = '')} />
+							</div>
+							{#if row.type === 'header' || row.type === 'cookie'}
+								<div class="field">
+									<label for={`limit-key-name-${i}`}>Name</label>
+									<div class="input">
+										<input id={`limit-key-name-${i}`} class="font-mono" bind:value={row.name}
+											placeholder={row.type === 'header' ? 'x-api-key' : 'session'}>
+									</div>
+								</div>
+							{/if}
+						</div>
+						{#if draft.key.length > 1}
+							<button type="button" class="key-row-remove button is-variant-tertiary is-size-small"
+								aria-label="Remove characteristic" onclick={() => removeKeyRow(i)}>
+								<i class="fa-solid fa-trash-can"></i>
+							</button>
+						{/if}
+					</div>
+				{/each}
+			</div>
+
+			<div class="flex justify-start">
+				<button type="button" class="button is-variant-secondary is-size-small" onclick={addKeyRow}>
+					<i class="fa-solid fa-plus mr-2"></i>
+					<span>Add characteristic</span>
+				</button>
+			</div>
+		</div>
+
+		<hr>
+
+		<div class="grid gap-4">
+			<div>
+				<h6><strong>Allow at most</strong></h6>
+				<p class="text-content/50 text-sm mt-1">
+					Requests over this rate are counted — and rejected when enforcing.
+				</p>
+			</div>
+
+			<div class="flex flex-wrap items-center gap-3">
+				<div class="field">
+					<label for="limit-rate">Requests</label>
+					<div class="input">
+						<input id="limit-rate" type="number" min="1" bind:value={draft.rate} placeholder="100">
+					</div>
+				</div>
+				<span class="text-content/60 text-sm mt-6">requests per</span>
+				<div class="field">
+					<label for="limit-window">Window</label>
+					<Select id="limit-window" bind:value={draft.window} options={allWindowOptions} />
+				</div>
+			</div>
+		</div>
+
+		<hr>
+
+		<div class="grid gap-4">
+			<div>
+				<h6><strong>Behavior</strong></h6>
+				<p class="text-content/50 text-sm mt-1">
+					Fixed window resets the counter at each window boundary; sliding
+					window weighs the previous window for a smoother limit.
+				</p>
+			</div>
+
+			<div class="grid gap-4 sm:grid-cols-2">
+				<div class="field">
+					<label for="limit-algorithm">Algorithm</label>
+					<Select id="limit-algorithm" bind:value={draft.algorithm} options={algorithmOptions} />
+				</div>
+				<div class="field">
+					<label for="limit-mode">Mode</label>
+					<Select id="limit-mode" bind:value={draft.mode} options={modeOptions} />
+				</div>
+			</div>
+		</div>
+
+		{#if draft.mode === 'enforce'}
+			<hr>
+
+			<div class="grid gap-4">
+				<div>
+					<h6><strong>Rejection response</strong></h6>
+					<p class="text-content/50 text-sm mt-1">
+						Returned to clients that exceed the limit.
+					</p>
+				</div>
+
+				<div class="grid gap-4 sm:grid-cols-2">
+					<div class="field">
+						<label for="limit-status">Response status</label>
+						<Select id="limit-status" bind:value={draft.status} options={statusOptions} />
+					</div>
+					<div class="field">
+						<label for="limit-message">Response message</label>
+						<div class="input">
+							<input id="limit-message" bind:value={draft.message} placeholder={DEFAULT_LIMIT_MESSAGE}>
+						</div>
+					</div>
+				</div>
+			</div>
+		{/if}
+
+		<hr>
+
+		<div class="grid gap-4">
+			<div>
+				<h6><strong>Exclusions</strong></h6>
+				<p class="text-content/50 text-sm mt-1">
+					Requests from these CIDRs skip this limit.
+				</p>
+			</div>
+
+			<div class="field">
+				<label for="limit-exclude">CIDRs</label>
+				<TagInput id="limit-exclude" bind:tags={draft.exclude}
+					placeholder="e.g. 203.0.113.0/24, press Enter to add" />
+			</div>
+		</div>
+
+		<hr>
+
+		<div class="flex items-center gap-3">
+			<button class="button" class:is-loading={saving} disabled={saving || !canSave}
+				title={canSave ? undefined : 'Set a rate, window, and complete every key characteristic before saving'}>Save</button>
+			<button type="button" class="button is-variant-secondary" onclick={cancel}>Cancel</button>
+			{#if !canSave}
+				<p class="text-content/50 text-sm">
+					{#if !keysComplete}
+						Name every header/cookie characteristic to save this limit.
+					{:else}
+						Set a rate of at least 1 request per window to save this limit.
+					{/if}
+				</p>
+			{/if}
+		</div>
+	</form>
+</div>
+
+<style>
+	.key-row {
+		display: flex;
+		align-items: flex-start;
+		gap: 0.75rem;
+		padding: 1rem;
+		border-radius: var(--radius-md);
+		border: 1px solid hsl(var(--hsl-line));
+		background-color: hsl(var(--hsl-base-400) / 0.12);
+	}
+
+	:root:not(.dark) .key-row {
+		background-color: hsl(var(--hsl-base-100) / 0.6);
+	}
+
+	.key-row-remove {
+		flex-shrink: 0;
+		margin-top: 1.75rem;
+	}
+</style>

--- a/src/routes/(auth)/(project)/waf/limit/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/limit/+page.svelte
@@ -4,7 +4,6 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
-	import TagInput from '$lib/components/TagInput.svelte'
 	import { normalizeRules, toApiRules } from '$lib/waf/rules'
 	import {
 		DEFAULT_LIMIT_MESSAGE,
@@ -55,9 +54,9 @@
 			const taken = limits.map((l) => l.id)
 			return { ...limitForm(), id: genLimitId(taken) }
 		}
-		// Deep-copy the key rows + exclusions so edits don't leak into `limits`.
+		// Deep-copy the key rows so edits don't leak into `limits`.
 		const seed = limits[editIndex]
-		return { ...seed, key: seed.key.map((k) => ({ ...k })), exclude: [...seed.exclude] }
+		return { ...seed, key: seed.key.map((k) => ({ ...k })) }
 	}))
 
 	let saving = $state(false)
@@ -128,10 +127,9 @@
 		backToManage()
 	}
 
-	// Enter inside a text field (description/rate/message, the key name inputs,
-	// the exclusion chips) must not implicitly submit the limit — in the
-	// TagInput it means "add this CIDR", elsewhere nothing. Saving is
-	// deliberate, via the Save button (a <button>, where Enter still works).
+	// Enter inside a text field (description/rate/message, the key name inputs)
+	// must not implicitly submit the limit. Saving is deliberate, via the Save
+	// button (a <button>, where Enter still works).
 	/** @param {HTMLFormElement} node */
 	function blockEnterSubmit (node) {
 		/** @param {KeyboardEvent} e */
@@ -295,23 +293,6 @@
 				</div>
 			</div>
 		{/if}
-
-		<hr>
-
-		<div class="grid gap-4">
-			<div>
-				<h6><strong>Exclusions</strong></h6>
-				<p class="text-content/50 text-sm mt-1">
-					Requests from these CIDRs skip this limit.
-				</p>
-			</div>
-
-			<div class="field">
-				<label for="limit-exclude">CIDRs</label>
-				<TagInput id="limit-exclude" bind:tags={draft.exclude}
-					placeholder="e.g. 203.0.113.0/24, press Enter to add" />
-			</div>
-		</div>
 
 		<hr>
 

--- a/src/routes/(auth)/(project)/waf/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/manage/+page.svelte
@@ -5,6 +5,7 @@
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import { actionLabels, normalizeRules, toApiRules } from '$lib/waf/rules'
+	import { describeKey, keyRowToApi, modeLabels, normalizeLimits, toApiLimits } from '$lib/waf/limits'
 
 	const { data } = $props()
 
@@ -15,6 +16,7 @@
 	// (e.g. from the edit page) reloads the loader, which re-seeds this copy.
 	let description = $state(untrack(() => data.zone?.description ?? ''))
 	let rules = $state(untrack(() => normalizeRules(data.zone?.rules)))
+	let limits = $state(untrack(() => normalizeLimits(data.zone?.limits)))
 
 	let loadedLocation = untrack(() => data.location ?? '')
 
@@ -28,6 +30,7 @@
 				loadedLocation = next.location ?? ''
 				description = next.zone?.description ?? ''
 				rules = normalizeRules(next.zone?.rules)
+				limits = normalizeLimits(next.zone?.limits)
 			}
 		})
 	})
@@ -49,17 +52,23 @@
 		const zone = resp.result ?? null
 		description = zone?.description ?? ''
 		rules = normalizeRules(zone?.rules)
+		limits = normalizeLimits(zone?.limits)
 	}
 
-	// Persist the whole zone (priority follows row order). On error, surface it
-	// and reload from the server so the UI matches reality.
-	/** @param {import('$lib/waf/rules').RuleForm[]} nextRules */
-	async function persistZone (nextRules) {
+	// Persist the whole zone (priority follows row order). waf.set replaces the
+	// entire zone, so rules and limits must always travel together. On error,
+	// surface it and reload from the server so the UI matches reality.
+	/**
+	 * @param {import('$lib/waf/rules').RuleForm[]} nextRules
+	 * @param {import('$lib/waf/limits').LimitForm[]} [nextLimits]
+	 */
+	async function persistZone (nextRules, nextLimits = limits) {
 		const resp = await api.invoke('waf.set', {
 			project,
 			location,
 			description,
-			rules: toApiRules(nextRules)
+			rules: toApiRules(nextRules),
+			limits: toApiLimits(nextLimits)
 		}, fetch)
 		if (!resp.ok) {
 			modal.error({ error: resp.error })
@@ -106,6 +115,30 @@
 		goto(`/waf/edit?project=${project}&location=${encodeURIComponent(location)}`)
 	}
 
+	/** @param {number} i */
+	function removeLimit (i) {
+		const limit = limits[i]
+		if (!limit) return
+		modal.confirm({
+			title: `Delete rate limit ${limit.id}?`,
+			yes: 'Delete',
+			callback: async () => {
+				const next = limits.filter((_, k) => k !== i)
+				limits = next
+				await persistZone(rules, next)
+			}
+		})
+	}
+
+	/** @param {import('$lib/waf/limits').LimitForm} limit */
+	function editLimit (limit) {
+		goto(`/waf/limit?project=${project}&location=${encodeURIComponent(location)}&limit=${encodeURIComponent(limit.id)}`)
+	}
+
+	function addLimit () {
+		goto(`/waf/limit?project=${project}&location=${encodeURIComponent(location)}`)
+	}
+
 	async function saveDescription () {
 		if (savingDescription) return
 		savingDescription = true
@@ -118,7 +151,7 @@
 
 	function deleteZone () {
 		modal.confirm({
-			title: `Disable the firewall in ${location}? All rules will be removed.`,
+			title: `Disable the firewall in ${location}? All rules and rate limits will be removed.`,
 			yes: 'Disable',
 			callback: async () => {
 				const resp = await api.invoke('waf.delete', { project, location }, fetch)
@@ -268,7 +301,87 @@
 			</table>
 		</div>
 
-		<DangerZone description="Disable the firewall in this location and permanently remove all of its rules.">
+		<br>
+		<hr>
+		<br>
+
+		<div class="flex items-center justify-between">
+			<div>
+				<h6><strong>Rate limits</strong></h6>
+				<p class="text-content/50 text-sm mt-1">
+					Limit how often clients can hit your routes. Shadow mode counts
+					matches without rejecting.
+				</p>
+			</div>
+		</div>
+
+		<div class="table-container">
+			<table class="table is-variant-compact">
+				<thead>
+					<tr>
+						<th>Description</th>
+						<th>Key</th>
+						<th>Limit</th>
+						<th>Mode</th>
+						<th class="is-collapse is-align-right">Actions</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each limits as limit, i (limit.id)}
+						<tr>
+							<td>
+								{#if limit.description}
+									{limit.description}
+								{:else}
+									<span class="text-content/40">—</span>
+								{/if}
+							</td>
+							<td>{describeKey(limit.key.map(keyRowToApi).filter(Boolean))}</td>
+							<td>
+								<span class="font-mono text-sm">{limit.rate} / {limit.window}</span>
+							</td>
+							<td>
+								<span class="mode-badge" data-mode={limit.mode}>
+									{modeLabels[limit.mode] ?? limit.mode}
+								</span>
+							</td>
+							<td>
+								<div class="flex gap-1 justify-end">
+									<button class="icon-button" type="button" aria-label="Edit rate limit"
+										onclick={() => editLimit(limit)}>
+										<i class="fa-solid fa-pencil"></i>
+									</button>
+									<button class="icon-button" type="button" aria-label="Remove rate limit"
+										onclick={() => removeLimit(i)}>
+										<i class="fa-solid fa-trash-alt"></i>
+									</button>
+								</div>
+							</td>
+						</tr>
+					{/each}
+					{#if limits.length === 0}
+						<tr>
+							<td colspan="5" class="text-center text-content/50">
+								No rate limits yet. Add a limit to throttle traffic.
+							</td>
+						</tr>
+					{/if}
+				</tbody>
+				<tfoot>
+					<tr>
+						<td colspan="5">
+							<button class="button is-variant-secondary flex m-auto" type="button"
+								onclick={addLimit}>
+								<i class="fa-solid fa-plus mr-3"></i>
+								<span>Add Limit</span>
+							</button>
+						</td>
+					</tr>
+				</tfoot>
+			</table>
+		</div>
+
+		<DangerZone description="Disable the firewall in this location and permanently remove all of its rules and rate limits.">
 			<button class="button is-variant-negative" type="button" onclick={deleteZone}>Disable firewall</button>
 		</DangerZone>
 	</div>
@@ -295,5 +408,23 @@
 	.action-badge[data-action='allow'] {
 		color: hsl(var(--hsl-positive));
 		background-color: hsl(var(--hsl-positive) / 0.12);
+	}
+
+	.mode-badge {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.125rem 0.625rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		line-height: 1.5;
+		color: hsl(var(--hsl-content) / 0.75);
+		background-color: hsl(var(--hsl-content) / 0.08);
+	}
+
+	/* Shadow only observes — render it muted so Enforce stands out. */
+	.mode-badge[data-mode='shadow'] {
+		color: hsl(var(--hsl-content) / 0.5);
+		background-color: hsl(var(--hsl-content) / 0.05);
 	}
 </style>

--- a/src/routes/(auth)/(project)/waf/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/metrics/+page.svelte
@@ -6,7 +6,9 @@
 	import * as modal from '$lib/modal'
 	import * as format from '$lib/format'
 	import { actionLabels } from '$lib/waf/rules'
+	import { describeKey, modeLabels } from '$lib/waf/limits'
 	import WafActivityChart from '$lib/components/WafActivityChart.svelte'
+	import LineChart from '$lib/components/LineChart.svelte'
 
 	const { data } = $props()
 
@@ -19,6 +21,10 @@
 	const ruleMeta = $derived(new Map(
 		(data.zone?.rules ?? []).map((/** @type {Api.WafRule} */ r) => [r.id, r])
 	))
+
+	// Configured limits drive the rate-limit section: no limits, no section.
+	const limits = $derived(/** @type {Api.WafLimit[]} */ (data.zone?.limits ?? []))
+	const hasLimits = $derived(limits.length > 0)
 
 	// Stacks render block on top of log on top of allow — most-severe last so it
 	// sits at the top of the column.
@@ -53,6 +59,7 @@
 
 	let loading = $state(true)
 	let result = $state(/** @type {Api.WafMetricsResult | null} */ (null))
+	let limitResult = $state(/** @type {Api.WafLimitMetricsResult | null} */ (null))
 	// Anchor the time window to the moment of the latest fetch so the chart grid
 	// and "as of" line agree.
 	let fetchedAt = $state(Math.floor(Date.now() / 1000))
@@ -63,13 +70,19 @@
 	async function fetchMetrics () {
 		loading = true
 		try {
-			/** @type {Api.Response<Api.WafMetricsResult>} */
-			const res = await api.invoke('waf.metrics', { project, location, timeRange: range }, fetch)
+			const args = { project, location, timeRange: range }
+			const [res, limitRes] = await Promise.all([
+				/** @type {Promise<Api.Response<Api.WafMetricsResult>>} */ (api.invoke('waf.metrics', args, fetch)),
+				hasLimits
+					? /** @type {Promise<Api.Response<Api.WafLimitMetricsResult>>} */ (api.invoke('waf.limitMetrics', args, fetch))
+					: Promise.resolve(/** @type {Api.Response<Api.WafLimitMetricsResult>} */ ({ ok: true, result: { series: [], total: 0 } }))
+			])
 			if (!res.ok) {
 				modal.error({ error: res.error })
 				return
 			}
 			result = res.result ?? { series: [], total: 0 }
+			limitResult = (limitRes.ok ? limitRes.result : null) ?? { series: [], total: 0 }
 			fetchedAt = Math.floor(Date.now() / 1000)
 		} finally {
 			loading = false
@@ -94,6 +107,7 @@
 		u.searchParams.set('range', r)
 		replaceState(u, {})
 		result = null
+		limitResult = null
 		fetchMetrics()
 	}
 
@@ -184,8 +198,70 @@
 		return total > 0 ? `${Math.round((v / total) * 100)}%` : '—'
 	}
 
+	// Per-limit (allowed, limited) bucket counts, joined from the sparse series.
+	const limitBuckets = $derived.by(() => {
+		/** @type {Record<string, { allowed: Record<number, number>, limited: Record<number, number> }>} */
+		const byLimit = {}
+		for (const s of limitResult?.series ?? []) {
+			const entry = byLimit[s.limitId] ??= { allowed: {}, limited: {} }
+			const m = entry[s.result]
+			if (!m) continue
+			for (const [ts, v] of s.points ?? []) {
+				m[ts] = (m[ts] ?? 0) + v
+			}
+		}
+		return byLimit
+	})
+
+	// One share line per configured limit: limited / (allowed + limited) as a
+	// percentage, over the union of that limit's bucket timestamps. A missing
+	// series counts as 0, so a bucket with only limited traffic reads 100%.
+	const limitShareSeries = $derived.by(() => {
+		/** @type {import('$lib/charts/util').LineSeries[]} */
+		const out = []
+		for (const limit of limits) {
+			const entry = limitBuckets[limit.id]
+			if (!entry) continue
+			const xs = [...new Set([...Object.keys(entry.allowed), ...Object.keys(entry.limited)])]
+				.map(Number)
+				.sort((a, b) => a - b)
+			if (!xs.length) continue
+			const name = limit.description || limit.id
+			out.push({
+				name: limit.mode === 'shadow' ? `${name} · shadow` : name,
+				dashed: limit.mode === 'shadow',
+				points: xs.map((ts) => {
+					const allowed = entry.allowed[ts] ?? 0
+					const limited = entry.limited[ts] ?? 0
+					const t = allowed + limited
+					return { x: ts * 1000, y: t > 0 ? (limited / t) * 100 : 0 }
+				})
+			})
+		}
+		return out
+	})
+
+	// Summary rows — every configured limit gets one, with — when it saw no
+	// traffic in the window.
+	const limitRows = $derived(limits.map((limit) => {
+		const entry = limitBuckets[limit.id]
+		const sum = (/** @type {Record<number, number> | undefined} */ m) =>
+			Object.values(m ?? {}).reduce((acc, v) => acc + v, 0)
+		const allowed = sum(entry?.allowed)
+		const limited = sum(entry?.limited)
+		const traffic = allowed + limited
+		return { limit, allowed, limited, traffic, share: traffic > 0 ? (limited / traffic) * 100 : null }
+	}))
+
+	/** @param {number} v */
+	function sharePct (v) {
+		return `${v >= 10 ? v.toFixed(1) : v.toFixed(2)}%`
+	}
+
 	const showSpinner = $derived(loading && !result)
 	const isEmpty = $derived(!loading && total === 0)
+	const limitSpinner = $derived(loading && !limitResult)
+	const limitEmpty = $derived(!limitSpinner && limitShareSeries.length === 0)
 </script>
 
 <div class="breadcrumb">
@@ -328,6 +404,95 @@
 							<i class="fa-solid fa-spinner-third fa-spin"></i>
 						</td></tr>
 					{/if}
+				</tbody>
+			</table>
+		</div>
+	</div>
+{/if}
+
+{#if hasLimits}
+	<div class="panel is-level-300 limit-panel">
+		<div class="panel-head">
+			<div>
+				<h6><strong>Rate limit activity</strong></h6>
+				<p class="page-sub">Share of requests over each limit — size shadow limits here before enforcing them.</p>
+			</div>
+		</div>
+
+		<div class="limit-chart-body">
+			{#if limitSpinner}
+				<div class="chart-state limit-state text-content/40">
+					<i class="fa-solid fa-spinner-third fa-spin text-2xl"></i>
+				</div>
+			{:else if limitEmpty}
+				<div class="chart-state limit-state">
+					<i class="fa-solid fa-gauge-high empty-icon"></i>
+					<p class="empty-title">No rate limit activity in this range.</p>
+					<p class="empty-sub">No request hit a configured limit's bucket in the {RANGE_LABEL[range]}.</p>
+				</div>
+			{:else}
+				<LineChart
+					series={limitShareSeries}
+					xType="time"
+					xDomain={[windowFrom * 1000, fetchedAt * 1000]}
+					height={280}
+					formatY={(v) => `${format.count(v)}%`}
+					formatValue={(v) => sharePct(v)}
+					legend />
+			{/if}
+		</div>
+
+		<div class="table-container limit-table">
+			<table class="table is-variant-compact">
+				<thead>
+					<tr>
+						<th>Limit</th>
+						<th>Mode</th>
+						<th class="is-align-right">Allowed</th>
+						<th class="is-align-right">Limited</th>
+						<th class="is-align-right">Share</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each limitRows as row (row.limit.id)}
+						<tr>
+							<td>
+								<div class="rule-cell">
+									<span class="rule-desc">{row.limit.description || row.limit.id}</span>
+									<span class="text-sm text-content/55">{describeKey(row.limit.key)} · {row.limit.rate} / {row.limit.window}</span>
+								</div>
+							</td>
+							<td>
+								<span class="mode-badge" data-mode={row.limit.mode ?? 'enforce'}>
+									{modeLabels[row.limit.mode ?? 'enforce'] ?? row.limit.mode}
+								</span>
+							</td>
+							<td class="is-align-right font-mono tabular-nums">
+								{#if row.traffic > 0}
+									{row.allowed.toLocaleString()}
+								{:else}
+									<span class="text-content/40">—</span>
+								{/if}
+							</td>
+							<td class="is-align-right">
+								{#if row.traffic > 0}
+									<span class="font-mono tabular-nums">{row.limited.toLocaleString()}</span>
+									{#if row.limit.mode === 'shadow'}
+										<span class="text-sm text-content/45">would be limited</span>
+									{/if}
+								{:else}
+									<span class="text-content/40">—</span>
+								{/if}
+							</td>
+							<td class="is-align-right font-mono tabular-nums">
+								{#if row.share != null}
+									{sharePct(row.share)}
+								{:else}
+									<span class="text-content/40">—</span>
+								{/if}
+							</td>
+						</tr>
+					{/each}
 				</tbody>
 			</table>
 		</div>
@@ -601,5 +766,41 @@
 	.act-badge[data-action='allow'] {
 		color: hsl(var(--hsl-positive));
 		background-color: hsl(var(--hsl-positive) / 0.12);
+	}
+
+	/* Rate limit activity */
+	.limit-panel {
+		margin-top: 1rem;
+	}
+
+	.limit-chart-body {
+		min-height: 280px;
+	}
+
+	.limit-state {
+		min-height: 280px;
+	}
+
+	.limit-table {
+		margin-top: 1rem;
+	}
+
+	/* Same badge as the manage page's limits table. */
+	.mode-badge {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.125rem 0.625rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		line-height: 1.5;
+		color: hsl(var(--hsl-content) / 0.75);
+		background-color: hsl(var(--hsl-content) / 0.08);
+	}
+
+	/* Shadow only observes — render it muted so Enforce stands out. */
+	.mode-badge[data-mode='shadow'] {
+		color: hsl(var(--hsl-content) / 0.5);
+		background-color: hsl(var(--hsl-content) / 0.05);
 	}
 </style>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -536,6 +536,19 @@ declare namespace Api {
         total: number
     }
 
+    export type WafLimitMetricsSeries = {
+        limitId: string
+        result: 'allowed' | 'limited'
+        total: number
+        // [unixSeconds, count], time-ordered; sparse — missing bucket = 0
+        points: [number, number][]
+    }
+
+    export type WafLimitMetricsResult = {
+        series: WafLimitMetricsSeries[]
+        total: number
+    }
+
     export type DropboxItem = {
         downloadUrl: string
         filename: string

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -486,11 +486,32 @@ declare namespace Api {
         priority: number
     }
 
+    export type WafLimit = {
+        id: string
+        description: string
+        // Bucket key characteristics. Allowed entries: 'ip' | 'host' | 'asn' |
+        // 'country' | 'header:<name>' | 'cookie:<name>'. Defaults to ['ip'].
+        key: string[]
+        // Requests per window per key; must be > 0.
+        rate: number
+        // Go duration string, 1s..1h (e.g. '10s', '1m', '1h').
+        window: string
+        algorithm?: 'fixed' | 'sliding'
+        // shadow counts matches but never rejects (default enforce).
+        mode?: 'enforce' | 'shadow'
+        // 429 (default) or 503 only.
+        status?: number
+        message?: string
+        // CIDRs whose client IP skips this limit.
+        exclude?: string[]
+    }
+
     export type WafZone = {
         project: string
         location: string
         description: string
         rules: WafRule[]
+        limits: WafLimit[]
         status: 'pending' | 'success' | 'error'
         action: 'create' | 'delete'
         createdAt: string

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -502,8 +502,6 @@ declare namespace Api {
         // 429 (default) or 503 only.
         status?: number
         message?: string
-        // CIDRs whose client IP skips this limit.
-        exclude?: string[]
     }
 
     export type WafZone = {


### PR DESCRIPTION
## Summary
The WAF zone API now carries a rate-limit set next to the rules (deploys-app/api#39). This adds the console UI:

- **Manage page**: new "Rate limits" section — key / rate-per-window / mode (Enforce / muted Shadow badge) table with edit + delete, "Add Limit" footer.
- **New `/waf/limit` page** (add/edit): bucket-key builder (IP / Host / Country / ASN / Header / Cookie rows with name inputs), rate + window presets (1s..1h, non-preset loaded windows preserved), fixed/sliding algorithm, enforce/shadow mode, rejection response (429/503 + message, hidden in shadow mode).
- **Index page**: Limits count column.
- `waf.set` replaces the whole zone, so every call site (manage, rule edit, limit edit, create) now echoes both `rules` and `limits` — saving a rule can't wipe limits and vice versa.
- Mock fixtures gain two seed limits for offline dev/screenshots.

`bun lint` + `bun check`: 0 errors. Verified visually against `bun dev:mock` (manage, limit add/edit, index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
