### PR TITLE
Load GitHub repos client-side on the link page

### DIFF
--- a/src/routes/(auth)/(project)/github/link/+page.js
+++ b/src/routes/(auth)/(project)/github/link/+page.js
@@ -9,7 +9,7 @@ export async function load ({ parent, url, fetch }) {
 	const hasValidUrlId = urlInstallationId !== null && Number.isInteger(urlInstallationId) && urlInstallationId > 0
 
 	// If a valid installation_id came from GitHub's setup redirect, persist it
-	// BEFORE calling listRepos — the backend now restricts listRepos to saved ids.
+	// BEFORE the client calls listRepos — the backend restricts listRepos to saved ids.
 	/** @type {Api.Error | undefined} */
 	let addInstallationError
 	if (hasValidUrlId) {
@@ -41,30 +41,6 @@ export async function load ({ parent, url, fetch }) {
 	}
 	if (hasValidUrlId) installationIds.add(urlInstallationId)
 
-	// Fetch repos for each installation id in parallel
-	/** @type {Map<number, Api.GithubRepoItem>} */
-	const repoMap = new Map()
-	/** @type {Api.Error | undefined} */
-	let repoError = addInstallationError
-
-	await Promise.all(
-		[...installationIds].map(async (installationId) => {
-			const resp = await api.invoke('github.listRepos', { project, installationId }, fetch)
-			if (!resp.ok) {
-				repoError = resp.error
-				return
-			}
-			for (const item of resp.result?.items ?? []) {
-				if (!repoMap.has(item.repositoryId)) {
-					repoMap.set(item.repositoryId, { ...item, installationId })
-				}
-			}
-		})
-	)
-
-	// Sort by repository name
-	const repos = [...repoMap.values()].sort((a, b) => a.repository.localeCompare(b.repository))
-
 	// Set of already-linked repository ids
 	const linkedRepoIds = new Set(linkItems.map((l) => l.repositoryId))
 
@@ -72,11 +48,11 @@ export async function load ({ parent, url, fetch }) {
 	const error = links.error ?? serviceAccounts.error ?? appInfo.error
 
 	return {
-		repos,
 		serviceAccounts: serviceAccounts.result?.items ?? [],
 		installUrl: appInfo.result?.installUrl ?? '',
 		linkedRepoIds: [...linkedRepoIds],
 		error,
-		repoError
+		addInstallationError,
+		installationIds: [...installationIds]
 	}
 }

--- a/src/routes/(auth)/(project)/github/link/+page.svelte
+++ b/src/routes/(auth)/(project)/github/link/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { onMount } from 'svelte'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
@@ -7,11 +8,62 @@
 	const { data } = $props()
 
 	const project = $derived(data.project)
-	const repos = $derived(data.repos)
 	const serviceAccounts = $derived(data.serviceAccounts)
 	const installUrl = $derived(data.installUrl)
-	const repoError = $derived(data.repoError)
 	const linkedRepoIds = $derived(new Set(data.linkedRepoIds))
+
+	/** @type {Api.GithubRepoItem[]} */
+	let repos = $state([])
+	/** @type {Api.Error | undefined} */
+	let repoError = $state(undefined)
+	let loadingRepos = $state(false)
+	let loadedOnce = $state(false)
+
+	const displayError = $derived(repoError ?? data.addInstallationError)
+
+	async function loadRepos () {
+		if (loadingRepos) return
+
+		loadingRepos = true
+		repoError = undefined
+		try {
+			/** @type {Record<number, Api.GithubRepoItem>} */
+			const repoMap = {}
+
+			await Promise.all(
+				data.installationIds.map(async (installationId) => {
+					const resp = await api.invoke('github.listRepos', { project, installationId }, fetch)
+					if (!resp.ok) {
+						repoError = resp.error
+						return
+					}
+					for (const item of resp.result?.items ?? []) {
+						if (!(item.repositoryId in repoMap)) {
+							repoMap[item.repositoryId] = { ...item, installationId }
+						}
+					}
+				})
+			)
+
+			repos = Object.values(repoMap).sort((a, b) => a.repository.localeCompare(b.repository))
+
+			// If the selected repo disappeared after a refresh, clear the selection.
+			if (selectedRepoName !== '' && !repos.some((r) => r.repository === selectedRepoName)) {
+				selectedRepoName = ''
+			}
+		} finally {
+			loadedOnce = true
+			loadingRepos = false
+		}
+	}
+
+	onMount(() => {
+		if (data.installationIds.length === 0) {
+			loadedOnce = true
+			return
+		}
+		loadRepos()
+	})
 
 	// Repos not yet linked
 	const availableRepos = $derived(repos.filter((r) => !linkedRepoIds.has(r.repositoryId)))
@@ -108,14 +160,15 @@
 <div class="panel is-level-300 grid gap-6">
 	<div>
 		<h6><strong>Step 2 — Pick a repository</strong></h6>
-		{#if repoError}
-			<p class="text-negative text-sm mt-1">Couldn't load repositories: {repoError.message}</p>
+		{#if displayError}
+			<p class="text-negative text-sm mt-1">Couldn't load repositories: {displayError.message}</p>
 		{/if}
 		<p class="text-content/50 text-sm mt-1">
-			{#if repos.length === 0 && !repoError}
+			{#if loadedOnce && repos.length === 0 && !displayError}
 				No repositories found. Complete step 1 to grant access — GitHub will redirect back here automatically.
 			{:else if repos.length > 0}
 				Select a repository from those visible to the installed GitHub App.
+				Just created a repository on GitHub? Hit Refresh to pick it up.
 				{#if hiddenCount > 0}
 					<span class="text-content/40">{hiddenCount} {hiddenCount === 1 ? 'repository is' : 'repositories are'} already linked and hidden.</span>
 				{/if}
@@ -133,13 +186,27 @@
 	<div class="grid gap-4 sm:grid-cols-2">
 		<div class="field">
 			<label for="link-repository">Repository</label>
-			<Select
-				id="link-repository"
-				bind:value={selectedRepoName}
-				options={repoOptions}
-				placeholder="Search repositories…"
-				editable={true}
-				disabled={repoOptions.length === 0} />
+			<div class="flex items-center gap-2">
+				<div class="flex-1">
+					<Select
+						id="link-repository"
+						bind:value={selectedRepoName}
+						options={repoOptions}
+						placeholder={loadingRepos ? 'Loading repositories…' : 'Search repositories…'}
+						editable={true}
+						disabled={loadingRepos || repoOptions.length === 0} />
+				</div>
+				<button
+					class="button is-variant-secondary"
+					class:is-loading={loadingRepos}
+					disabled={loadingRepos}
+					onclick={loadRepos}
+					aria-label="Refresh"
+					title="Re-fetch the repository list — newly created repos appear after Refresh"
+					type="button">
+					<i class="fa-solid fa-rotate"></i>
+				</button>
+			</div>
 		</div>
 		<div class="field">
 			<label for="link-service-account">Service account</label>

--- a/tests/github.spec.js
+++ b/tests/github.spec.js
@@ -275,6 +275,37 @@ test.describe('github link page', () => {
 		await expect(page.getByRole('option', { name: 'acme/api' })).toBeVisible()
 	})
 
+	test('Refresh re-fetches repositories and the dropdown reflects updated data', async ({ page }) => {
+		await mocks({ 'github.list': { ok: true, result: { items: [] } } })
+
+		await page.goto('/github/link?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		// Wait for the initial client-side fetch to populate the dropdown.
+		const repoSelect = main.locator('#link-repository')
+		await repoSelect.click()
+		await expect(page.getByRole('option', { name: 'acme/api' })).toBeVisible()
+		await page.keyboard.press('Escape')
+
+		// A new repo was created on GitHub — the next listRepos returns it.
+		await setMocks({
+			'github.listRepos': {
+				ok: true,
+				result: { items: [...repos, { repositoryId: 812345700, repository: 'acme/new-repo', private: false }] }
+			}
+		})
+
+		await main.getByRole('button', { name: 'Refresh' }).click()
+
+		await repoSelect.click()
+		await expect(page.getByRole('option', { name: 'acme/new-repo' })).toBeVisible()
+
+		// listRepos must have been issued again by the Refresh click.
+		const log = await getRequestLog()
+		const listReposCalls = log.filter((r) => r.path === '/github.listRepos')
+		expect(listReposCalls.length).toBeGreaterThanOrEqual(2)
+	})
+
 	test('shows inline warning when github.listRepos fails and hides complete-step-1 copy', async ({ page }) => {
 		await mocks({
 			'github.listRepos': { ok: false, error: { message: 'boom' } }


### PR DESCRIPTION
## Why

\`github.listRepos\` goes apiserver → GitHub (installation token mint + paginated repo list), which blocked SvelteKit navigation to \`/github/link\` for seconds since it ran inside \`load()\`.

## What

- **\`+page.js\`** keeps only the fast calls: \`github.addInstallation\` (must stay before any \`listRepos\` — the backend restricts \`listRepos\` to saved installation ids), the parallel \`github.list\` / \`serviceAccount.list\` / \`github.getApp\` / \`github.listInstallations\` batch, and the deduped \`installationIds\` / \`linkedRepoIds\` computation. The \`listRepos\` fan-out is removed from \`load()\`.
- **\`+page.svelte\`** owns the repo list as \`$state\`, fetching it after mount with the same fan-out/dedupe/sort logic. While loading, the repo picker is disabled with a "Loading repositories…" placeholder; empty-state copy only shows after the first fetch completes. A selection that disappears after a refresh is cleared.
- **Refresh button** (icon, beside the picker) re-fetches the list — covers "I just created the repo on GitHub".

## Tests

- New e2e: Refresh re-issues \`github.listRepos\` and the dropdown reflects updated mock data.
- Existing addInstallation-before-listRepos ordering test still passes (ordering is now load() vs post-mount fetch).
- \`bun lint\` / \`bun check\` clean; 167/167 Playwright tests pass.
- Visually verified in mock mode (light theme, fields aligned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)