### PR TITLE
Remember GitHub App installations on link page

### DIFF
--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -1007,6 +1007,10 @@ const handlers = {
 	]),
 
 	'github.getApp': () => ok({ installUrl: 'https://github.com/apps/deploys-app/installations/new' }),
+	'github.addInstallation': () => ok({}),
+	'github.listInstallations': () => list([
+		{ installationId: 77, createdAt: '2026-05-01T08:00:00Z' }
+	]),
 	'github.listRepos': () => list([
 		{ repositoryId: 812345678, repository: 'acme/web', private: false },
 		{ repositoryId: 812345679, repository: 'acme/api', private: false },

--- a/src/routes/(auth)/(project)/github/link/+page.js
+++ b/src/routes/(auth)/(project)/github/link/+page.js
@@ -6,28 +6,46 @@ export async function load ({ parent, url, fetch }) {
 	const urlInstallationId = url.searchParams.get('installation_id')
 		? Number(url.searchParams.get('installation_id'))
 		: null
+	const hasValidUrlId = urlInstallationId !== null && Number.isInteger(urlInstallationId) && urlInstallationId > 0
 
-	const [links, serviceAccounts, appInfo] = await Promise.all([
+	// If a valid installation_id came from GitHub's setup redirect, persist it
+	// BEFORE calling listRepos — the backend now restricts listRepos to saved ids.
+	/** @type {Api.Error | undefined} */
+	let addInstallationError
+	if (hasValidUrlId) {
+		const addResp = await api.invoke('github.addInstallation', { project, installationId: urlInstallationId }, fetch)
+		if (!addResp.ok) {
+			addInstallationError = addResp.error
+		}
+	}
+
+	const [links, serviceAccounts, appInfo, installations] = await Promise.all([
 		api.invoke('github.list', { project }, fetch),
 		api.invoke('serviceAccount.list', { project }, fetch),
-		api.invoke('github.getApp', { project }, fetch)
+		api.invoke('github.getApp', { project }, fetch),
+		api.invoke('github.listInstallations', { project }, fetch)
 	])
 
-	// Collect unique installation ids from existing links + url param
+	// Collect unique installation ids from saved installations + existing links + url param
 	/** @type {Set<number>} */
 	const installationIds = new Set()
+	const savedItems = installations.result?.items ?? []
+	for (const s of savedItems) {
+		const id = s.installationId
+		if (Number.isInteger(id) && id > 0) installationIds.add(id)
+	}
 	const linkItems = links.result?.items ?? []
 	for (const l of linkItems) {
 		const id = l.installationId
 		if (Number.isInteger(id) && id > 0) installationIds.add(id)
 	}
-	if (urlInstallationId !== null && Number.isInteger(urlInstallationId) && urlInstallationId > 0) installationIds.add(urlInstallationId)
+	if (hasValidUrlId) installationIds.add(urlInstallationId)
 
 	// Fetch repos for each installation id in parallel
 	/** @type {Map<number, Api.GithubRepoItem>} */
 	const repoMap = new Map()
 	/** @type {Api.Error | undefined} */
-	let repoError
+	let repoError = addInstallationError
 
 	await Promise.all(
 		[...installationIds].map(async (installationId) => {

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -380,6 +380,11 @@ declare namespace Api {
         installationId: number
     }
 
+    export type GithubInstallationItem = {
+        installationId: number
+        createdAt: string
+    }
+
     export type EmailDomain = {
         domain: string
         createdAt: string

--- a/tests/github.spec.js
+++ b/tests/github.spec.js
@@ -29,11 +29,15 @@ const repos = [
 	{ repositoryId: 812345681, repository: 'acme/mobile', private: true }
 ]
 
+const savedInstallation = { installationId: 77, createdAt: '2026-01-01T00:00:00Z' }
+
 function mocks (overrides = {}) {
 	return setMocks({
 		'github.list': { ok: true, result: { items: [link] } },
 		'github.getApp': { ok: true, result: appInfo },
 		'github.listRepos': { ok: true, result: { items: repos } },
+		'github.listInstallations': { ok: true, result: { items: [savedInstallation] } },
+		'github.addInstallation': { ok: true, result: {} },
 		'serviceAccount.list': { ok: true, result: { items: [serviceAccount] } },
 		'location.list': { ok: true, result: { items: [location] } },
 		...overrides
@@ -161,7 +165,8 @@ test.describe('github link page', () => {
 
 	test('link page with ?installation_id=99 calls github.listRepos with installationId 99', async ({ page }) => {
 		await mocks({
-			'github.list': { ok: true, result: { items: [] } }
+			'github.list': { ok: true, result: { items: [] } },
+			'github.listInstallations': { ok: true, result: { items: [] } }
 		})
 
 		await page.goto('/github/link?project=test-project&installation_id=99')
@@ -175,6 +180,61 @@ test.describe('github link page', () => {
 		const listReposReqs = log.filter((r) => r.path === '/github.listRepos')
 		const bodies = listReposReqs.map((r) => JSON.parse(r.body ?? '{}'))
 		expect(bodies.some((b) => b.installationId === 99)).toBe(true)
+	})
+
+	test('landing with ?installation_id=88 calls addInstallation before listRepos for that id', async ({ page }) => {
+		await mocks({
+			'github.list': { ok: true, result: { items: [] } },
+			'github.listInstallations': { ok: true, result: { items: [] } }
+		})
+
+		await page.goto('/github/link?project=test-project&installation_id=88')
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/github.listRepos')
+		}).toBe(true)
+
+		const log = await getRequestLog()
+
+		// addInstallation must have been called with the correct payload
+		const addIndex = log.findIndex((r) => r.path === '/github.addInstallation')
+		expect(addIndex).toBeGreaterThanOrEqual(0)
+		const addBody = JSON.parse(log[addIndex]?.body ?? '{}')
+		expect(addBody.installationId).toBe(88)
+		expect(addBody.project).toBe('test-project')
+
+		// addInstallation must appear before listRepos for id 88 in the log
+		const listReposIndex = log.findIndex(
+			(r) => r.path === '/github.listRepos' && JSON.parse(r.body ?? '{}').installationId === 88
+		)
+		expect(listReposIndex).toBeGreaterThan(addIndex)
+	})
+
+	test('without ?installation_id repos are populated from remembered installations', async ({ page }) => {
+		// savedInstallation has installationId: 77 — listInstallations returns it, no URL param
+		await mocks({
+			'github.list': { ok: true, result: { items: [] } },
+			'github.listInstallations': { ok: true, result: { items: [savedInstallation] } }
+		})
+
+		await page.goto('/github/link?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		// The repo dropdown should be populated from installation 77
+		const repoSelect = main.locator('#link-repository')
+		await repoSelect.click()
+		await expect(page.getByRole('option', { name: 'acme/api' })).toBeVisible()
+
+		// Confirm listRepos was called for the saved installation id
+		const log = await getRequestLog()
+		const listReposBodies = log
+			.filter((r) => r.path === '/github.listRepos')
+			.map((r) => JSON.parse(r.body ?? '{}'))
+		expect(listReposBodies.some((b) => b.installationId === 77)).toBe(true)
+
+		// addInstallation must NOT have been called (no URL param)
+		expect(log.some((r) => r.path === '/github.addInstallation')).toBe(false)
 	})
 
 	test('already-linked repos are hidden from dropdown', async ({ page }) => {


### PR DESCRIPTION
## Summary

- **Install once, repos persist**: When GitHub redirects back with `?installation_id=`, the page now calls `github.addInstallation` to persist the id server-side before fetching repos. On all subsequent visits to `/github/link` the page calls `github.listInstallations` and uses the saved ids to populate the repo dropdown — no URL param needed.
- **addInstallation-before-listRepos ordering**: The backend restricts `github.listRepos` to previously saved installation ids. The load function awaits `github.addInstallation` to completion before the parallel `github.listRepos` fan-out, so the id is already known to the backend when the repo fetch runs.
- **Graceful error handling**: A failed `addInstallation` (e.g. bogus id from GitHub) is captured and surfaced through the existing `repoError` warning path rather than throwing, consistent with how per-installation `listRepos` failures are handled.
- **Mock fixtures**: `github.addInstallation` → `{}`, `github.listInstallations` → one item with `installationId: 77` (aligned with the existing `listRepos` mock), so offline dev shows repos without any URL param.

## Test plan

- [x] New test: navigating to `/github/link?project=acme` without `?installation_id=` populates the repo dropdown from the remembered installation (id 77 from `listInstallations`)
- [x] New test: landing with `?installation_id=88` issues `github.addInstallation` with `{project, installationId: 88}` and asserts it appears before `github.listRepos` for id 88 in the request log
- [x] All 13 pre-existing GitHub tests continue to pass (166/166 total)
- [x] `bun lint` — zero errors
- [x] `bun check` — zero errors
- [x] `bunx playwright test` — 166/166 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)