### PR TITLE
Add the GitHub page: repo links + workflow generator

### DIFF
--- a/src/lib/nav.js
+++ b/src/lib/nav.js
@@ -28,5 +28,6 @@ export const projectMenu = [
 	{ id: 'service-account', title: 'Service Accounts', icon: 'fa-user-lock', link: '/service-account' },
 	{ id: 'dropbox', title: 'Dropbox', icon: 'fa-box-open', link: '/dropbox' },
 	{ id: 'registry', title: 'Registry', icon: 'fa-warehouse-full', link: '/registry' },
+	{ id: 'github', title: 'GitHub', icon: 'fa-code-branch', link: '/github', preview: true },
 	{ id: 'audit-log', title: 'Audit Logs', icon: 'fa-clipboard-list', link: '/audit-log' }
 ]

--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -538,6 +538,19 @@ const serviceAccounts = [
 	}
 ]
 
+// github repo links — mutated by github.link / github.unlink within a session.
+const githubLinks = [
+	{
+		repositoryId: 812345678,
+		repository: 'acme/web',
+		installationId: 77,
+		serviceAccount: 'sa_mock_ci',
+		serviceAccountEmail: 'ci@acme.deploys.app',
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL
+	}
+]
+
 // Synthesize enough rows to exercise the infinite-scroll cursor offline. The
 // real backend orders `id desc`; we mirror that here so the array is already in
 // the order the API would return.
@@ -993,6 +1006,40 @@ const handlers = {
 		{ email: 'teammate@acme.example.com', roles: ['viewer'] }
 	]),
 
+	'github.list': () => list([...githubLinks]),
+	'github.lookupRepo': (args) => {
+		const repository = args?.repository ?? ''
+		if (repository.startsWith('notinstalled/')) {
+			return err('api: github app is not installed on the repository')
+		}
+		return ok({
+			repositoryId: 700000 + repository.length,
+			repository,
+			installationId: 77
+		})
+	},
+	'github.link': (args) => {
+		if (githubLinks.some((l) => l.repositoryId === args?.repositoryId)) {
+			return err('api: github repository already linked')
+		}
+		const sa = serviceAccounts.find((s) => s.sid === args?.serviceAccount)
+		githubLinks.push({
+			repositoryId: args?.repositoryId,
+			repository: args?.repository,
+			installationId: args?.installationId ?? 0,
+			serviceAccount: args?.serviceAccount,
+			serviceAccountEmail: sa?.email ?? `${args?.serviceAccount}@acme.serviceaccount.deploys.app`,
+			createdAt: CREATED_AT,
+			createdBy: USER_EMAIL
+		})
+		return ok({})
+	},
+	'github.unlink': (args) => {
+		const i = githubLinks.findIndex((l) => l.repositoryId === args?.repositoryId)
+		if (i < 0) return err('api: github repository link not found')
+		githubLinks.splice(i, 1)
+		return ok({})
+	},
 	'serviceAccount.list': () => list(serviceAccounts),
 	'serviceAccount.get': (args) => ok({
 		...serviceAccounts[0],

--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -1006,6 +1006,15 @@ const handlers = {
 		{ email: 'teammate@acme.example.com', roles: ['viewer'] }
 	]),
 
+	'github.getApp': () => ok({ installUrl: 'https://github.com/apps/deploys-app/installations/new' }),
+	'github.listRepos': () => list([
+		{ repositoryId: 812345678, repository: 'acme/web', private: false },
+		{ repositoryId: 812345679, repository: 'acme/api', private: false },
+		{ repositoryId: 812345680, repository: 'acme/docs', private: false },
+		{ repositoryId: 812345681, repository: 'acme/mobile', private: true },
+		{ repositoryId: 812345682, repository: 'contoso/site', private: false },
+		{ repositoryId: 812345683, repository: 'contoso/backend', private: false }
+	]),
 	'github.list': () => list([...githubLinks]),
 	'github.lookupRepo': (args) => {
 		const repository = args?.repository ?? ''

--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -530,7 +530,7 @@ const permissions = [
 const serviceAccounts = [
 	{
 		sid: 'sa_mock_ci',
-		email: 'ci@acme.deploys.app',
+		email: 'ci@acme.serviceaccount.deploys.app',
 		name: 'CI Deployer',
 		description: 'Used by CI to deploy services',
 		createdAt: CREATED_AT,
@@ -545,7 +545,7 @@ const githubLinks = [
 		repository: 'acme/web',
 		installationId: 77,
 		serviceAccount: 'sa_mock_ci',
-		serviceAccountEmail: 'ci@acme.deploys.app',
+		serviceAccountEmail: 'ci@acme.serviceaccount.deploys.app',
 		createdAt: CREATED_AT,
 		createdBy: USER_EMAIL
 	}

--- a/src/routes/(auth)/(project)/github/+layout.js
+++ b/src/routes/(auth)/(project)/github/+layout.js
@@ -1,0 +1,6 @@
+export function load () {
+	return {
+		menu: 'github',
+		overrideRedirect: '/github'
+	}
+}

--- a/src/routes/(auth)/(project)/github/+page.js
+++ b/src/routes/(auth)/(project)/github/+page.js
@@ -1,0 +1,18 @@
+import api from '$lib/api'
+
+export async function load ({ parent, fetch }) {
+	const { project } = await parent()
+
+	const [links, serviceAccounts, locations] = await Promise.all([
+		api.invoke('github.list', { project }, fetch),
+		api.invoke('serviceAccount.list', { project }, fetch),
+		api.invoke('location.list', { project }, fetch)
+	])
+
+	return {
+		links: links.result?.items ?? [],
+		serviceAccounts: serviceAccounts.result?.items ?? [],
+		locations: locations.result?.items ?? [],
+		error: links.error
+	}
+}

--- a/src/routes/(auth)/(project)/github/+page.js
+++ b/src/routes/(auth)/(project)/github/+page.js
@@ -3,15 +3,13 @@ import api from '$lib/api'
 export async function load ({ parent, fetch }) {
 	const { project } = await parent()
 
-	const [links, serviceAccounts, locations] = await Promise.all([
+	const [links, locations] = await Promise.all([
 		api.invoke('github.list', { project }, fetch),
-		api.invoke('serviceAccount.list', { project }, fetch),
 		api.invoke('location.list', { project }, fetch)
 	])
 
 	return {
 		links: links.result?.items ?? [],
-		serviceAccounts: serviceAccounts.result?.items ?? [],
 		locations: locations.result?.items ?? [],
 		error: links.error
 	}

--- a/src/routes/(auth)/(project)/github/+page.svelte
+++ b/src/routes/(auth)/(project)/github/+page.svelte
@@ -1,0 +1,284 @@
+<script>
+	import { onMount, untrack } from 'svelte'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
+	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import * as format from '$lib/format'
+	import { setupCopy } from '$lib/clipboard'
+
+	const { data } = $props()
+
+	const project = $derived(data.project)
+	const serviceAccounts = $derived(data.serviceAccounts)
+	const locations = $derived(data.locations)
+	const error = $derived(data.error)
+
+	let links = $state(untrack(() => data.links))
+
+	const serviceAccountOptions = $derived(serviceAccounts.map((sa) => ({
+		value: sa.sid,
+		label: `${sa.sid} — ${sa.name}`
+	})))
+	const locationOptions = $derived(locations.map((l) => ({ value: l.id, label: l.id })))
+
+	// link form
+	const linkDraft = $state({ repository: '', serviceAccount: '' })
+	let linking = $state(false)
+	const canLink = $derived(/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(linkDraft.repository.trim()) && !!linkDraft.serviceAccount)
+
+	async function reloadLinks () {
+		const resp = await api.invoke('github.list', { project }, fetch)
+		if (resp.ok) links = resp.result?.items ?? []
+	}
+
+	/** @param {Event} e */
+	async function link (e) {
+		e.preventDefault()
+		if (linking || !canLink) return
+
+		linking = true
+		try {
+			// Resolve owner/name to the immutable repository id through the
+			// GitHub App — this also verifies the App is installed on the repo.
+			const lookup = await api.invoke('github.lookupRepo', {
+				project,
+				repository: linkDraft.repository.trim()
+			}, fetch)
+			if (!lookup.ok) {
+				modal.error({ error: lookup.error })
+				return
+			}
+
+			const resp = await api.invoke('github.link', {
+				project,
+				repositoryId: lookup.result.repositoryId,
+				repository: lookup.result.repository,
+				installationId: lookup.result.installationId,
+				serviceAccount: linkDraft.serviceAccount
+			}, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+
+			linkDraft.repository = ''
+			await reloadLinks()
+		} finally {
+			linking = false
+		}
+	}
+
+	/** @param {Api.GithubLink} it */
+	function unlink (it) {
+		modal.confirm({
+			title: `Unlink ${it.repository}? Workflows from this repository will no longer be able to deploy. Existing deployments are not affected.`,
+			yes: 'Unlink',
+			async callback () {
+				const resp = await api.invoke('github.unlink', {
+					project,
+					repositoryId: it.repositoryId
+				}, fetch)
+				if (!resp.ok) {
+					modal.error({ error: resp.error })
+					return
+				}
+				await reloadLinks()
+			}
+		})
+	}
+
+	// workflow generator
+	const gen = $state(untrack(() => ({
+		repository: data.links[0]?.repository ?? '',
+		location: data.locations[0]?.id ?? '',
+		name: 'web',
+		port: 8080
+	})))
+	const genRepoOptions = $derived(links.map((l) => ({ value: l.repository, label: l.repository })))
+
+	const workflowYaml = $derived(`name: Deploy
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  id-token: write   # required — this is the credential
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: deploys-app/build-deploy-action@v1
+      with:
+        project: ${project}
+        location: ${gen.location}
+        name: ${gen.name || 'web'}
+        port: ${Number(gen.port) || 8080}
+`)
+
+	const createOnGitHubURL = $derived(gen.repository
+		? `https://github.com/${gen.repository}/new/main?filename=.github/workflows/deploy.yml&value=${encodeURIComponent(workflowYaml)}`
+		: '')
+
+	onMount(() => setupCopy('.copy-workflow'))
+</script>
+
+<div class="page-head">
+	<div>
+		<h4><strong>GitHub</strong></h4>
+		<p class="page-sub">Build and deploy linked repositories with GitHub Actions — keyless, with pull request previews</p>
+	</div>
+</div>
+
+<div class="panel is-level-300 grid gap-6">
+	<div>
+		<h6><strong>Linked repositories</strong></h6>
+		<p class="text-content/50 text-sm mt-1">
+			Workflows in a linked repository can deploy to this project as the
+			linked service account — authenticated by GitHub OIDC, no stored secrets.
+		</p>
+	</div>
+
+	<div class="table-container">
+		<table class="table is-variant-compact">
+			<thead>
+			<tr>
+				<th>Repository</th>
+				<th>Service Account</th>
+				<th>Linked</th>
+				<th class="is-collapse is-align-right"></th>
+			</tr>
+			</thead>
+			<tbody>
+				{#each links as it (it.repositoryId)}
+					<tr>
+						<td>
+							<a class="link cell-name" href={`https://github.com/${it.repository}`} target="_blank" rel="noreferrer">
+								<i class="fa-brands fa-github mr-1"></i>{it.repository}
+							</a>
+						</td>
+						<td><span class="cell-muted font-mono text-sm">{it.serviceAccountEmail}</span></td>
+						<td>
+							<span class="cell-time" title={format.datetime(it.createdAt)}>{format.fromNow(it.createdAt) || '—'}</span>
+						</td>
+						<td>
+							<button class="icon-button" type="button" aria-label="Unlink repository" onclick={() => unlink(it)}>
+								<i class="fa-solid fa-link-slash"></i>
+							</button>
+						</td>
+					</tr>
+				{/each}
+				<NoDataRow span={4} list={links} />
+				<ErrorRow span={4} {error} />
+			</tbody>
+		</table>
+	</div>
+
+	<hr>
+
+	<form class="grid gap-4" onsubmit={link}>
+		<div>
+			<h6><strong>Link a repository</strong></h6>
+			<p class="text-content/50 text-sm mt-1">
+				Install the deploys.app GitHub App on the repository first — linking
+				verifies the installation. The service account needs
+				<span class="font-mono">deployment.deploy</span>,
+				<span class="font-mono">deployment.get</span>,
+				<span class="font-mono">deployment.delete</span> and
+				<span class="font-mono">registry.push</span>.
+			</p>
+		</div>
+		<div class="grid gap-4 sm:grid-cols-2">
+			<div class="field">
+				<label for="github-repository">Repository</label>
+				<div class="input">
+					<input id="github-repository" class="font-mono" bind:value={linkDraft.repository} placeholder="owner/name">
+				</div>
+			</div>
+			<div class="field">
+				<label for="github-service-account">Service account</label>
+				<Select id="github-service-account" bind:value={linkDraft.serviceAccount}
+					options={serviceAccountOptions} placeholder="Select a service account" />
+			</div>
+		</div>
+		<div class="flex items-center gap-3">
+			<button class="button" class:is-loading={linking} disabled={linking || !canLink}>Link</button>
+			{#if serviceAccounts.length === 0}
+				<p class="text-content/50 text-sm">
+					No service accounts yet — <a class="link" href={`/service-account/create?project=${project}`}>create one</a> first.
+				</p>
+			{/if}
+		</div>
+	</form>
+</div>
+
+{#if links.length > 0}
+	<br>
+	<div class="panel is-level-300 grid gap-6">
+		<div>
+			<h6><strong>Workflow</strong></h6>
+			<p class="text-content/50 text-sm mt-1">
+				Add this file as <span class="font-mono">.github/workflows/deploy.yml</span>
+				to deploy on push and get pull request previews.
+			</p>
+		</div>
+
+		<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+			<div class="field">
+				<label for="gen-repository">Repository</label>
+				<Select id="gen-repository" bind:value={gen.repository} options={genRepoOptions} />
+			</div>
+			<div class="field">
+				<label for="gen-location">Location</label>
+				<Select id="gen-location" bind:value={gen.location} options={locationOptions} />
+			</div>
+			<div class="field">
+				<label for="gen-name">Deployment name</label>
+				<div class="input">
+					<input id="gen-name" class="font-mono" bind:value={gen.name} placeholder="web">
+				</div>
+			</div>
+			<div class="field">
+				<label for="gen-port">Port</label>
+				<div class="input">
+					<input id="gen-port" type="number" min="1" bind:value={gen.port} placeholder="8080">
+				</div>
+			</div>
+		</div>
+
+		<pre class="workflow-yaml font-mono text-sm">{workflowYaml}</pre>
+
+		<div class="flex items-center gap-3">
+			<button type="button" class="button is-variant-secondary copy-workflow" data-clipboard-text={workflowYaml}>
+				<i class="fa-solid fa-copy mr-2"></i>
+				<span>Copy</span>
+			</button>
+			<a class="button" href={createOnGitHubURL} target="_blank" rel="noreferrer">
+				<i class="fa-brands fa-github mr-2"></i>
+				<span>Create on GitHub</span>
+			</a>
+			<p class="text-content/50 text-sm">
+				Opens GitHub's file editor pre-filled — commit it there.
+			</p>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.workflow-yaml {
+		padding: 1rem;
+		border-radius: var(--radius-md);
+		border: 1px solid hsl(var(--hsl-line));
+		background-color: hsl(var(--hsl-base-400) / 0.12);
+		overflow-x: auto;
+	}
+
+	:root:not(.dark) .workflow-yaml {
+		background-color: hsl(var(--hsl-base-100) / 0.6);
+	}
+</style>

--- a/src/routes/(auth)/(project)/github/+page.svelte
+++ b/src/routes/(auth)/(project)/github/+page.svelte
@@ -11,63 +11,16 @@
 	const { data } = $props()
 
 	const project = $derived(data.project)
-	const serviceAccounts = $derived(data.serviceAccounts)
 	const locations = $derived(data.locations)
 	const error = $derived(data.error)
 
 	let links = $state(untrack(() => data.links))
 
-	const serviceAccountOptions = $derived(serviceAccounts.map((sa) => ({
-		value: sa.sid,
-		label: `${sa.sid} — ${sa.name}`
-	})))
 	const locationOptions = $derived(locations.map((l) => ({ value: l.id, label: l.id })))
-
-	// link form
-	const linkDraft = $state({ repository: '', serviceAccount: '' })
-	let linking = $state(false)
-	const canLink = $derived(/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(linkDraft.repository.trim()) && !!linkDraft.serviceAccount)
 
 	async function reloadLinks () {
 		const resp = await api.invoke('github.list', { project }, fetch)
 		if (resp.ok) links = resp.result?.items ?? []
-	}
-
-	/** @param {Event} e */
-	async function link (e) {
-		e.preventDefault()
-		if (linking || !canLink) return
-
-		linking = true
-		try {
-			// Resolve owner/name to the immutable repository id through the
-			// GitHub App — this also verifies the App is installed on the repo.
-			const lookup = await api.invoke('github.lookupRepo', {
-				project,
-				repository: linkDraft.repository.trim()
-			}, fetch)
-			if (!lookup.ok) {
-				modal.error({ error: lookup.error })
-				return
-			}
-
-			const resp = await api.invoke('github.link', {
-				project,
-				repositoryId: lookup.result.repositoryId,
-				repository: lookup.result.repository,
-				installationId: lookup.result.installationId,
-				serviceAccount: linkDraft.serviceAccount
-			}, fetch)
-			if (!resp.ok) {
-				modal.error({ error: resp.error })
-				return
-			}
-
-			linkDraft.repository = ''
-			await reloadLinks()
-		} finally {
-			linking = false
-		}
 	}
 
 	/** @param {Api.GithubLink} it */
@@ -133,6 +86,12 @@ jobs:
 		<h4><strong>GitHub</strong></h4>
 		<p class="page-sub">Build and deploy linked repositories with GitHub Actions — keyless, with pull request previews</p>
 	</div>
+	<div>
+		<a class="button" href={`/github/link?project=${project}`}>
+			<i class="fa-solid fa-link mr-2"></i>
+			Link repository
+		</a>
+	</div>
 </div>
 
 <div class="panel is-level-300 grid gap-6">
@@ -178,43 +137,6 @@ jobs:
 			</tbody>
 		</table>
 	</div>
-
-	<hr>
-
-	<form class="grid gap-4" onsubmit={link}>
-		<div>
-			<h6><strong>Link a repository</strong></h6>
-			<p class="text-content/50 text-sm mt-1">
-				Install the deploys.app GitHub App on the repository first — linking
-				verifies the installation. The service account needs
-				<span class="font-mono">deployment.deploy</span>,
-				<span class="font-mono">deployment.get</span>,
-				<span class="font-mono">deployment.delete</span> and
-				<span class="font-mono">registry.push</span>.
-			</p>
-		</div>
-		<div class="grid gap-4 sm:grid-cols-2">
-			<div class="field">
-				<label for="github-repository">Repository</label>
-				<div class="input">
-					<input id="github-repository" class="font-mono" bind:value={linkDraft.repository} placeholder="owner/name">
-				</div>
-			</div>
-			<div class="field">
-				<label for="github-service-account">Service account</label>
-				<Select id="github-service-account" bind:value={linkDraft.serviceAccount}
-					options={serviceAccountOptions} placeholder="Select a service account" />
-			</div>
-		</div>
-		<div class="flex items-center gap-3">
-			<button class="button" class:is-loading={linking} disabled={linking || !canLink}>Link</button>
-			{#if serviceAccounts.length === 0}
-				<p class="text-content/50 text-sm">
-					No service accounts yet — <a class="link" href={`/service-account/create?project=${project}`}>create one</a> first.
-				</p>
-			{/if}
-		</div>
-	</form>
 </div>
 
 {#if links.length > 0}

--- a/src/routes/(auth)/(project)/github/link/+page.js
+++ b/src/routes/(auth)/(project)/github/link/+page.js
@@ -18,17 +18,24 @@ export async function load ({ parent, url, fetch }) {
 	const installationIds = new Set()
 	const linkItems = links.result?.items ?? []
 	for (const l of linkItems) {
-		if (l.installationId) installationIds.add(l.installationId)
+		const id = l.installationId
+		if (Number.isInteger(id) && id > 0) installationIds.add(id)
 	}
-	if (urlInstallationId) installationIds.add(urlInstallationId)
+	if (urlInstallationId !== null && Number.isInteger(urlInstallationId) && urlInstallationId > 0) installationIds.add(urlInstallationId)
 
 	// Fetch repos for each installation id in parallel
 	/** @type {Map<number, Api.GithubRepoItem>} */
 	const repoMap = new Map()
+	/** @type {Api.Error | undefined} */
+	let repoError
 
 	await Promise.all(
 		[...installationIds].map(async (installationId) => {
 			const resp = await api.invoke('github.listRepos', { project, installationId }, fetch)
+			if (!resp.ok) {
+				repoError = resp.error
+				return
+			}
 			for (const item of resp.result?.items ?? []) {
 				if (!repoMap.has(item.repositoryId)) {
 					repoMap.set(item.repositoryId, { ...item, installationId })
@@ -51,6 +58,7 @@ export async function load ({ parent, url, fetch }) {
 		serviceAccounts: serviceAccounts.result?.items ?? [],
 		installUrl: appInfo.result?.installUrl ?? '',
 		linkedRepoIds: [...linkedRepoIds],
-		error
+		error,
+		repoError
 	}
 }

--- a/src/routes/(auth)/(project)/github/link/+page.js
+++ b/src/routes/(auth)/(project)/github/link/+page.js
@@ -1,0 +1,56 @@
+import api from '$lib/api'
+
+export async function load ({ parent, url, fetch }) {
+	const { project } = await parent()
+
+	const urlInstallationId = url.searchParams.get('installation_id')
+		? Number(url.searchParams.get('installation_id'))
+		: null
+
+	const [links, serviceAccounts, appInfo] = await Promise.all([
+		api.invoke('github.list', { project }, fetch),
+		api.invoke('serviceAccount.list', { project }, fetch),
+		api.invoke('github.getApp', { project }, fetch)
+	])
+
+	// Collect unique installation ids from existing links + url param
+	/** @type {Set<number>} */
+	const installationIds = new Set()
+	const linkItems = links.result?.items ?? []
+	for (const l of linkItems) {
+		if (l.installationId) installationIds.add(l.installationId)
+	}
+	if (urlInstallationId) installationIds.add(urlInstallationId)
+
+	// Fetch repos for each installation id in parallel
+	/** @type {Map<number, Api.GithubRepoItem>} */
+	const repoMap = new Map()
+
+	await Promise.all(
+		[...installationIds].map(async (installationId) => {
+			const resp = await api.invoke('github.listRepos', { project, installationId }, fetch)
+			for (const item of resp.result?.items ?? []) {
+				if (!repoMap.has(item.repositoryId)) {
+					repoMap.set(item.repositoryId, { ...item, installationId })
+				}
+			}
+		})
+	)
+
+	// Sort by repository name
+	const repos = [...repoMap.values()].sort((a, b) => a.repository.localeCompare(b.repository))
+
+	// Set of already-linked repository ids
+	const linkedRepoIds = new Set(linkItems.map((l) => l.repositoryId))
+
+	/** @type {Api.Error | undefined} */
+	const error = links.error ?? serviceAccounts.error ?? appInfo.error
+
+	return {
+		repos,
+		serviceAccounts: serviceAccounts.result?.items ?? [],
+		installUrl: appInfo.result?.installUrl ?? '',
+		linkedRepoIds: [...linkedRepoIds],
+		error
+	}
+}

--- a/src/routes/(auth)/(project)/github/link/+page.svelte
+++ b/src/routes/(auth)/(project)/github/link/+page.svelte
@@ -1,0 +1,166 @@
+<script>
+	import { goto } from '$app/navigation'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
+
+	const { data } = $props()
+
+	const project = $derived(data.project)
+	const repos = $derived(data.repos)
+	const serviceAccounts = $derived(data.serviceAccounts)
+	const installUrl = $derived(data.installUrl)
+	const linkedRepoIds = $derived(new Set(data.linkedRepoIds))
+
+	// Repos not yet linked
+	const availableRepos = $derived(repos.filter((r) => !linkedRepoIds.has(r.repositoryId)))
+	const hiddenCount = $derived(repos.length - availableRepos.length)
+
+	const repoOptions = $derived(availableRepos.map((r) => ({
+		value: r.repositoryId,
+		label: r.private ? `${r.repository} — private` : r.repository
+	})))
+
+	const serviceAccountOptions = $derived(serviceAccounts.map((sa) => ({
+		value: sa.sid,
+		label: `${sa.sid} — ${sa.name}`
+	})))
+
+	/** @type {number | ''} */
+	let selectedRepoId = $state('')
+	let selectedServiceAccount = $state('')
+	let linking = $state(false)
+
+	const selectedRepo = $derived(
+		selectedRepoId !== '' ? repos.find((r) => r.repositoryId === selectedRepoId) : undefined
+	)
+	const canLink = $derived(selectedRepoId !== '' && !!selectedServiceAccount)
+
+	const installHref = $derived(
+		installUrl + (project ? `?state=${encodeURIComponent(project)}` : '')
+	)
+
+	async function link () {
+		if (linking || !canLink || !selectedRepo) return
+
+		linking = true
+		try {
+			const resp = await api.invoke('github.link', {
+				project,
+				repositoryId: selectedRepo.repositoryId,
+				repository: selectedRepo.repository,
+				installationId: selectedRepo.installationId,
+				serviceAccount: selectedServiceAccount
+			}, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+			goto(`/github?project=${project}`)
+		} finally {
+			linking = false
+		}
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/github?project=${project}`} class="link"><h6>GitHub</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<h6>Link repository</h6>
+	</div>
+</div>
+
+<br>
+
+<div class="page-head">
+	<div>
+		<h4><strong>Link a GitHub repository</strong></h4>
+		<p class="page-sub">Connect a repository so its GitHub Actions workflows can deploy to this project.</p>
+	</div>
+</div>
+
+<div class="panel is-level-300 grid gap-6">
+	<div>
+		<h6><strong>Step 1 — Install the GitHub App</strong></h6>
+		<p class="text-content/50 text-sm mt-1">
+			Grant the deploys.app GitHub App access to the repositories you want to link.
+			Already installed? Use the same link to add more repositories.
+		</p>
+	</div>
+	<div>
+		{#if installUrl}
+			<a class="button is-variant-secondary" href={installHref}>
+				<i class="fa-brands fa-github mr-2"></i>
+				Install GitHub App
+			</a>
+		{:else}
+			<p class="text-content/50 text-sm">
+				The GitHub App is not available right now{data.error ? ` — ${data.error.message}` : ''}. Try again later.
+			</p>
+		{/if}
+	</div>
+</div>
+
+<br>
+
+<div class="panel is-level-300 grid gap-6">
+	<div>
+		<h6><strong>Step 2 — Pick a repository</strong></h6>
+		<p class="text-content/50 text-sm mt-1">
+			{#if repos.length === 0}
+				No repositories found. Complete step 1 to grant access — GitHub will redirect back here automatically.
+			{:else}
+				Select a repository from those visible to the installed GitHub App.
+				{#if hiddenCount > 0}
+					<span class="text-content/40">{hiddenCount} {hiddenCount === 1 ? 'repository is' : 'repositories are'} already linked and hidden.</span>
+				{/if}
+			{/if}
+		</p>
+		<p class="text-content/50 text-sm mt-1">
+			Workflows deploy as the linked service account — it needs
+			<span class="font-mono">deployment.deploy</span>,
+			<span class="font-mono">deployment.get</span>,
+			<span class="font-mono">deployment.delete</span> and
+			<span class="font-mono">registry.push</span>.
+		</p>
+	</div>
+
+	<div class="grid gap-4 sm:grid-cols-2">
+		<div class="field">
+			<label for="link-repository">Repository</label>
+			<Select
+				id="link-repository"
+				bind:value={selectedRepoId}
+				options={repoOptions}
+				placeholder="Search repositories…"
+				editable={true}
+				disabled={repoOptions.length === 0} />
+		</div>
+		<div class="field">
+			<label for="link-service-account">Service account</label>
+			<Select
+				id="link-service-account"
+				bind:value={selectedServiceAccount}
+				options={serviceAccountOptions}
+				placeholder="Select a service account" />
+		</div>
+	</div>
+
+	<div class="flex items-center gap-3">
+		<button
+			class="button"
+			class:is-loading={linking}
+			disabled={linking || !canLink}
+			onclick={link}
+			type="button">
+			Link
+		</button>
+		{#if serviceAccounts.length === 0}
+			<p class="text-content/50 text-sm">
+				No service accounts yet — <a class="link" href={`/service-account/create?project=${project}`}>create one</a> first.
+			</p>
+		{/if}
+	</div>
+</div>

--- a/src/routes/(auth)/(project)/github/link/+page.svelte
+++ b/src/routes/(auth)/(project)/github/link/+page.svelte
@@ -10,6 +10,7 @@
 	const repos = $derived(data.repos)
 	const serviceAccounts = $derived(data.serviceAccounts)
 	const installUrl = $derived(data.installUrl)
+	const repoError = $derived(data.repoError)
 	const linkedRepoIds = $derived(new Set(data.linkedRepoIds))
 
 	// Repos not yet linked
@@ -17,8 +18,8 @@
 	const hiddenCount = $derived(repos.length - availableRepos.length)
 
 	const repoOptions = $derived(availableRepos.map((r) => ({
-		value: r.repositoryId,
-		label: r.private ? `${r.repository} — private` : r.repository
+		value: r.repository,
+		label: r.repository
 	})))
 
 	const serviceAccountOptions = $derived(serviceAccounts.map((sa) => ({
@@ -26,15 +27,14 @@
 		label: `${sa.sid} — ${sa.name}`
 	})))
 
-	/** @type {number | ''} */
-	let selectedRepoId = $state('')
+	let selectedRepoName = $state('')
 	let selectedServiceAccount = $state('')
 	let linking = $state(false)
 
 	const selectedRepo = $derived(
-		selectedRepoId !== '' ? repos.find((r) => r.repositoryId === selectedRepoId) : undefined
+		selectedRepoName !== '' ? repos.find((r) => r.repository === selectedRepoName) : undefined
 	)
-	const canLink = $derived(selectedRepoId !== '' && !!selectedServiceAccount)
+	const canLink = $derived(!!selectedRepo && !!selectedServiceAccount)
 
 	const installHref = $derived(
 		installUrl + (project ? `?state=${encodeURIComponent(project)}` : '')
@@ -108,10 +108,13 @@
 <div class="panel is-level-300 grid gap-6">
 	<div>
 		<h6><strong>Step 2 — Pick a repository</strong></h6>
+		{#if repoError}
+			<p class="text-negative text-sm mt-1">Couldn't load repositories: {repoError.message}</p>
+		{/if}
 		<p class="text-content/50 text-sm mt-1">
-			{#if repos.length === 0}
+			{#if repos.length === 0 && !repoError}
 				No repositories found. Complete step 1 to grant access — GitHub will redirect back here automatically.
-			{:else}
+			{:else if repos.length > 0}
 				Select a repository from those visible to the installed GitHub App.
 				{#if hiddenCount > 0}
 					<span class="text-content/40">{hiddenCount} {hiddenCount === 1 ? 'repository is' : 'repositories are'} already linked and hidden.</span>
@@ -132,7 +135,7 @@
 			<label for="link-repository">Repository</label>
 			<Select
 				id="link-repository"
-				bind:value={selectedRepoId}
+				bind:value={selectedRepoName}
 				options={repoOptions}
 				placeholder="Search repositories…"
 				editable={true}

--- a/src/routes/(auth)/github-setup/+page.js
+++ b/src/routes/(auth)/github-setup/+page.js
@@ -1,0 +1,26 @@
+import { redirect } from '@sveltejs/kit'
+
+// GitHub's App "Setup URL" redirects here after installation.
+// GitHub appends ?installation_id=N&setup_action=install and optionally ?state=<project>
+// (we pass the project as state in the install link on the link page).
+//
+// This route lives OUTSIDE the (project) group because GitHub's redirect has no
+// ?project= param. The (project)+layout.js redirects to /project when there is
+// no ?project= param, so we route to /github/link without a project and let the
+// (project) layout handle picking one.
+
+export function load ({ url }) {
+	const installationId = url.searchParams.get('installation_id')
+	const state = url.searchParams.get('state')
+
+	if (state && installationId) {
+		redirect(302, `/github/link?project=${encodeURIComponent(state)}&installation_id=${installationId}`)
+	}
+
+	if (installationId) {
+		// No project state — the (project) layout will redirect the user to pick a project.
+		redirect(302, `/github/link?installation_id=${installationId}`)
+	}
+
+	redirect(302, '/github')
+}

--- a/src/routes/(auth)/github-setup/+page.svelte
+++ b/src/routes/(auth)/github-setup/+page.svelte
@@ -1,0 +1,1 @@
+<!-- This page always redirects in +page.js — nothing to render. -->

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -349,6 +349,24 @@ declare namespace Api {
         createdBy: string
     }
 
+    export type GithubLink = {
+        repositoryId: number
+        // owner/name
+        repository: string
+        installationId: number
+        // service account sid
+        serviceAccount: string
+        serviceAccountEmail: string
+        createdAt: string
+        createdBy: string
+    }
+
+    export type GithubLookupRepoResult = {
+        repositoryId: number
+        repository: string
+        installationId: number
+    }
+
     export type EmailDomain = {
         domain: string
         createdAt: string

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -367,6 +367,19 @@ declare namespace Api {
         installationId: number
     }
 
+    export type GithubAppInfo = {
+        installUrl: string
+    }
+
+    export type GithubRepoItem = {
+        repositoryId: number
+        // owner/name
+        repository: string
+        private: boolean
+        // installation id this repo belongs to
+        installationId: number
+    }
+
     export type EmailDomain = {
         domain: string
         createdAt: string

--- a/tests/github.spec.js
+++ b/tests/github.spec.js
@@ -194,6 +194,38 @@ test.describe('github link page', () => {
 		const webOption = page.getByRole('option', { name: /acme\/web/ })
 		await expect(webOption).toHaveCount(0)
 	})
+
+	test('after selecting a repo the input shows the repo name and dropdown still lists options on reopen', async ({ page }) => {
+		// Keep the default mocks (link has installationId 77 → listRepos is called)
+		await mocks()
+
+		await page.goto('/github/link?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		const repoSelect = main.locator('#link-repository')
+		await repoSelect.click()
+		await repoSelect.fill('acme/api')
+		await page.getByRole('option', { name: 'acme/api' }).click()
+
+		// Input must display the full name, not a numeric id
+		await expect(repoSelect).toHaveValue('acme/api')
+
+		// Reopen the dropdown — options must still appear (regression for numeric-value bug)
+		await repoSelect.click()
+		await expect(page.getByRole('option', { name: 'acme/api' })).toBeVisible()
+	})
+
+	test('shows inline warning when github.listRepos fails and hides complete-step-1 copy', async ({ page }) => {
+		await mocks({
+			'github.listRepos': { ok: false, error: { message: 'boom' } }
+		})
+
+		await page.goto('/github/link?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		await expect(main.getByText(/Couldn't load repositories: boom/)).toBeVisible()
+		await expect(main.getByText(/Complete step 1 to grant access/)).toHaveCount(0)
+	})
 })
 
 test.describe('github-setup redirect', () => {

--- a/tests/github.spec.js
+++ b/tests/github.spec.js
@@ -1,0 +1,137 @@
+import { test, expect, setMocks, getRequestLog } from './helpers.js'
+
+const link = {
+	repositoryId: 812345678,
+	repository: 'acme/web',
+	installationId: 77,
+	serviceAccount: 'ci',
+	serviceAccountEmail: 'ci@test-project.serviceaccount.deploys.app',
+	createdAt: '2026-01-01T00:00:00Z',
+	createdBy: 'dev@deploys.app'
+}
+
+const serviceAccount = {
+	sid: 'ci',
+	email: 'ci@test-project.serviceaccount.deploys.app',
+	name: 'CI Deployer',
+	description: '',
+	createdAt: '2026-01-01T00:00:00Z',
+	createdBy: 'dev@deploys.app'
+}
+
+const location = { id: 'gke' }
+
+function mocks (overrides = {}) {
+	return setMocks({
+		'github.list': { ok: true, result: { items: [link] } },
+		'serviceAccount.list': { ok: true, result: { items: [serviceAccount] } },
+		'location.list': { ok: true, result: { items: [location] } },
+		...overrides
+	})
+}
+
+test.describe('github', () => {
+	test('lists linked repositories and renders the workflow generator', async ({ page }) => {
+		await mocks()
+
+		await page.goto('/github?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'GitHub' })).toBeVisible()
+		await expect(main.getByRole('link', { name: /acme\/web/ })).toBeVisible()
+		await expect(main.getByText(link.serviceAccountEmail)).toBeVisible()
+
+		// The generated workflow carries the project and the action pin.
+		const yaml = main.locator('.workflow-yaml')
+		await expect(yaml).toContainText('uses: deploys-app/build-deploy-action@v1')
+		await expect(yaml).toContainText('project: test-project')
+		await expect(yaml).toContainText('location: gke')
+
+		// Editing the generator inputs updates the yaml.
+		await main.locator('#gen-name').fill('api')
+		await expect(yaml).toContainText('name: api')
+
+		// Create-on-GitHub deep-link targets the linked repo's file editor.
+		const href = await main.getByRole('link', { name: 'Create on GitHub' }).getAttribute('href')
+		expect(href).toContain('https://github.com/acme/web/new/main?filename=.github/workflows/deploy.yml&value=')
+		expect(decodeURIComponent(href ?? '')).toContain('name: api')
+	})
+
+	test('empty state hides the workflow generator', async ({ page }) => {
+		await mocks({ 'github.list': { ok: true, result: { items: [] } } })
+
+		await page.goto('/github?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('Nothing here yet')).toBeVisible()
+		await expect(main.locator('.workflow-yaml')).toHaveCount(0)
+	})
+
+	test('links a repository via lookupRepo', async ({ page }) => {
+		await mocks({
+			'github.list': { ok: true, result: { items: [] } },
+			'github.lookupRepo': {
+				ok: true,
+				result: { repositoryId: 900001, repository: 'acme/api', installationId: 77 }
+			},
+			'github.link': { ok: true, result: {} }
+		})
+
+		await page.goto('/github?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		await main.locator('#github-repository').fill('acme/api')
+		await main.locator('#github-service-account').click()
+		await page.getByRole('option', { name: /ci — CI Deployer/ }).click()
+		await main.getByRole('button', { name: 'Link', exact: true }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/github.link')
+		}).toBe(true)
+
+		const log = await getRequestLog()
+		const lookup = JSON.parse(log.find((r) => r.path === '/github.lookupRepo')?.body ?? '{}')
+		expect(lookup.repository).toBe('acme/api')
+		const linkReq = JSON.parse(log.find((r) => r.path === '/github.link')?.body ?? '{}')
+		expect(linkReq.repositoryId).toBe(900001)
+		expect(linkReq.installationId).toBe(77)
+		expect(linkReq.serviceAccount).toBe('ci')
+	})
+
+	test('surfaces app-not-installed from lookup', async ({ page }) => {
+		await mocks({
+			'github.lookupRepo': {
+				ok: false,
+				error: { message: 'api: github app is not installed on the repository' }
+			}
+		})
+
+		await page.goto('/github?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		await main.locator('#github-repository').fill('acme/private')
+		await main.locator('#github-service-account').click()
+		await page.getByRole('option', { name: /ci — CI Deployer/ }).click()
+		await main.getByRole('button', { name: 'Link', exact: true }).click()
+
+		await expect(page.getByText('github app is not installed')).toBeVisible()
+	})
+
+	test('unlinks after confirmation', async ({ page }) => {
+		await mocks({ 'github.unlink': { ok: true, result: {} } })
+
+		await page.goto('/github?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		await main.getByRole('button', { name: 'Unlink repository' }).click()
+		await page.getByRole('button', { name: 'Unlink', exact: true }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/github.unlink')
+		}).toBe(true)
+
+		const req = JSON.parse((await getRequestLog()).find((r) => r.path === '/github.unlink')?.body ?? '{}')
+		expect(req.repositoryId).toBe(link.repositoryId)
+	})
+})

--- a/tests/github.spec.js
+++ b/tests/github.spec.js
@@ -21,9 +21,19 @@ const serviceAccount = {
 
 const location = { id: 'gke' }
 
+const appInfo = { installUrl: 'https://github.com/apps/deploys-app/installations/new' }
+
+const repos = [
+	{ repositoryId: 812345678, repository: 'acme/web', private: false },
+	{ repositoryId: 812345679, repository: 'acme/api', private: false },
+	{ repositoryId: 812345681, repository: 'acme/mobile', private: true }
+]
+
 function mocks (overrides = {}) {
 	return setMocks({
 		'github.list': { ok: true, result: { items: [link] } },
+		'github.getApp': { ok: true, result: appInfo },
+		'github.listRepos': { ok: true, result: { items: repos } },
 		'serviceAccount.list': { ok: true, result: { items: [serviceAccount] } },
 		'location.list': { ok: true, result: { items: [location] } },
 		...overrides
@@ -66,55 +76,16 @@ test.describe('github', () => {
 		await expect(main.locator('.workflow-yaml')).toHaveCount(0)
 	})
 
-	test('links a repository via lookupRepo', async ({ page }) => {
-		await mocks({
-			'github.list': { ok: true, result: { items: [] } },
-			'github.lookupRepo': {
-				ok: true,
-				result: { repositoryId: 900001, repository: 'acme/api', installationId: 77 }
-			},
-			'github.link': { ok: true, result: {} }
-		})
+	test('shows a "Link repository" button pointing at /github/link', async ({ page }) => {
+		await mocks()
 
 		await page.goto('/github?project=test-project')
 		const main = page.locator('.content-wrapper')
 
-		await main.locator('#github-repository').fill('acme/api')
-		await main.locator('#github-service-account').click()
-		await page.getByRole('option', { name: /ci — CI Deployer/ }).click()
-		await main.getByRole('button', { name: 'Link', exact: true }).click()
-
-		await expect.poll(async () => {
-			const log = await getRequestLog()
-			return log.some((r) => r.path === '/github.link')
-		}).toBe(true)
-
-		const log = await getRequestLog()
-		const lookup = JSON.parse(log.find((r) => r.path === '/github.lookupRepo')?.body ?? '{}')
-		expect(lookup.repository).toBe('acme/api')
-		const linkReq = JSON.parse(log.find((r) => r.path === '/github.link')?.body ?? '{}')
-		expect(linkReq.repositoryId).toBe(900001)
-		expect(linkReq.installationId).toBe(77)
-		expect(linkReq.serviceAccount).toBe('ci')
-	})
-
-	test('surfaces app-not-installed from lookup', async ({ page }) => {
-		await mocks({
-			'github.lookupRepo': {
-				ok: false,
-				error: { message: 'api: github app is not installed on the repository' }
-			}
-		})
-
-		await page.goto('/github?project=test-project')
-		const main = page.locator('.content-wrapper')
-
-		await main.locator('#github-repository').fill('acme/private')
-		await main.locator('#github-service-account').click()
-		await page.getByRole('option', { name: /ci — CI Deployer/ }).click()
-		await main.getByRole('button', { name: 'Link', exact: true }).click()
-
-		await expect(page.getByText('github app is not installed')).toBeVisible()
+		const linkBtn = main.getByRole('link', { name: /Link repository/ })
+		await expect(linkBtn).toBeVisible()
+		const href = await linkBtn.getAttribute('href')
+		expect(href).toBe('/github/link?project=test-project')
 	})
 
 	test('unlinks after confirmation', async ({ page }) => {
@@ -133,5 +104,125 @@ test.describe('github', () => {
 
 		const req = JSON.parse((await getRequestLog()).find((r) => r.path === '/github.unlink')?.body ?? '{}')
 		expect(req.repositoryId).toBe(link.repositoryId)
+	})
+})
+
+test.describe('github link page', () => {
+	test('install button carries installUrl with state=project', async ({ page }) => {
+		await mocks({
+			'github.list': { ok: true, result: { items: [] } },
+			'github.listRepos': { ok: true, result: { items: [] } }
+		})
+
+		await page.goto('/github/link?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		const installBtn = main.getByRole('link', { name: /Install GitHub App/ })
+		await expect(installBtn).toBeVisible()
+		const href = await installBtn.getAttribute('href')
+		expect(href).toContain('https://github.com/apps/deploys-app/installations/new')
+		expect(href).toContain('state=test-project')
+	})
+
+	test('repo dropdown lists mocked repos and links with correct payload', async ({ page }) => {
+		await mocks({
+			// link has installationId: 77 so the page calls github.listRepos for it
+			'github.link': { ok: true, result: {} }
+		})
+
+		await page.goto('/github/link?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		// Open the repo select and pick acme/api (acme/web is already linked so hidden)
+		const repoSelect = main.locator('#link-repository')
+		await repoSelect.click()
+		await repoSelect.fill('acme/api')
+		await page.getByRole('option', { name: 'acme/api' }).click()
+
+		// Pick a service account
+		await main.locator('#link-service-account').click()
+		await page.getByRole('option', { name: /ci — CI Deployer/ }).click()
+
+		// Click link
+		await main.getByRole('button', { name: 'Link', exact: true }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/github.link')
+		}).toBe(true)
+
+		const log = await getRequestLog()
+		const linkReq = JSON.parse(log.find((r) => r.path === '/github.link')?.body ?? '{}')
+		expect(linkReq.repositoryId).toBe(812345679)
+		expect(linkReq.installationId).toBe(77)
+		expect(linkReq.serviceAccount).toBe('ci')
+		expect(linkReq.repository).toBe('acme/api')
+	})
+
+	test('link page with ?installation_id=99 calls github.listRepos with installationId 99', async ({ page }) => {
+		await mocks({
+			'github.list': { ok: true, result: { items: [] } }
+		})
+
+		await page.goto('/github/link?project=test-project&installation_id=99')
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/github.listRepos')
+		}).toBe(true)
+
+		const log = await getRequestLog()
+		const listReposReqs = log.filter((r) => r.path === '/github.listRepos')
+		const bodies = listReposReqs.map((r) => JSON.parse(r.body ?? '{}'))
+		expect(bodies.some((b) => b.installationId === 99)).toBe(true)
+	})
+
+	test('already-linked repos are hidden from dropdown', async ({ page }) => {
+		await mocks()
+		// link fixture has repositoryId 812345678 (acme/web)
+		// repos fixture includes acme/web, acme/api, acme/mobile
+
+		await page.goto('/github/link?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		// Open the repo dropdown
+		const repoSelect = main.locator('#link-repository')
+		await repoSelect.click()
+
+		// acme/api should be visible; acme/web (already linked) should not appear
+		await expect(page.getByRole('option', { name: 'acme/api' })).toBeVisible()
+		const webOption = page.getByRole('option', { name: /acme\/web/ })
+		await expect(webOption).toHaveCount(0)
+	})
+})
+
+test.describe('github-setup redirect', () => {
+	test('/github-setup?installation_id=99&state=test-project redirects to link page', async ({ page }) => {
+		await mocks()
+
+		await page.goto('/github-setup?installation_id=99&state=test-project')
+
+		await expect(page).toHaveURL(/\/github\/link\?project=test-project&installation_id=99/)
+	})
+
+	test('/github-setup?installation_id=99 (no state) redirects to link page without project', async ({ page }) => {
+		// Without a project param the (project) layout redirects to /project,
+		// but the URL should first land on /github/link with installation_id.
+		await mocks()
+
+		await page.goto('/github-setup?installation_id=99')
+
+		// The (project) layout will redirect further (to /project) because there
+		// is no ?project= param — just assert the initial redirect happened.
+		await expect(page).toHaveURL(/\/github\/link\?installation_id=99|\/project/)
+	})
+
+	test('/github-setup with no params redirects to /github (then to /project)', async ({ page }) => {
+		await mocks()
+
+		await page.goto('/github-setup')
+
+		// Should redirect to /github which then redirects to /project (no ?project=)
+		await expect(page).toHaveURL(/\/github|\/project/)
 	})
 })


### PR DESCRIPTION
Adds the project **GitHub page** for the build & deploy feature (apiserver/docs/github-build-deploy.md, Phase 4), with a Cloudflare-Pages-style link flow.

## GitHub page (`/github`)

- **Linked repositories table** — repo (linked to github.com), service-account email, linked-when, unlink with confirmation.
- **Link repository** button → the dedicated link page.
- **Workflow generator** — renders a filled-in `deploy.yml` (project/location/name/port) with Copy and a **Create on GitHub** deep-link (`github.com/<repo>/new/main?filename=…&value=…`) that pre-fills GitHub's file editor, so nobody hand-writes the workflow.

## Link flow (`/github/link`)

Install-and-pick, no typing owner/name:

1. **Install the GitHub App** — button from `github.getApp`'s install URL, carrying the project as `?state=`.
2. GitHub's App **Setup URL** redirects back to **`/github-setup`** (outside the project route group, since GitHub's redirect has no `?project=`), which restores the project from `state` and lands on the link page with `installation_id`.
3. **Searchable repository dropdown** — `github.listRepos` per installation id (from the redirect + existing links), deduped, already-linked repos hidden with a count note; reuses `Select`'s editable filter mode.
4. Pick a service account (permission hint shown: `deployment.deploy/get/delete`, `registry.push`) → `github.link` → back to the GitHub page.

Degrades cleanly: no repos yet → step-1 explainer; `github.getApp` unavailable → button replaced by a notice.

## Also

- Sidebar **GitHub** entry (preview badge) + active-state highlight via `github/+layout.js`.
- Mock fixtures for `github.getApp` / `github.listRepos` (+ corrected service-account email format).
- Types in `api.d.ts`; 11 GitHub e2e tests (link page, payload assertions, setup-redirect scenarios); full suite 162/162 green.

Backend: api#47 (merged) + apiserver#105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)