### PR TITLE
Add production branch to GitHub link flow

### DIFF
--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -546,6 +546,18 @@ const githubLinks = [
 		installationId: 77,
 		serviceAccount: 'sa_mock_ci',
 		serviceAccountEmail: 'ci@acme.serviceaccount.deploys.app',
+		productionBranch: 'main',
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL
+	},
+	{
+		repositoryId: 812345682,
+		repository: 'contoso/site',
+		installationId: 77,
+		serviceAccount: 'sa_mock_ci',
+		serviceAccountEmail: 'ci@acme.serviceaccount.deploys.app',
+		// no productionBranch — any branch can deploy; exercises the "—" / fallback path
+		productionBranch: '',
 		createdAt: CREATED_AT,
 		createdBy: USER_EMAIL
 	}
@@ -1042,6 +1054,7 @@ const handlers = {
 			installationId: args?.installationId ?? 0,
 			serviceAccount: args?.serviceAccount,
 			serviceAccountEmail: sa?.email ?? `${args?.serviceAccount}@acme.serviceaccount.deploys.app`,
+			productionBranch: args?.productionBranch ?? '',
 			createdAt: CREATED_AT,
 			createdBy: USER_EMAIL
 		})

--- a/src/routes/(auth)/(project)/github/+page.svelte
+++ b/src/routes/(auth)/(project)/github/+page.svelte
@@ -50,11 +50,12 @@
 		port: 8080
 	})))
 	const genRepoOptions = $derived(links.map((l) => ({ value: l.repository, label: l.repository })))
+	const genBranch = $derived(links.find((l) => l.repository === gen.repository)?.productionBranch || 'main')
 
 	const workflowYaml = $derived(`name: Deploy
 on:
   push:
-    branches: [main]
+    branches: [${genBranch}]
   pull_request:
 
 permissions:
@@ -109,6 +110,7 @@ jobs:
 			<tr>
 				<th>Repository</th>
 				<th>Service Account</th>
+				<th>Branch</th>
 				<th>Linked</th>
 				<th class="is-collapse is-align-right"></th>
 			</tr>
@@ -123,6 +125,13 @@ jobs:
 						</td>
 						<td><span class="cell-muted font-mono text-sm">{it.serviceAccountEmail}</span></td>
 						<td>
+							{#if it.productionBranch}
+								<span class="cell-muted font-mono text-sm">{it.productionBranch}</span>
+							{:else}
+								<span class="cell-muted" title="Any branch can deploy">—</span>
+							{/if}
+						</td>
+						<td>
 							<span class="cell-time" title={format.datetime(it.createdAt)}>{format.fromNow(it.createdAt) || '—'}</span>
 						</td>
 						<td>
@@ -132,8 +141,8 @@ jobs:
 						</td>
 					</tr>
 				{/each}
-				<NoDataRow span={4} list={links} />
-				<ErrorRow span={4} {error} />
+				<NoDataRow span={5} list={links} />
+				<ErrorRow span={5} {error} />
 			</tbody>
 		</table>
 	</div>

--- a/src/routes/(auth)/(project)/github/link/+page.svelte
+++ b/src/routes/(auth)/(project)/github/link/+page.svelte
@@ -29,6 +29,7 @@
 
 	let selectedRepoName = $state('')
 	let selectedServiceAccount = $state('')
+	let productionBranch = $state('main')
 	let linking = $state(false)
 
 	const selectedRepo = $derived(
@@ -50,7 +51,8 @@
 				repositoryId: selectedRepo.repositoryId,
 				repository: selectedRepo.repository,
 				installationId: selectedRepo.installationId,
-				serviceAccount: selectedServiceAccount
+				serviceAccount: selectedServiceAccount,
+				productionBranch: productionBranch.trim()
 			}, fetch)
 			if (!resp.ok) {
 				modal.error({ error: resp.error })
@@ -148,6 +150,16 @@
 				bind:value={selectedServiceAccount}
 				options={serviceAccountOptions}
 				placeholder="Select a service account" />
+		</div>
+		<div class="field sm:col-span-2">
+			<label for="link-production-branch">Production branch</label>
+			<div class="input">
+				<input id="link-production-branch" class="font-mono" bind:value={productionBranch} placeholder="main">
+			</div>
+			<p class="text-content/50 text-sm mt-1">
+				Production deploys are only accepted from this branch; pull-request previews are always allowed.
+				Leave empty to allow any branch.
+			</p>
 		</div>
 	</div>
 

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -357,6 +357,9 @@ declare namespace Api {
         // service account sid
         serviceAccount: string
         serviceAccountEmail: string
+        // production deploys (push events) are only accepted from this branch;
+        // empty = any branch. pull-request previews are always allowed.
+        productionBranch?: string
         createdAt: string
         createdBy: string
     }

--- a/tests/github.spec.js
+++ b/tests/github.spec.js
@@ -6,6 +6,19 @@ const link = {
 	installationId: 77,
 	serviceAccount: 'ci',
 	serviceAccountEmail: 'ci@test-project.serviceaccount.deploys.app',
+	productionBranch: 'release',
+	createdAt: '2026-01-01T00:00:00Z',
+	createdBy: 'dev@deploys.app'
+}
+
+// linked repo without a production branch — any branch may deploy
+const linkAnyBranch = {
+	repositoryId: 812345681,
+	repository: 'acme/mobile',
+	installationId: 77,
+	serviceAccount: 'ci',
+	serviceAccountEmail: 'ci@test-project.serviceaccount.deploys.app',
+	productionBranch: '',
 	createdAt: '2026-01-01T00:00:00Z',
 	createdBy: 'dev@deploys.app'
 }
@@ -92,6 +105,33 @@ test.describe('github', () => {
 		expect(href).toBe('/github/link?project=test-project')
 	})
 
+	test('renders the production branch per row, with "—" when unset', async ({ page }) => {
+		await mocks({ 'github.list': { ok: true, result: { items: [link, linkAnyBranch] } } })
+
+		await page.goto('/github?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		await expect(main.getByRole('columnheader', { name: 'Branch' })).toBeVisible()
+		await expect(main.locator('tr', { hasText: 'acme/web' })).toContainText('release')
+		await expect(main.locator('tr', { hasText: 'acme/mobile' })).toContainText('—')
+	})
+
+	test('workflow generator uses the link production branch, falling back to main', async ({ page }) => {
+		await mocks({ 'github.list': { ok: true, result: { items: [link, linkAnyBranch] } } })
+
+		await page.goto('/github?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		// Default selection is acme/web, which restricts production to "release".
+		const yaml = main.locator('.workflow-yaml')
+		await expect(yaml).toContainText('branches: [release]')
+
+		// acme/mobile has no production branch — the generator falls back to main.
+		await main.locator('#gen-repository').click()
+		await page.getByRole('option', { name: 'acme/mobile' }).click()
+		await expect(yaml).toContainText('branches: [main]')
+	})
+
 	test('unlinks after confirmation', async ({ page }) => {
 		await mocks({ 'github.unlink': { ok: true, result: {} } })
 
@@ -147,6 +187,11 @@ test.describe('github link page', () => {
 		await main.locator('#link-service-account').click()
 		await page.getByRole('option', { name: /ci — CI Deployer/ }).click()
 
+		// Production branch is prefilled with "main"; override it (trimmed on submit)
+		const branchInput = main.locator('#link-production-branch')
+		await expect(branchInput).toHaveValue('main')
+		await branchInput.fill('  release  ')
+
 		// Click link
 		await main.getByRole('button', { name: 'Link', exact: true }).click()
 
@@ -161,6 +206,7 @@ test.describe('github link page', () => {
 		expect(linkReq.installationId).toBe(77)
 		expect(linkReq.serviceAccount).toBe('ci')
 		expect(linkReq.repository).toBe('acme/api')
+		expect(linkReq.productionBranch).toBe('release')
 	})
 
 	test('link page with ?installation_id=99 calls github.listRepos with installationId 99', async ({ page }) => {


### PR DESCRIPTION
Console side of the production-branch restriction (api#50 merged, apiserver#109):

- Link form: "Production branch" input, prefilled \`main\`; helper text explains production pushes are only accepted from this branch, PR previews always allowed, empty = any branch. Trimmed value sent as \`productionBranch\` in \`github.link\`.
- Links table: new Branch column (em-dash + tooltip when unrestricted).
- Workflow generator: \`on.push.branches\` now comes from the selected repo's link (falls back to \`main\`).
- Types, mock fixtures, and 3 e2e additions (payload, list rendering, generator output per link).

\`bun lint\` / \`bun check\` clean; 168/168 Playwright tests.

Note: touches the same link page as #194 — whichever merges second needs a trivial conflict resolution; ping me and I'll handle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)