### PR TITLE
Gate action buttons on user permissions

### DIFF
--- a/src/lib/components/GuardedButton.svelte
+++ b/src/lib/components/GuardedButton.svelte
@@ -1,0 +1,66 @@
+<script>
+	import { getContext } from 'svelte'
+	import { denyTooltip } from '$lib/permission'
+
+	/**
+	 * @typedef {Object} Props
+	 * @property {string} permission  required permission, e.g. 'deployment.deploy'
+	 * @property {string} [href]  when set AND allowed, renders an <a> instead of a <button>
+	 * @property {(e: MouseEvent) => void} [onclick]
+	 * @property {'button' | 'submit' | 'reset'} [type]  button type (ignored for <a>); default 'button'
+	 * @property {boolean} [loading]  adds the is-loading state
+	 * @property {boolean} [disabled]  an ADDITIONAL disable, independent of permission
+	 * @property {string} [class]  control class; default 'button'
+	 * @property {string} [title]  overrides the allowed-state title; ignored when denied
+	 * @property {import('svelte').Snippet} [children]
+	 */
+
+	/** @type {Props & Record<string, any>} */
+	const {
+		permission,
+		href,
+		onclick,
+		type = 'button',
+		loading = false,
+		disabled = false,
+		class: klass = 'button',
+		title,
+		children,
+		...rest
+	} = $props()
+
+	/** @type {{ can: (p: string) => boolean }} */
+	const { can } = getContext('permission')
+
+	const allowed = $derived(can(permission))
+</script>
+
+{#if !allowed}
+	<!--
+		Denied: render a disabled <button> (never an <a>, so it cannot navigate
+		even if href was set), wrapped in a <span> carrying the deny tooltip. The
+		wrapping span is what makes the native title tooltip reliably appear on
+		hover — a bare disabled button does not fire hover tooltips consistently
+		across browsers.
+	-->
+	<span class="inline-flex" title={denyTooltip(permission)}>
+		<button class={klass} type="button" disabled aria-disabled="true" {...rest}>
+			{@render children?.()}
+		</button>
+	</span>
+{:else if href}
+	<a class={klass} {href} {title} {...rest}>
+		{@render children?.()}
+	</a>
+{:else}
+	<button
+		class={klass}
+		class:is-loading={loading}
+		{type}
+		{onclick}
+		{title}
+		disabled={disabled || loading}
+		{...rest}>
+		{@render children?.()}
+	</button>
+{/if}

--- a/src/lib/permission.js
+++ b/src/lib/permission.js
@@ -15,8 +15,12 @@ export function hasPermission (permissions, admin, permission) {
 	if (admin) return true
 	if (!permissions || permissions.length === 0) return false
 	if (permissions.includes('*')) return true
-	const dot = permission.indexOf('.')
-	if (dot > 0 && permissions.includes(permission.slice(0, dot) + '.*')) return true
+	// The server only honors a '<resource>.*' wildcard for TWO-segment
+	// permissions (iam.validPermissions checks len(parts)==2). Three-segment
+	// permissions like 'serviceaccount.key.create' require an exact grant (or
+	// '*'); 'serviceaccount.*' does NOT cover them. Mirror that exactly.
+	const parts = permission.split('.')
+	if (parts.length === 2 && permissions.includes(parts[0] + '.*')) return true
 	return permissions.includes(permission)
 }
 

--- a/src/lib/permission.js
+++ b/src/lib/permission.js
@@ -1,0 +1,30 @@
+// Permission matching mirrors the server's effective-grant check exactly.
+// `permissions` is the caller's effective grant set and may contain the
+// wildcards '*' (all) and '<resource>.*' (all actions on a resource). `admin`
+// means platform admin — it holds everything. Keep this in lockstep with the
+// backend so a button rendered enabled here never gets rejected by the API
+// (and vice versa).
+
+/**
+ * @param {string[] | undefined} permissions  effective grants (may include '*' and '<resource>.*')
+ * @param {boolean} admin
+ * @param {string} permission  e.g. 'deployment.deploy'
+ * @returns {boolean}
+ */
+export function hasPermission (permissions, admin, permission) {
+	if (admin) return true
+	if (!permissions || permissions.length === 0) return false
+	if (permissions.includes('*')) return true
+	const dot = permission.indexOf('.')
+	if (dot > 0 && permissions.includes(permission.slice(0, dot) + '.*')) return true
+	return permissions.includes(permission)
+}
+
+/**
+ * Default tooltip shown on a denied action control.
+ * @param {string} permission  the missing permission, e.g. 'deployment.deploy'
+ * @returns {string}
+ */
+export function denyTooltip (permission) {
+	return `You don't have permission to do this (requires ${permission}).`
+}

--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -793,6 +793,9 @@ const handlers = {
 	'me.get': () => ok({ email: USER_EMAIL }),
 	// The mock user is a full-access owner, so every permission probe passes.
 	'me.authorized': () => ok({ authorized: true }),
+	// Effective grants for the mock user: the '*' wildcard grants everything, so
+	// all gated buttons (GuardedButton) render enabled by default offline.
+	'me.permissions': () => ok({ permissions: ['*'], admin: false }),
 
 	'project.list': () => list(projects),
 	'project.get': (args) => ok(projects.find((p) => p.project === args?.project) ?? { ...projects[0], project: args?.project ?? 'acme' }),

--- a/src/routes/(auth)/(project)/+layout.js
+++ b/src/routes/(auth)/(project)/+layout.js
@@ -7,6 +7,8 @@ import { browser } from '$app/environment'
  * @property {string} project
  * @property {Api.Project} projectInfo
  * @property {Api.Location[]} locations
+ * @property {string[]} permissions  caller's effective grants for this project
+ * @property {boolean} permissionsAdmin  caller is a platform admin
  */
 
 /** @type {BrowserCache | null} */
@@ -27,7 +29,9 @@ export async function load ({ url, data, fetch }) {
 		return {
 			project,
 			projectInfo: browserCache.projectInfo,
-			locations: browserCache.locations
+			locations: browserCache.locations,
+			permissions: browserCache.permissions,
+			permissionsAdmin: browserCache.permissionsAdmin
 		}
 	}
 
@@ -47,17 +51,30 @@ export async function load ({ url, data, fetch }) {
 	if (!locations.ok) error(500, `locations: ${locations.error?.message}`)
 	if (!locations.result) redirect(302, '/project')
 
+	// Effective permissions for the current user on this project. A non-ok
+	// response must never break the page — gate everything off instead (empty
+	// grants + non-admin), so action buttons render disabled rather than the
+	// whole project layout failing to load.
+	/** @type {Api.Response<{ permissions: string[], admin: boolean }>} */
+	const permissionsResp = await api.invoke('me.permissions', { project }, fetch)
+	const permissions = permissionsResp.ok ? (permissionsResp.result?.permissions ?? []) : []
+	const permissionsAdmin = permissionsResp.ok ? (permissionsResp.result?.admin === true) : false
+
 	if (browser) {
 		browserCache = {
 			project,
 			projectInfo: projectInfo.result,
-			locations: locations.result.items ?? []
+			locations: locations.result.items ?? [],
+			permissions,
+			permissionsAdmin
 		}
 	}
 
 	return {
 		project,
 		projectInfo: projectInfo.result,
-		locations: locations.result.items ?? []
+		locations: locations.result.items ?? [],
+		permissions,
+		permissionsAdmin
 	}
 }

--- a/src/routes/(auth)/(project)/+layout.svelte
+++ b/src/routes/(auth)/(project)/+layout.svelte
@@ -1,10 +1,28 @@
 <script>
 	import Cookie from 'js-cookie'
-	import { onMount } from 'svelte'
+	import { onMount, setContext } from 'svelte'
+	import { page } from '$app/stores'
+	import { hasPermission } from '$lib/permission'
 
 	const { data, children } = $props()
 
 	const project = $derived(data.project)
+
+	// Provide a reactive `can(permission)` to every descendant page/component so
+	// gated action controls (GuardedButton) can ask whether the current user is
+	// allowed, without each page re-fetching permissions.
+	//
+	// Reactive source: the app `page` store ($page.data) rather than this
+	// layout's own `data` prop. Both update on client-side navigation while this
+	// layout stays mounted, but $page.data is the canonical merged load data and
+	// matches the page-store convention used elsewhere in this repo — it stays
+	// correct even if the permission fields were ever moved to a different load
+	// level. `can` reads $page.data at call time, so it always reflects the
+	// current project's permissions after navigation.
+	setContext('permission', {
+		/** @param {string} p */
+		can: (p) => hasPermission($page.data.permissions, $page.data.permissionsAdmin, p)
+	})
 
 	onMount(() => {
 		Cookie.set('project', project, { expires: 7 })

--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -6,6 +6,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import Secret from '$lib/components/Secret.svelte'
 	import EnvGroupModal from '$lib/components/EnvGroupModal.svelte'
 
@@ -782,7 +783,7 @@
 </div>
 
 <DangerZone description="Permanently delete this deployment. All running instances will be stopped and removed.">
-	<button class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</button>
+	<GuardedButton permission="deployment.delete" class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</GuardedButton>
 </DangerZone>
 
 <EnvGroupModal bind:this={envGroupModal} />

--- a/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
@@ -1,9 +1,14 @@
 <script>
-	import { onMount } from 'svelte'
+	import { onMount, getContext } from 'svelte'
 	import * as format from '$lib/format'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import { denyTooltip } from '$lib/permission'
+
+	/** @type {{ can: (p: string) => boolean }} */
+	const { can } = getContext('permission')
 
 	const { data } = $props()
 	const deployment = $derived(data.deployment)
@@ -551,11 +556,14 @@
 				</span>
 				<span class="rev-row__act">
 					{#if i > 0}
-						<button type="button" class="rail-btn"
-							onclick={() => rollback(it)}>
-							<i class="fa-solid fa-rotate-left"></i>
-							Rollback
-						</button>
+						<span class="inline-flex" title={can('deployment.rollback') ? null : denyTooltip('deployment.rollback')}>
+							<button type="button" class="rail-btn"
+								disabled={!can('deployment.rollback')}
+								onclick={() => rollback(it)}>
+								<i class="fa-solid fa-rotate-left"></i>
+								Rollback
+							</button>
+						</span>
 					{/if}
 				</span>
 			</li>
@@ -658,11 +666,11 @@
 		{/if}
 
 		<div class="flex items-center gap-3 mt-6">
-			<button type="button" class="button" class:is-loading={rollingBack}
-				disabled={rollingBack} onclick={confirmRollback}>
+			<GuardedButton permission="deployment.rollback" class="button"
+				loading={rollingBack} onclick={confirmRollback}>
 				<i class="fa-solid fa-rotate-left mr-2"></i>
 				Rollback
-			</button>
+			</GuardedButton>
 			<button type="button" class="button is-variant-secondary" disabled={rollingBack}
 				onclick={closeRollback}>Cancel</button>
 		</div>

--- a/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
@@ -556,9 +556,9 @@
 				</span>
 				<span class="rev-row__act">
 					{#if i > 0}
-						<span class="inline-flex" title={can('deployment.rollback') ? null : denyTooltip('deployment.rollback')}>
+						<span class="inline-flex" title={can('deployment.delete') ? null : denyTooltip('deployment.delete')}>
 							<button type="button" class="rail-btn"
-								disabled={!can('deployment.rollback')}
+								disabled={!can('deployment.delete')}
 								onclick={() => rollback(it)}>
 								<i class="fa-solid fa-rotate-left"></i>
 								Rollback
@@ -666,7 +666,7 @@
 		{/if}
 
 		<div class="flex items-center gap-3 mt-6">
-			<GuardedButton permission="deployment.rollback" class="button"
+			<GuardedButton permission="deployment.delete" class="button"
 				loading={rollingBack} onclick={confirmRollback}>
 				<i class="fa-solid fa-rotate-left mr-2"></i>
 				Rollback

--- a/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
@@ -556,9 +556,9 @@
 				</span>
 				<span class="rev-row__act">
 					{#if i > 0}
-						<span class="inline-flex" title={can('deployment.delete') ? null : denyTooltip('deployment.delete')}>
+						<span class="inline-flex" title={can('deployment.deploy') ? null : denyTooltip('deployment.deploy')}>
 							<button type="button" class="rail-btn"
-								disabled={!can('deployment.delete')}
+								disabled={!can('deployment.deploy')}
 								onclick={() => rollback(it)}>
 								<i class="fa-solid fa-rotate-left"></i>
 								Rollback
@@ -666,7 +666,7 @@
 		{/if}
 
 		<div class="flex items-center gap-3 mt-6">
-			<GuardedButton permission="deployment.delete" class="button"
+			<GuardedButton permission="deployment.deploy" class="button"
 				loading={rollingBack} onclick={confirmRollback}>
 				<i class="fa-solid fa-rotate-left mr-2"></i>
 				Rollback

--- a/src/routes/(auth)/(project)/deployment/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/+page.svelte
@@ -3,6 +3,7 @@
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as format from '$lib/format'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -69,10 +70,10 @@
 		<h4><strong>Deployments</strong></h4>
 		<p class="page-sub">{deployments.length} {deployments.length === 1 ? 'deployment' : 'deployments'}</p>
 	</div>
-	<a class="button is-icon-left" href="/deployment/deploy?project={project}">
+	<GuardedButton permission="deployment.deploy" class="button is-icon-left" href="/deployment/deploy?project={project}">
 		<i class="fa-solid fa-plus"></i>
 		Deploy
-	</a>
+	</GuardedButton>
 </div>
 <div class="panel is-level-300">
 	<div class="table-container">

--- a/src/routes/(auth)/(project)/deployment/_components/Header.svelte
+++ b/src/routes/(auth)/(project)/deployment/_components/Header.svelte
@@ -1,9 +1,11 @@
 <script>
 	import DeploymentStatusIcon from '$lib/components/DeploymentStatusIcon.svelte'
+	import { getContext } from 'svelte'
 	import { page } from '$app/stores'
 	import api from '$lib/api'
 	import * as modal from '$lib/modal'
 	import * as format from '$lib/format'
+	import { denyTooltip } from '$lib/permission'
 
 	/**
 	 * @typedef {Object} Props
@@ -15,6 +17,9 @@
 	const { deployment, invalidate } = $props()
 
 	const project = $derived($page.data.project)
+
+	/** @type {{ can: (p: string) => boolean }} */
+	const { can } = getContext('permission')
 
 	const canPause = $derived(deployment.status === 'success' && deployment.action === 'deploy')
 	const canResume = $derived(deployment.status === 'success' && deployment.action === 'pause')
@@ -178,17 +183,21 @@
 		text-decoration: none;
 		transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 	}
-	.mast-btn:hover {
+	.mast-btn:hover:not(:disabled) {
 		background: hsl(var(--hsl-content) / 0.05);
 		color: hsl(var(--hsl-content));
 		border-color: hsl(var(--hsl-content) / 0.2);
+	}
+	.mast-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 	.mast-btn.is-primary {
 		background: hsl(var(--hsl-primary));
 		border-color: hsl(var(--hsl-primary));
 		color: hsl(var(--hsl-primary-content));
 	}
-	.mast-btn.is-primary:hover {
+	.mast-btn.is-primary:hover:not(:disabled) {
 		background: hsl(var(--hsl-primary) / 0.92);
 		border-color: hsl(var(--hsl-primary) / 0.92);
 	}
@@ -303,19 +312,31 @@
 		</div>
 		<div class="masthead__actions">
 			{#if canPause}
-				<button class="mast-btn" type="button" onclick={pause}>
-					<i class="fa-solid fa-pause"></i> Pause
-				</button>
+				<span class="inline-flex" title={can('deployment.pause') ? null : denyTooltip('deployment.pause')}>
+					<button class="mast-btn" type="button" disabled={!can('deployment.pause')} aria-disabled={!can('deployment.pause')} onclick={pause}>
+						<i class="fa-solid fa-pause"></i> Pause
+					</button>
+				</span>
 			{/if}
 			{#if canResume}
-				<button class="mast-btn" type="button" onclick={resume}>
-					<i class="fa-solid fa-play"></i> Resume
-				</button>
+				<span class="inline-flex" title={can('deployment.resume') ? null : denyTooltip('deployment.resume')}>
+					<button class="mast-btn" type="button" disabled={!can('deployment.resume')} aria-disabled={!can('deployment.resume')} onclick={resume}>
+						<i class="fa-solid fa-play"></i> Resume
+					</button>
+				</span>
 			{/if}
-			<a class="mast-btn is-primary"
-				href={`/deployment/deploy?project=${project}&location=${deployment.location}&name=${deployment.name}`}>
-				<i class="fa-solid fa-rocket"></i> Deploy New Revision
-			</a>
+			{#if can('deployment.deploy')}
+				<a class="mast-btn is-primary"
+					href={`/deployment/deploy?project=${project}&location=${deployment.location}&name=${deployment.name}`}>
+					<i class="fa-solid fa-rocket"></i> Deploy New Revision
+				</a>
+			{:else}
+				<span class="inline-flex" title={denyTooltip('deployment.deploy')}>
+					<button class="mast-btn is-primary" type="button" disabled aria-disabled="true">
+						<i class="fa-solid fa-rocket"></i> Deploy New Revision
+					</button>
+				</span>
+			{/if}
 		</div>
 	</div>
 

--- a/src/routes/(auth)/(project)/deployment/_components/Header.svelte
+++ b/src/routes/(auth)/(project)/deployment/_components/Header.svelte
@@ -312,15 +312,15 @@
 		</div>
 		<div class="masthead__actions">
 			{#if canPause}
-				<span class="inline-flex" title={can('deployment.pause') ? null : denyTooltip('deployment.pause')}>
-					<button class="mast-btn" type="button" disabled={!can('deployment.pause')} aria-disabled={!can('deployment.pause')} onclick={pause}>
+				<span class="inline-flex" title={can('deployment.deploy') ? null : denyTooltip('deployment.deploy')}>
+					<button class="mast-btn" type="button" disabled={!can('deployment.deploy')} aria-disabled={!can('deployment.deploy')} onclick={pause}>
 						<i class="fa-solid fa-pause"></i> Pause
 					</button>
 				</span>
 			{/if}
 			{#if canResume}
-				<span class="inline-flex" title={can('deployment.resume') ? null : denyTooltip('deployment.resume')}>
-					<button class="mast-btn" type="button" disabled={!can('deployment.resume')} aria-disabled={!can('deployment.resume')} onclick={resume}>
+				<span class="inline-flex" title={can('deployment.deploy') ? null : denyTooltip('deployment.deploy')}>
+					<button class="mast-btn" type="button" disabled={!can('deployment.deploy')} aria-disabled={!can('deployment.deploy')} onclick={resume}>
 						<i class="fa-solid fa-play"></i> Resume
 					</button>
 				</span>

--- a/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
@@ -6,6 +6,7 @@
 	import api from '$lib/api'
 	import EnvGroupModal from '$lib/components/EnvGroupModal.svelte'
 	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -934,9 +935,9 @@
 
 		<hr>
 
-		<button class="button mt-4 mr-auto" class:is-loading={saving}>
+		<GuardedButton permission="deployment.deploy" type="submit" class="button mt-4 mr-auto" loading={saving}>
 			Deploy
-		</button>
+		</GuardedButton>
 	{/if}
 	</form>
 </div>

--- a/src/routes/(auth)/(project)/disk/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/disk/(detail)/detail/+page.svelte
@@ -4,6 +4,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -64,11 +65,11 @@
 <hr>
 
 <div class="flex gap-4">
-	<a class="button" href={`/disk/create?project=${project}&location=${location}&name=${name}`}>Update</a>
+	<GuardedButton permission="disk.update" href={`/disk/create?project=${project}&location=${location}&name=${name}`}>Update</GuardedButton>
 </div>
 
 <DangerZone description="Permanently delete this disk. All data stored on it will be lost.">
-	<button class="button is-variant-negative" type="button" onclick={deleteItem}>
+	<GuardedButton permission="disk.delete" class="button is-variant-negative" type="button" onclick={deleteItem}>
 		Delete
-	</button>
+	</GuardedButton>
 </DangerZone>

--- a/src/routes/(auth)/(project)/disk/+page.svelte
+++ b/src/routes/(auth)/(project)/disk/+page.svelte
@@ -1,14 +1,20 @@
 <script>
+	import { getContext } from 'svelte'
 	import StatusIcon from '$lib/components/StatusIcon.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import * as format from '$lib/format'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import { denyTooltip } from '$lib/permission'
 
 	const { data } = $props()
 
 	const project = $derived(data.project)
 	const disks = $derived(data.disks)
 	const error = $derived(data.error)
+
+	/** @type {{ can: (p: string) => boolean }} */
+	const { can } = getContext('permission')
 </script>
 
 <div class="page-head">
@@ -16,10 +22,10 @@
 		<h4><strong>Disks</strong></h4>
 		<p class="page-sub">{disks.length} {disks.length === 1 ? 'disk' : 'disks'}</p>
 	</div>
-	<a class="button is-icon-left" href="/disk/create?project={project}">
+	<GuardedButton permission="disk.create" class="button is-icon-left" href="/disk/create?project={project}">
 		<i class="fa-solid fa-plus"></i>
 		Create
-	</a>
+	</GuardedButton>
 </div>
 <div class="panel is-level-300">
 	<div class="table-container">
@@ -50,11 +56,17 @@
 							<span class="cell-time" title={format.datetime(it.createdAt)}>{format.fromNow(it.createdAt) || '—'}</span>
 						</td>
 						<td>
-							<a href="/disk/create?project={project}&location={it.location}&name={it.name}" aria-label="Edit">
-								<div class="icon-button">
-									<i class="fa-solid fa-pen"></i>
-								</div>
-							</a>
+							<span class="inline-flex" title={can('disk.update') ? null : denyTooltip('disk.update')}>
+								<a
+									class="edit-link"
+									href={can('disk.update') ? `/disk/create?project=${project}&location=${it.location}&name=${it.name}` : undefined}
+									aria-label="Edit"
+									aria-disabled={can('disk.update') ? undefined : 'true'}>
+									<div class="icon-button">
+										<i class="fa-solid fa-pen"></i>
+									</div>
+								</a>
+							</span>
 						</td>
 					</tr>
 				{/each}
@@ -64,3 +76,12 @@
 		</table>
 	</div>
 </div>
+
+<style>
+	/* Denied-state for the Edit link: no navigation, dimmed, non-interactive. */
+	.edit-link[aria-disabled='true'] {
+		cursor: not-allowed;
+		opacity: 0.45;
+		pointer-events: none;
+	}
+</style>

--- a/src/routes/(auth)/(project)/disk/create/+page.svelte
+++ b/src/routes/(auth)/(project)/disk/create/+page.svelte
@@ -4,6 +4,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 	const locations = $derived(data.locations)
@@ -18,6 +19,9 @@
 		name: name || '',
 		size: disk?.size || 1
 	})
+
+	// Edit mode submits disk.update; create mode submits disk.create.
+	const submitPermission = $derived(disk ? 'disk.update' : 'disk.create')
 
 	let saving = $state(false)
 
@@ -106,13 +110,13 @@
 			</div>
 		</div>
 
-		<button class="button mr-auto" class:is-loading={saving}>
+		<GuardedButton permission={submitPermission} type="submit" class="button mr-auto" loading={saving}>
 			{#if disk}
 				Save
 			{:else}
 				Create
 			{/if}
-		</button>
+		</GuardedButton>
 	</form>
 </div>
 

--- a/src/routes/(auth)/(project)/domain/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/+page.svelte
@@ -4,6 +4,7 @@
 	import StatusIcon from '$lib/components/StatusIcon.svelte'
 	import api from '$lib/api'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -35,10 +36,10 @@
 		<h4><strong>Domains</strong></h4>
 		<p class="page-sub">{domains.length} {domains.length === 1 ? 'domain' : 'domains'}</p>
 	</div>
-	<a class="button is-icon-left" href={`/domain/create?project=${project}`}>
+	<GuardedButton permission="domain.create" class="button is-icon-left" href={`/domain/create?project=${project}`}>
 		<i class="fa-solid fa-plus"></i>
 		Create
-	</a>
+	</GuardedButton>
 </div>
 <div class="panel is-level-300">
 	<div class="table-container">
@@ -75,9 +76,9 @@
 <!--						<td>{format.datetime(it.createdAt)}</td>-->
 <!--						<td>{it.createdBy}</td>-->
 						<td>
-							<button class="icon-button" aria-label="Remove" onclick={() => deleteDomain(it)}>
+							<GuardedButton permission="domain.delete" class="icon-button" aria-label="Remove" onclick={() => deleteDomain(it)}>
 								<i class="fa-solid fa-trash-alt"></i>
-							</button>
+							</GuardedButton>
 						</td>
 					</tr>
 				{/each}

--- a/src/routes/(auth)/(project)/domain/create/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/create/+page.svelte
@@ -3,6 +3,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 	const project = $derived(data.project)
@@ -94,7 +95,7 @@
 
 		<hr>
 
-		<button class="button mr-auto" class:is-loading={saving}>Save</button>
+		<GuardedButton permission="domain.create" type="submit" class="button mr-auto" loading={saving}>Save</GuardedButton>
 	</form>
 </div>
 

--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -6,6 +6,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import StatusIcon from '$lib/components/StatusIcon.svelte'
 	import Swal from 'sweetalert2'
 
@@ -781,27 +782,27 @@
 						<strong>Purge everything</strong>
 						<p>Remove all cached resources</p>
 					</div>
-					<button class="button is-variant-secondary" class:is-loading={purging} onclick={purgeCache} disabled={domain.wildcard}>
+					<GuardedButton permission="domain.purgeCache" class="button is-variant-secondary" loading={purging} onclick={purgeCache} disabled={domain.wildcard}>
 						Purge everything
-					</button>
+					</GuardedButton>
 				</div>
 				<div class="purge-row">
 					<div class="purge-row__text">
 						<strong>Purge prefix</strong>
 						<p>Remove cached resources at a prefix path</p>
 					</div>
-					<button class="button is-variant-secondary" class:is-loading={purging} onclick={purgeCachePrefix}>
+					<GuardedButton permission="domain.purgeCache" class="button is-variant-secondary" loading={purging} onclick={purgeCachePrefix}>
 						Purge prefix
-					</button>
+					</GuardedButton>
 				</div>
 				<div class="purge-row">
 					<div class="purge-row__text">
 						<strong>Purge file</strong>
 						<p>Remove cached resources at an exact path</p>
 					</div>
-					<button class="button is-variant-secondary" class:is-loading={purging} onclick={purgeCacheFile}>
+					<GuardedButton permission="domain.purgeCache" class="button is-variant-secondary" loading={purging} onclick={purgeCacheFile}>
 						Purge file
-					</button>
+					</GuardedButton>
 				</div>
 			</section>
 		</div>
@@ -809,7 +810,7 @@
 {/if}
 
 <DangerZone description="Permanently delete this domain. Routing and TLS certificates will be removed.">
-	<button class="button is-variant-negative" type="button" onclick={deleteItem}>
+	<GuardedButton permission="domain.delete" class="button is-variant-negative" type="button" onclick={deleteItem}>
 		Delete
-	</button>
+	</GuardedButton>
 </DangerZone>

--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -782,7 +782,7 @@
 						<strong>Purge everything</strong>
 						<p>Remove all cached resources</p>
 					</div>
-					<GuardedButton permission="domain.purgeCache" class="button is-variant-secondary" loading={purging} onclick={purgeCache} disabled={domain.wildcard}>
+					<GuardedButton permission="domain.purgecache" class="button is-variant-secondary" loading={purging} onclick={purgeCache} disabled={domain.wildcard}>
 						Purge everything
 					</GuardedButton>
 				</div>
@@ -791,7 +791,7 @@
 						<strong>Purge prefix</strong>
 						<p>Remove cached resources at a prefix path</p>
 					</div>
-					<GuardedButton permission="domain.purgeCache" class="button is-variant-secondary" loading={purging} onclick={purgeCachePrefix}>
+					<GuardedButton permission="domain.purgecache" class="button is-variant-secondary" loading={purging} onclick={purgeCachePrefix}>
 						Purge prefix
 					</GuardedButton>
 				</div>
@@ -800,7 +800,7 @@
 						<strong>Purge file</strong>
 						<p>Remove cached resources at an exact path</p>
 					</div>
-					<GuardedButton permission="domain.purgeCache" class="button is-variant-secondary" loading={purging} onclick={purgeCacheFile}>
+					<GuardedButton permission="domain.purgecache" class="button is-variant-secondary" loading={purging} onclick={purgeCacheFile}>
 						Purge file
 					</GuardedButton>
 				</div>

--- a/src/routes/(auth)/(project)/env-group/+page.svelte
+++ b/src/routes/(auth)/(project)/env-group/+page.svelte
@@ -1,7 +1,13 @@
 <script>
+	import { getContext } from 'svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as format from '$lib/format'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import { denyTooltip } from '$lib/permission'
+
+	/** @type {{ can: (p: string) => boolean }} */
+	const { can } = getContext('permission')
 
 	const { data } = $props()
 
@@ -15,10 +21,10 @@
 		<h4><strong>Env Groups</strong></h4>
 		<p class="page-sub">{envGroups.length} {envGroups.length === 1 ? 'env group' : 'env groups'}</p>
 	</div>
-	<a class="button is-icon-left" href="/env-group/create?project={project}">
+	<GuardedButton permission="envGroup.create" class="button is-icon-left" href="/env-group/create?project={project}">
 		<i class="fa-solid fa-plus"></i>
 		Create
-	</a>
+	</GuardedButton>
 </div>
 <div class="panel is-level-300">
 	<div class="table-container">
@@ -44,11 +50,16 @@
 							<span class="cell-time" title={format.datetime(it.createdAt)}>{format.fromNow(it.createdAt) || '—'}</span>
 						</td>
 						<td>
-							<a href="/env-group/create?project={project}&name={it.name}" aria-label="Edit">
-								<div class="icon-button">
-									<i class="fa-solid fa-pen"></i>
-								</div>
-							</a>
+							<span class="inline-flex" title={can('envGroup.update') ? null : denyTooltip('envGroup.update')}>
+								<a
+									href={can('envGroup.update') ? `/env-group/create?project=${project}&name=${it.name}` : null}
+									aria-label="Edit"
+									aria-disabled={can('envGroup.update') ? null : 'true'}>
+									<div class="icon-button">
+										<i class="fa-solid fa-pen"></i>
+									</div>
+								</a>
+							</span>
 						</td>
 					</tr>
 				{/each}

--- a/src/routes/(auth)/(project)/env-group/+page.svelte
+++ b/src/routes/(auth)/(project)/env-group/+page.svelte
@@ -21,7 +21,7 @@
 		<h4><strong>Env Groups</strong></h4>
 		<p class="page-sub">{envGroups.length} {envGroups.length === 1 ? 'env group' : 'env groups'}</p>
 	</div>
-	<GuardedButton permission="envGroup.create" class="button is-icon-left" href="/env-group/create?project={project}">
+	<GuardedButton permission="envgroup.create" class="button is-icon-left" href="/env-group/create?project={project}">
 		<i class="fa-solid fa-plus"></i>
 		Create
 	</GuardedButton>
@@ -50,11 +50,11 @@
 							<span class="cell-time" title={format.datetime(it.createdAt)}>{format.fromNow(it.createdAt) || '—'}</span>
 						</td>
 						<td>
-							<span class="inline-flex" title={can('envGroup.update') ? null : denyTooltip('envGroup.update')}>
+							<span class="inline-flex" title={can('envgroup.update') ? null : denyTooltip('envgroup.update')}>
 								<a
-									href={can('envGroup.update') ? `/env-group/create?project=${project}&name=${it.name}` : null}
+									href={can('envgroup.update') ? `/env-group/create?project=${project}&name=${it.name}` : null}
 									aria-label="Edit"
-									aria-disabled={can('envGroup.update') ? null : 'true'}>
+									aria-disabled={can('envgroup.update') ? null : 'true'}>
 									<div class="icon-button">
 										<i class="fa-solid fa-pen"></i>
 									</div>

--- a/src/routes/(auth)/(project)/env-group/create/+page.svelte
+++ b/src/routes/(auth)/(project)/env-group/create/+page.svelte
@@ -3,6 +3,7 @@
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -32,6 +33,11 @@
 	}
 
 	let saving = $state(false)
+
+	// The submit RPC depends on whether we're editing an existing env group
+	// (envGroup.update) or creating a new one (envGroup.create); gate on the one
+	// the save handler will actually call.
+	const savePermission = $derived(envGroup ? 'envGroup.update' : 'envGroup.create')
 
 	/**
 	 * @param {Event} e
@@ -173,9 +179,9 @@
 		<hr>
 
 		<div class="flex gap-4">
-			<button class="button" class:is-loading={saving}>
+			<GuardedButton permission={savePermission} type="submit" class="button" loading={saving}>
 				{#if envGroup}Update{:else}Create{/if}
-			</button>
+			</GuardedButton>
 		</div>
 	</form>
 </div>

--- a/src/routes/(auth)/(project)/env-group/create/+page.svelte
+++ b/src/routes/(auth)/(project)/env-group/create/+page.svelte
@@ -37,7 +37,7 @@
 	// The submit RPC depends on whether we're editing an existing env group
 	// (envGroup.update) or creating a new one (envGroup.create); gate on the one
 	// the save handler will actually call.
-	const savePermission = $derived(envGroup ? 'envGroup.update' : 'envGroup.create')
+	const savePermission = $derived(envGroup ? 'envgroup.update' : 'envgroup.create')
 
 	/**
 	 * @param {Event} e
@@ -56,7 +56,7 @@
 				return p
 			}, {})
 
-			const fn = envGroup ? 'envGroup.update' : 'envGroup.create'
+			const fn = envGroup ? 'envgroup.update' : 'envgroup.create'
 			const resp = await api.invoke(fn, {
 				project,
 				name: form.name,

--- a/src/routes/(auth)/(project)/env-group/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/env-group/detail/+page.svelte
@@ -4,6 +4,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import Secret from '$lib/components/Secret.svelte'
 
 	const { data } = $props()
@@ -46,11 +47,11 @@
 		<h4 class="min-w-0 wrap-anywhere"><strong>{envGroup.name}</strong></h4>
 		<p class="page-sub">{entries.length} {entries.length === 1 ? 'variable' : 'variables'}</p>
 	</div>
-	<a class="button is-variant-secondary is-icon-left"
+	<GuardedButton permission="envGroup.update" class="button is-variant-secondary is-icon-left"
 		href={`/env-group/create?project=${project}&name=${encodeURIComponent(envGroup.name)}`}>
 		<i class="fa-solid fa-pen"></i>
 		Edit
-	</a>
+	</GuardedButton>
 </div>
 
 <div class="panel is-level-300 grid gap-6">
@@ -116,7 +117,7 @@
 		</div>
 
 		<DangerZone description="Permanently delete this env group. Deployments referencing it may fail to start.">
-			<button class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</button>
+			<GuardedButton permission="envGroup.delete" class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</GuardedButton>
 		</DangerZone>
 	</div>
 </div>

--- a/src/routes/(auth)/(project)/env-group/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/env-group/detail/+page.svelte
@@ -47,7 +47,7 @@
 		<h4 class="min-w-0 wrap-anywhere"><strong>{envGroup.name}</strong></h4>
 		<p class="page-sub">{entries.length} {entries.length === 1 ? 'variable' : 'variables'}</p>
 	</div>
-	<GuardedButton permission="envGroup.update" class="button is-variant-secondary is-icon-left"
+	<GuardedButton permission="envgroup.update" class="button is-variant-secondary is-icon-left"
 		href={`/env-group/create?project=${project}&name=${encodeURIComponent(envGroup.name)}`}>
 		<i class="fa-solid fa-pen"></i>
 		Edit
@@ -117,7 +117,7 @@
 		</div>
 
 		<DangerZone description="Permanently delete this env group. Deployments referencing it may fail to start.">
-			<GuardedButton permission="envGroup.delete" class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</GuardedButton>
+			<GuardedButton permission="envgroup.delete" class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</GuardedButton>
 		</DangerZone>
 	</div>
 </div>

--- a/src/routes/(auth)/(project)/github/+page.svelte
+++ b/src/routes/(auth)/(project)/github/+page.svelte
@@ -5,6 +5,7 @@
 	import Select from '$lib/components/Select.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import * as format from '$lib/format'
 	import { setupCopy } from '$lib/clipboard'
 
@@ -88,10 +89,10 @@ jobs:
 		<p class="page-sub">Build and deploy linked repositories with GitHub Actions — keyless, with pull request previews</p>
 	</div>
 	<div>
-		<a class="button" href={`/github/link?project=${project}`}>
+		<GuardedButton permission="github.link" href={`/github/link?project=${project}`}>
 			<i class="fa-solid fa-link mr-2"></i>
 			Link repository
-		</a>
+		</GuardedButton>
 	</div>
 </div>
 
@@ -135,9 +136,9 @@ jobs:
 							<span class="cell-time" title={format.datetime(it.createdAt)}>{format.fromNow(it.createdAt) || '—'}</span>
 						</td>
 						<td>
-							<button class="icon-button" type="button" aria-label="Unlink repository" onclick={() => unlink(it)}>
+							<GuardedButton permission="github.unlink" class="icon-button" type="button" aria-label="Unlink repository" onclick={() => unlink(it)}>
 								<i class="fa-solid fa-link-slash"></i>
-							</button>
+							</GuardedButton>
 						</td>
 					</tr>
 				{/each}

--- a/src/routes/(auth)/(project)/github/link/+page.js
+++ b/src/routes/(auth)/(project)/github/link/+page.js
@@ -1,7 +1,9 @@
 import api from '$lib/api'
+import { hasPermission } from '$lib/permission'
 
 export async function load ({ parent, url, fetch }) {
-	const { project } = await parent()
+	const parentData = await parent()
+	const { project, permissions, permissionsAdmin } = parentData
 
 	const urlInstallationId = url.searchParams.get('installation_id')
 		? Number(url.searchParams.get('installation_id'))
@@ -24,31 +26,26 @@ export async function load ({ parent, url, fetch }) {
 		serviceAccounts,
 		appInfo,
 		installations,
-		canCreateSaResp,
-		canBindResp,
-		canCreateRoleResp,
 		githubDeployRole
 	] = await Promise.all([
 		api.invoke('github.list', { project }, fetch),
 		api.invoke('serviceAccount.list', { project }, fetch),
 		api.invoke('github.getApp', { project }, fetch),
 		api.invoke('github.listInstallations', { project }, fetch),
-		// Up-front permission probes — me.authorized is a logical AND over the
-		// listed permissions. A failed probe just gates the affordance off; it
-		// must never break the page, so any non-ok response is treated as false.
-		api.invoke('me.authorized', { project, permissions: ['serviceAccount.create'] }, fetch),
-		api.invoke('me.authorized', { project, permissions: ['role.bind'] }, fetch),
-		api.invoke('me.authorized', { project, permissions: ['role.create'] }, fetch),
+		// Still needed to decide whether the shared github-deploy role already
+		// exists (vs. needing role.create to grant it below).
 		api.invoke('role.get', { project, role: 'github-deploy' }, fetch)
 	])
 
-	const canCreateServiceAccount = canCreateSaResp.result?.authorized === true
-	const canBindRole = canBindResp.result?.authorized === true
-	const canCreateRole = canCreateRoleResp.result?.authorized === true
+	// Permission flags come from the project layout's effective grants (me.permissions)
+	// rather than per-affordance me.authorized probes. hasPermission mirrors the
+	// server's wildcard matching, so a denied grant just gates the affordance off.
+	const canCreateServiceAccount = hasPermission(permissions, permissionsAdmin, 'serviceAccount.create')
 	const githubDeployRoleExists = githubDeployRole.ok && !!githubDeployRole.result
 	// Granting the deploy role needs role.bind, plus role.create only when the
 	// shared github-deploy role doesn't exist yet.
-	const canGrantRole = canBindRole && (githubDeployRoleExists || canCreateRole)
+	const canGrantRole = hasPermission(permissions, permissionsAdmin, 'role.bind') &&
+		(githubDeployRoleExists || hasPermission(permissions, permissionsAdmin, 'role.create'))
 
 	// Collect unique installation ids from saved installations + existing links + url param
 	/** @type {Set<number>} */

--- a/src/routes/(auth)/(project)/pull-secret/+page.svelte
+++ b/src/routes/(auth)/(project)/pull-secret/+page.svelte
@@ -3,6 +3,7 @@
 	import StatusIcon from '$lib/components/StatusIcon.svelte'
 	import * as format from '$lib/format'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -16,10 +17,10 @@
 		<h4><strong>Pull Secrets</strong></h4>
 		<p class="page-sub">{pullSecrets.length} {pullSecrets.length === 1 ? 'pull secret' : 'pull secrets'}</p>
 	</div>
-	<a class="button is-icon-left" href="/pull-secret/create?project={project}">
+	<GuardedButton permission="pullSecret.create" class="button is-icon-left" href="/pull-secret/create?project={project}">
 		<i class="fa-solid fa-plus"></i>
 		Create
-	</a>
+	</GuardedButton>
 </div>
 <div class="panel is-level-300">
 	<div class="table-container">

--- a/src/routes/(auth)/(project)/pull-secret/+page.svelte
+++ b/src/routes/(auth)/(project)/pull-secret/+page.svelte
@@ -17,7 +17,7 @@
 		<h4><strong>Pull Secrets</strong></h4>
 		<p class="page-sub">{pullSecrets.length} {pullSecrets.length === 1 ? 'pull secret' : 'pull secrets'}</p>
 	</div>
-	<GuardedButton permission="pullSecret.create" class="button is-icon-left" href="/pull-secret/create?project={project}">
+	<GuardedButton permission="pullsecret.create" class="button is-icon-left" href="/pull-secret/create?project={project}">
 		<i class="fa-solid fa-plus"></i>
 		Create
 	</GuardedButton>

--- a/src/routes/(auth)/(project)/pull-secret/create/+page.svelte
+++ b/src/routes/(auth)/(project)/pull-secret/create/+page.svelte
@@ -4,6 +4,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -114,6 +115,6 @@
 
 		<hr>
 
-		<button class="button mr-auto" class:is-loading={saving}>Save</button>
+		<GuardedButton permission="pullSecret.create" type="submit" class="button mr-auto" loading={saving}>Save</GuardedButton>
 	</form>
 </div>

--- a/src/routes/(auth)/(project)/pull-secret/create/+page.svelte
+++ b/src/routes/(auth)/(project)/pull-secret/create/+page.svelte
@@ -115,6 +115,6 @@
 
 		<hr>
 
-		<GuardedButton permission="pullSecret.create" type="submit" class="button mr-auto" loading={saving}>Save</GuardedButton>
+		<GuardedButton permission="pullsecret.create" type="submit" class="button mr-auto" loading={saving}>Save</GuardedButton>
 	</form>
 </div>

--- a/src/routes/(auth)/(project)/pull-secret/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/pull-secret/detail/+page.svelte
@@ -98,7 +98,7 @@
 		</div>
 
 		<DangerZone description="Permanently delete this pull secret. Deployments using it will fail to pull images.">
-			<GuardedButton permission="pullSecret.delete" class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</GuardedButton>
+			<GuardedButton permission="pullsecret.delete" class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</GuardedButton>
 		</DangerZone>
 	</div>
 </div>

--- a/src/routes/(auth)/(project)/pull-secret/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/pull-secret/detail/+page.svelte
@@ -5,6 +5,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -97,7 +98,7 @@
 		</div>
 
 		<DangerZone description="Permanently delete this pull secret. Deployments using it will fail to pull images.">
-			<button class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</button>
+			<GuardedButton permission="pullSecret.delete" class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</GuardedButton>
 		</DangerZone>
 	</div>
 </div>

--- a/src/routes/(auth)/(project)/registry/(list)/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/(list)/+page.svelte
@@ -1,6 +1,7 @@
 <script>
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 
@@ -55,9 +56,9 @@
 							</a>
 						</td>
 						<td>
-							<button class="icon-button" aria-label="Remove" onclick={() => deleteRepository(repo.name)}>
+							<GuardedButton permission="registry.delete" class="icon-button" aria-label="Remove" onclick={() => deleteRepository(repo.name)}>
 								<i class="fa-solid fa-trash-alt"></i>
-							</button>
+							</GuardedButton>
 						</td>
 					</tr>
 				{/each}

--- a/src/routes/(auth)/(project)/registry/(list)/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/(list)/+page.svelte
@@ -56,7 +56,7 @@
 							</a>
 						</td>
 						<td>
-							<GuardedButton permission="registry.delete" class="icon-button" aria-label="Remove" onclick={() => deleteRepository(repo.name)}>
+							<GuardedButton permission="registry.push" class="icon-button" aria-label="Remove" onclick={() => deleteRepository(repo.name)}>
 								<i class="fa-solid fa-trash-alt"></i>
 							</GuardedButton>
 						</td>

--- a/src/routes/(auth)/(project)/registry/detail/manifests/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/detail/manifests/+page.svelte
@@ -4,6 +4,7 @@
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -42,9 +43,9 @@
 					<td>{format.shortDigest(manifest.digest)}</td>
 					<td>{format.datetime(manifest.createdAt)}</td>
 					<td>
-						<button class="icon-button" aria-label="Delete" onclick={() => deleteManifest(manifest.digest)}>
+						<GuardedButton permission="registry.deleteManifest" class="icon-button" aria-label="Delete" onclick={() => deleteManifest(manifest.digest)}>
 							<i class="fa-solid fa-trash-alt"></i>
-						</button>
+						</GuardedButton>
 					</td>
 				</tr>
 			{/each}

--- a/src/routes/(auth)/(project)/registry/detail/manifests/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/detail/manifests/+page.svelte
@@ -43,7 +43,7 @@
 					<td>{format.shortDigest(manifest.digest)}</td>
 					<td>{format.datetime(manifest.createdAt)}</td>
 					<td>
-						<GuardedButton permission="registry.deleteManifest" class="icon-button" aria-label="Delete" onclick={() => deleteManifest(manifest.digest)}>
+						<GuardedButton permission="registry.push" class="icon-button" aria-label="Delete" onclick={() => deleteManifest(manifest.digest)}>
 							<i class="fa-solid fa-trash-alt"></i>
 						</GuardedButton>
 					</td>

--- a/src/routes/(auth)/(project)/registry/detail/tags/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/detail/tags/+page.svelte
@@ -3,6 +3,7 @@
 	import { onMount } from 'svelte'
 	import { setupCopy } from '$lib/clipboard'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
@@ -61,9 +62,9 @@
 					</td>
 					<td>{format.datetime(tag.createdAt)}</td>
 					<td>
-						<button class="icon-button" aria-label="Untag" onclick={() => untagTag(tag.tag)}>
+						<GuardedButton permission="registry.untag" class="icon-button" aria-label="Untag" onclick={() => untagTag(tag.tag)}>
 							<i class="fa-solid fa-trash-alt"></i>
-						</button>
+						</GuardedButton>
 					</td>
 				</tr>
 			{/each}

--- a/src/routes/(auth)/(project)/registry/detail/tags/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/detail/tags/+page.svelte
@@ -62,7 +62,7 @@
 					</td>
 					<td>{format.datetime(tag.createdAt)}</td>
 					<td>
-						<GuardedButton permission="registry.untag" class="icon-button" aria-label="Untag" onclick={() => untagTag(tag.tag)}>
+						<GuardedButton permission="registry.push" class="icon-button" aria-label="Untag" onclick={() => untagTag(tag.tag)}>
 							<i class="fa-solid fa-trash-alt"></i>
 						</GuardedButton>
 					</td>

--- a/src/routes/(auth)/(project)/role/+page.svelte
+++ b/src/routes/(auth)/(project)/role/+page.svelte
@@ -2,6 +2,7 @@
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as format from '$lib/format'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -22,10 +23,10 @@
 		<h4><strong>Roles</strong></h4>
 		<p class="page-sub">{roles.length} {roles.length === 1 ? 'role' : 'roles'}</p>
 	</div>
-	<a class="button is-icon-left" href="/role/create?project={project}">
+	<GuardedButton permission="role.create" class="button is-icon-left" href="/role/create?project={project}">
 		<i class="fa-solid fa-plus"></i>
 		Create
-	</a>
+	</GuardedButton>
 </div>
 <div class="panel is-level-300">
 	<div class="table-container">
@@ -52,11 +53,11 @@
 						</td>
 						<td>
 							{#if roleCanUpdate(it.role)}
-								<a href="/role/create?project={project}&role={it.role}" aria-label="Edit">
+								<GuardedButton permission="role.create" class="contents" href="/role/create?project={project}&role={it.role}" aria-label="Edit">
 									<div class="icon-button">
 										<i class="fa-solid fa-pen"></i>
 									</div>
-								</a>
+								</GuardedButton>
 							{:else}
 								<!-- Reserve the icon-button's footprint so rows without an
 								     edit action keep the same height as the others. -->

--- a/src/routes/(auth)/(project)/role/bind/+page.svelte
+++ b/src/routes/(auth)/(project)/role/bind/+page.svelte
@@ -3,6 +3,7 @@
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import Select from '$lib/components/Select.svelte'
 
@@ -158,8 +159,8 @@
 			</table>
 		</div>
 
-		<button class="button mt-4 mr-auto" class:is-loading={saving}>
+		<GuardedButton permission="role.bind" type="submit" class="button mt-4 mr-auto" loading={saving}>
 			Save
-		</button>
+		</GuardedButton>
 	</form>
 </div>

--- a/src/routes/(auth)/(project)/role/create/+page.svelte
+++ b/src/routes/(auth)/(project)/role/create/+page.svelte
@@ -5,6 +5,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 	const role = $derived(data.role)
@@ -152,9 +153,9 @@
 		<hr>
 
 		<div class="flex gap-4">
-			<button class="button" class:is-loading={saving}>
+			<GuardedButton permission="role.create" type="submit" class="button" loading={saving}>
 				{#if role}Update{:else}Create{/if}
-			</button>
+			</GuardedButton>
 		</div>
 	</form>
 </div>

--- a/src/routes/(auth)/(project)/role/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/role/detail/+page.svelte
@@ -4,6 +4,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -48,11 +49,12 @@
 		<p class="page-sub">{role.name}</p>
 	</div>
 	{#if canUpdate}
-		<a class="button is-variant-secondary is-icon-left"
+		<GuardedButton permission="role.create"
+			class="button is-variant-secondary is-icon-left"
 			href={`/role/create?project=${project}&role=${encodeURIComponent(role.role)}`}>
 			<i class="fa-solid fa-pen"></i>
 			Edit
-		</a>
+		</GuardedButton>
 	{/if}
 </div>
 
@@ -156,7 +158,7 @@
 
 		{#if canUpdate}
 			<DangerZone description="Permanently delete this role. Members assigned only this role will lose their access.">
-				<button class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</button>
+				<GuardedButton permission="role.delete" class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</GuardedButton>
 			</DangerZone>
 		{/if}
 	</div>

--- a/src/routes/(auth)/(project)/role/users/+page.svelte
+++ b/src/routes/(auth)/(project)/role/users/+page.svelte
@@ -1,11 +1,17 @@
 <script>
+	import { getContext } from 'svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import { denyTooltip } from '$lib/permission'
 	import gravatarUrl from 'gravatar-url'
 
 	const { data } = $props()
+
+	/** @type {{ can: (p: string) => boolean }} */
+	const { can } = getContext('permission')
 
 	const project = $derived(data.project)
 	const users = $derived(data.users)
@@ -112,10 +118,10 @@
 		<h4><strong>Users</strong></h4>
 		<p class="page-sub">{users.length} {users.length === 1 ? 'user' : 'users'}</p>
 	</div>
-	<a class="button is-icon-left" href="/role/bind?project={project}">
+	<GuardedButton permission="role.bind" class="button is-icon-left" href="/role/bind?project={project}">
 		<i class="fa-solid fa-plus"></i>
 		Add
-	</a>
+	</GuardedButton>
 </div>
 <div class="panel is-level-300">
 	<div class="table-container">
@@ -155,14 +161,22 @@
 							{/if}
 						</td>
 						<td>
-							<a href="/role/bind?project={project}&email={it.email}" aria-label="Edit">
-								<div class="icon-button">
-									<i class="fa-solid fa-pen"></i>
-								</div>
-							</a>
-							<button class="icon-button" aria-label="Remove" onclick={() => deleteUser(it.email)}>
+							{#if can('role.bind')}
+								<a href="/role/bind?project={project}&email={it.email}" aria-label="Edit">
+									<div class="icon-button">
+										<i class="fa-solid fa-pen"></i>
+									</div>
+								</a>
+							{:else}
+								<span class="inline-flex" title={denyTooltip('role.bind')}>
+									<button class="icon-button" type="button" aria-label="Edit" disabled aria-disabled="true">
+										<i class="fa-solid fa-pen"></i>
+									</button>
+								</span>
+							{/if}
+							<GuardedButton permission="role.bind" class="icon-button" aria-label="Remove" onclick={() => deleteUser(it.email)}>
 								<i class="fa-solid fa-trash-alt"></i>
-							</button>
+							</GuardedButton>
 						</td>
 					</tr>
 				{/each}

--- a/src/routes/(auth)/(project)/route/+page.svelte
+++ b/src/routes/(auth)/(project)/route/+page.svelte
@@ -69,7 +69,7 @@
 		<h4><strong>Routes</strong></h4>
 		<p class="page-sub">{routes.length} {routes.length === 1 ? 'route' : 'routes'}</p>
 	</div>
-	<GuardedButton permission="route.createV2" class="button is-icon-left" href={`/route/create?project=${project}`}>
+	<GuardedButton permission="route.create" class="button is-icon-left" href={`/route/create?project=${project}`}>
 		<i class="fa-solid fa-plus"></i>
 		Create
 	</GuardedButton>

--- a/src/routes/(auth)/(project)/route/+page.svelte
+++ b/src/routes/(auth)/(project)/route/+page.svelte
@@ -1,9 +1,15 @@
 <script>
+	import { getContext } from 'svelte'
 	import { goto } from '$app/navigation'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import { denyTooltip } from '$lib/permission'
+
+	/** @type {{ can: (p: string) => boolean }} */
+	const { can } = getContext('permission')
 
 	const { data } = $props()
 
@@ -63,10 +69,10 @@
 		<h4><strong>Routes</strong></h4>
 		<p class="page-sub">{routes.length} {routes.length === 1 ? 'route' : 'routes'}</p>
 	</div>
-	<a class="button is-icon-left" href={`/route/create?project=${project}`}>
+	<GuardedButton permission="route.createV2" class="button is-icon-left" href={`/route/create?project=${project}`}>
 		<i class="fa-solid fa-plus"></i>
 		Create
-	</a>
+	</GuardedButton>
 </div>
 <div class="panel is-level-300">
 	<div class="table-container">
@@ -110,10 +116,13 @@
 								   onclick={(e) => e.stopPropagation()}>
 									<i class="fa-solid fa-arrow-up-right-from-square"></i>
 								</a>
-								<button class="icon-button" type="button" aria-label="Remove"
-									onclick={(e) => { e.stopPropagation(); deleteRoute(it) }}>
-									<i class="fa-solid fa-trash-alt"></i>
-								</button>
+								<span class="inline-flex" title={can('route.delete') ? null : denyTooltip('route.delete')}>
+									<button class="icon-button" type="button" aria-label="Remove"
+										disabled={!can('route.delete')}
+										onclick={(e) => { e.stopPropagation(); deleteRoute(it) }}>
+										<i class="fa-solid fa-trash-alt"></i>
+									</button>
+								</span>
 							</div>
 						</td>
 					</tr>

--- a/src/routes/(auth)/(project)/route/create/+page.svelte
+++ b/src/routes/(auth)/(project)/route/create/+page.svelte
@@ -3,6 +3,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -273,7 +274,7 @@
 
 			<hr>
 
-			<button class="button mr-auto" class:is-loading={saving}>Save</button>
+			<GuardedButton permission="route.createV2" type="submit" class="button mr-auto" loading={saving}>Save</GuardedButton>
 		{/if}
 	</form>
 </div>

--- a/src/routes/(auth)/(project)/route/create/+page.svelte
+++ b/src/routes/(auth)/(project)/route/create/+page.svelte
@@ -274,7 +274,7 @@
 
 			<hr>
 
-			<GuardedButton permission="route.createV2" type="submit" class="button mr-auto" loading={saving}>Save</GuardedButton>
+			<GuardedButton permission="route.create" type="submit" class="button mr-auto" loading={saving}>Save</GuardedButton>
 		{/if}
 	</form>
 </div>

--- a/src/routes/(auth)/(project)/route/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/route/edit/+page.svelte
@@ -338,7 +338,7 @@
 		<hr>
 
 		<div class="flex gap-3">
-			<GuardedButton permission="route.createV2" type="submit" loading={saving}>Save</GuardedButton>
+			<GuardedButton permission="route.create" type="submit" loading={saving}>Save</GuardedButton>
 			<a class="button is-variant-tertiary" href={detailUrl}>Cancel</a>
 		</div>
 	</form>

--- a/src/routes/(auth)/(project)/route/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/route/edit/+page.svelte
@@ -4,6 +4,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -337,7 +338,7 @@
 		<hr>
 
 		<div class="flex gap-3">
-			<button class="button" class:is-loading={saving}>Save</button>
+			<GuardedButton permission="route.createV2" type="submit" loading={saving}>Save</GuardedButton>
 			<a class="button is-variant-tertiary" href={detailUrl}>Cancel</a>
 		</div>
 	</form>

--- a/src/routes/(auth)/(project)/route/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/route/manage/+page.svelte
@@ -6,6 +6,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -402,10 +403,10 @@
 			<i class="fa-solid fa-arrow-up-right-from-square"></i>
 			Visit
 		</a>
-		<a class="button is-icon-left" href={`/route/edit?${params}`}>
+		<GuardedButton permission="route.createV2" class="button is-icon-left" href={`/route/edit?${params}`}>
 			<i class="fa-solid fa-pencil"></i>
 			Edit
-		</a>
+		</GuardedButton>
 	</div>
 </div>
 
@@ -591,5 +592,5 @@
 </div>
 
 <DangerZone description="Delete this route. Traffic to this domain path stops being forwarded.">
-	<button class="button is-variant-negative" type="button" onclick={deleteRoute}>Delete route</button>
+	<GuardedButton permission="route.delete" class="button is-variant-negative" type="button" onclick={deleteRoute}>Delete route</GuardedButton>
 </DangerZone>

--- a/src/routes/(auth)/(project)/route/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/route/manage/+page.svelte
@@ -403,7 +403,7 @@
 			<i class="fa-solid fa-arrow-up-right-from-square"></i>
 			Visit
 		</a>
-		<GuardedButton permission="route.createV2" class="button is-icon-left" href={`/route/edit?${params}`}>
+		<GuardedButton permission="route.create" class="button is-icon-left" href={`/route/edit?${params}`}>
 			<i class="fa-solid fa-pencil"></i>
 			Edit
 		</GuardedButton>

--- a/src/routes/(auth)/(project)/service-account/+page.svelte
+++ b/src/routes/(auth)/(project)/service-account/+page.svelte
@@ -2,6 +2,7 @@
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as format from '$lib/format'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -15,10 +16,10 @@
 		<h4><strong>Service Accounts</strong></h4>
 		<p class="page-sub">{serviceAccounts.length} {serviceAccounts.length === 1 ? 'service account' : 'service accounts'}</p>
 	</div>
-	<a class="button is-icon-left" href="/service-account/create?project={project}">
+	<GuardedButton permission="serviceAccount.create" class="button is-icon-left" href="/service-account/create?project={project}">
 		<i class="fa-solid fa-plus"></i>
 		Create
-	</a>
+	</GuardedButton>
 </div>
 <div class="panel is-level-300">
 	<div class="table-container">
@@ -44,11 +45,11 @@
 							<span class="cell-time" title={format.datetime(it.createdAt)}>{format.fromNow(it.createdAt) || '—'}</span>
 						</td>
 						<td>
-							<a href="/service-account/create?project={project}&id={it.sid}" aria-label="Edit">
+							<GuardedButton permission="serviceAccount.update" class="" href="/service-account/create?project={project}&id={it.sid}" aria-label="Edit">
 								<div class="icon-button">
 									<i class="fa-solid fa-pen"></i>
 								</div>
-							</a>
+							</GuardedButton>
 						</td>
 					</tr>
 				{/each}

--- a/src/routes/(auth)/(project)/service-account/+page.svelte
+++ b/src/routes/(auth)/(project)/service-account/+page.svelte
@@ -16,7 +16,7 @@
 		<h4><strong>Service Accounts</strong></h4>
 		<p class="page-sub">{serviceAccounts.length} {serviceAccounts.length === 1 ? 'service account' : 'service accounts'}</p>
 	</div>
-	<GuardedButton permission="serviceAccount.create" class="button is-icon-left" href="/service-account/create?project={project}">
+	<GuardedButton permission="serviceaccount.create" class="button is-icon-left" href="/service-account/create?project={project}">
 		<i class="fa-solid fa-plus"></i>
 		Create
 	</GuardedButton>
@@ -45,7 +45,7 @@
 							<span class="cell-time" title={format.datetime(it.createdAt)}>{format.fromNow(it.createdAt) || '—'}</span>
 						</td>
 						<td>
-							<GuardedButton permission="serviceAccount.update" class="" href="/service-account/create?project={project}&id={it.sid}" aria-label="Edit">
+							<GuardedButton permission="serviceaccount.create" class="" href="/service-account/create?project={project}&id={it.sid}" aria-label="Edit">
 								<div class="icon-button">
 									<i class="fa-solid fa-pen"></i>
 								</div>

--- a/src/routes/(auth)/(project)/service-account/create/+page.svelte
+++ b/src/routes/(auth)/(project)/service-account/create/+page.svelte
@@ -107,7 +107,7 @@
 		</div>
 
 		<GuardedButton
-			permission={id ? 'serviceAccount.update' : 'serviceAccount.create'}
+			permission="serviceaccount.create"
 			type="submit"
 			class="button mr-auto"
 			loading={saving}

--- a/src/routes/(auth)/(project)/service-account/create/+page.svelte
+++ b/src/routes/(auth)/(project)/service-account/create/+page.svelte
@@ -3,6 +3,7 @@
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 	const id = $derived(data.id)
@@ -105,6 +106,11 @@
 			</div>
 		</div>
 
-		<button class="button mr-auto" class:is-loading={saving} disabled={saving}>Save</button>
+		<GuardedButton
+			permission={id ? 'serviceAccount.update' : 'serviceAccount.create'}
+			type="submit"
+			class="button mr-auto"
+			loading={saving}
+			disabled={saving}>Save</GuardedButton>
 	</form>
 </div>

--- a/src/routes/(auth)/(project)/service-account/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/service-account/detail/+page.svelte
@@ -1,11 +1,16 @@
 <script>
-	import { onMount } from 'svelte'
+	import { onMount, getContext } from 'svelte'
 	import { goto } from '$app/navigation'
 	import * as format from '$lib/format'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import { setupCopy } from '$lib/clipboard'
+	import { denyTooltip } from '$lib/permission'
+
+	/** @type {{ can: (p: string) => boolean }} */
+	const { can } = getContext('permission')
 
 	onMount(() => setupCopy('.copy'))
 
@@ -131,24 +136,26 @@
 							<i class="fa-light fa-copy"></i>
 						</span>
 					</div>
-					<button class="icon" onclick={() => deleteKey(key.secret)} type="button" aria-label="Delete">
+					<GuardedButton permission="serviceAccount.deleteKey" class="icon" onclick={() => deleteKey(key.secret)} type="button" aria-label="Delete">
 						<i class="fa-solid fa-trash-alt"></i>
-					</button>
+					</GuardedButton>
 				</div>
 			{/each}
 
 			<div class="grid gap-4 w-full">
-				<button class="button mx-auto" class:loading={loadingCreateKey} onclick={createKey} disabled={loadingCreateKey} type="button">
-					<i class="fa-solid fa-plus mr-3"></i>
-					Create key
-				</button>
+				<span class="inline-flex mx-auto" title={can('serviceAccount.createKey') ? null : denyTooltip('serviceAccount.createKey')}>
+					<button class="button" class:loading={loadingCreateKey} onclick={createKey} disabled={!can('serviceAccount.createKey') || loadingCreateKey} type="button">
+						<i class="fa-solid fa-plus mr-3"></i>
+						Create key
+					</button>
+				</span>
 			</div>
 		</div>
 
 		<DangerZone description="Permanently delete this service account and revoke all of its keys.">
-			<button class="button is-variant-negative" type="button" onclick={deleteItem}>
+			<GuardedButton permission="serviceAccount.delete" class="button is-variant-negative" type="button" onclick={deleteItem}>
 				Delete
-			</button>
+			</GuardedButton>
 		</DangerZone>
 	</div>
 </div>

--- a/src/routes/(auth)/(project)/service-account/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/service-account/detail/+page.svelte
@@ -136,15 +136,15 @@
 							<i class="fa-light fa-copy"></i>
 						</span>
 					</div>
-					<GuardedButton permission="serviceAccount.deleteKey" class="icon" onclick={() => deleteKey(key.secret)} type="button" aria-label="Delete">
+					<GuardedButton permission="serviceaccount.key.delete" class="icon" onclick={() => deleteKey(key.secret)} type="button" aria-label="Delete">
 						<i class="fa-solid fa-trash-alt"></i>
 					</GuardedButton>
 				</div>
 			{/each}
 
 			<div class="grid gap-4 w-full">
-				<span class="inline-flex mx-auto" title={can('serviceAccount.createKey') ? null : denyTooltip('serviceAccount.createKey')}>
-					<button class="button" class:loading={loadingCreateKey} onclick={createKey} disabled={!can('serviceAccount.createKey') || loadingCreateKey} type="button">
+				<span class="inline-flex mx-auto" title={can('serviceaccount.key.create') ? null : denyTooltip('serviceaccount.key.create')}>
+					<button class="button" class:loading={loadingCreateKey} onclick={createKey} disabled={!can('serviceaccount.key.create') || loadingCreateKey} type="button">
 						<i class="fa-solid fa-plus mr-3"></i>
 						Create key
 					</button>
@@ -153,7 +153,7 @@
 		</div>
 
 		<DangerZone description="Permanently delete this service account and revoke all of its keys.">
-			<GuardedButton permission="serviceAccount.delete" class="button is-variant-negative" type="button" onclick={deleteItem}>
+			<GuardedButton permission="serviceaccount.delete" class="button is-variant-negative" type="button" onclick={deleteItem}>
 				Delete
 			</GuardedButton>
 		</DangerZone>

--- a/src/routes/(auth)/(project)/waf/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/+page.svelte
@@ -2,6 +2,7 @@
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import Sparkline from '$lib/components/Sparkline.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import { onMount } from 'svelte'
 	import api from '$lib/api'
 	import * as format from '$lib/format'
@@ -82,10 +83,10 @@
 			{firewalls.length} {firewalls.length === 1 ? 'firewall' : 'firewalls'}
 		</p>
 	</div>
-	<a class="button is-icon-left" href={`/waf/create?project=${project}`}>
+	<GuardedButton permission="waf.set" class="button is-icon-left" href={`/waf/create?project=${project}`}>
 		<i class="fa-solid fa-plus"></i>
 		Create firewall
-	</a>
+	</GuardedButton>
 </div>
 
 <div class="panel is-level-300">

--- a/src/routes/(auth)/(project)/waf/create/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/create/+page.svelte
@@ -3,6 +3,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -90,7 +91,7 @@
 			<hr>
 
 			<div class="flex gap-3">
-				<button class="button" class:is-loading={saving}>Save</button>
+				<GuardedButton permission="waf.set" type="submit" loading={saving}>Save</GuardedButton>
 				<button type="button" class="button is-variant-secondary" onclick={cancel}>Cancel</button>
 			</div>
 		</form>

--- a/src/routes/(auth)/(project)/waf/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/edit/+page.svelte
@@ -4,6 +4,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import WafConditionBuilder from '$lib/components/WafConditionBuilder.svelte'
 	import { parseExpression } from '$lib/waf/expression'
 	import {
@@ -283,8 +284,8 @@
 		<hr>
 
 		<div class="flex items-center gap-3">
-			<button class="button" class:is-loading={saving} disabled={saving || !hasCondition}
-				title={hasCondition ? undefined : 'Add at least one condition before saving'}>Save</button>
+			<GuardedButton permission="waf.set" type="submit" loading={saving} disabled={saving || !hasCondition}
+				title={hasCondition ? undefined : 'Add at least one condition before saving'}>Save</GuardedButton>
 			<button type="button" class="button is-variant-secondary" onclick={cancel}>Cancel</button>
 			{#if !hasCondition}
 				<p class="text-content/50 text-sm">Configure at least one condition to save this rule.</p>

--- a/src/routes/(auth)/(project)/waf/limit/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/limit/+page.svelte
@@ -4,6 +4,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import WafConditionBuilder from '$lib/components/WafConditionBuilder.svelte'
 	import { parseExpression } from '$lib/waf/expression'
 	import { normalizeRules, toApiRules } from '$lib/waf/rules'
@@ -399,8 +400,8 @@
 		<hr>
 
 		<div class="flex items-center gap-3">
-			<button class="button" class:is-loading={saving} disabled={saving || !canSave}
-				title={canSave ? undefined : 'Set a rate, window, and complete every key characteristic before saving'}>Save</button>
+			<GuardedButton permission="waf.set" type="submit" loading={saving} disabled={saving || !canSave}
+				title={canSave ? undefined : 'Set a rate, window, and complete every key characteristic before saving'}>Save</GuardedButton>
 			<button type="button" class="button is-variant-secondary" onclick={cancel}>Cancel</button>
 			{#if !canSave}
 				<p class="text-content/50 text-sm">

--- a/src/routes/(auth)/(project)/waf/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/manage/+page.svelte
@@ -4,6 +4,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import { actionLabels, normalizeRules, toApiRules } from '$lib/waf/rules'
 	import { describeKey, keyRowToApi, modeLabels, normalizeLimits, toApiLimits } from '$lib/waf/limits'
 
@@ -208,10 +209,10 @@
 				<input id="input-description" bind:value={description} placeholder="Optional description">
 			</div>
 			<div class="flex justify-self-start mt-2">
-				<button type="button" class="button is-variant-secondary is-size-small"
-					class:is-loading={savingDescription} onclick={saveDescription}>
+				<GuardedButton permission="waf.set" class="button is-variant-secondary is-size-small"
+					loading={savingDescription} onclick={saveDescription}>
 					Save
-				</button>
+				</GuardedButton>
 			</div>
 		</div>
 
@@ -259,22 +260,22 @@
 							</td>
 							<td>
 								<div class="flex gap-1 justify-end">
-									<button class="icon-button" type="button" aria-label="Edit rule"
+									<GuardedButton permission="waf.set" class="icon-button" aria-label="Edit rule"
 										onclick={() => editRule(rule)}>
 										<i class="fa-solid fa-pencil"></i>
-									</button>
-									<button class="icon-button" type="button" aria-label="Move rule up"
+									</GuardedButton>
+									<GuardedButton permission="waf.set" class="icon-button" aria-label="Move rule up"
 										disabled={i === 0} onclick={() => moveRule(i, -1)}>
 										<i class="fa-solid fa-chevron-up"></i>
-									</button>
-									<button class="icon-button" type="button" aria-label="Move rule down"
+									</GuardedButton>
+									<GuardedButton permission="waf.set" class="icon-button" aria-label="Move rule down"
 										disabled={i === rules.length - 1} onclick={() => moveRule(i, 1)}>
 										<i class="fa-solid fa-chevron-down"></i>
-									</button>
-									<button class="icon-button" type="button" aria-label="Remove rule"
+									</GuardedButton>
+									<GuardedButton permission="waf.set" class="icon-button" aria-label="Remove rule"
 										onclick={() => removeRule(i)}>
 										<i class="fa-solid fa-trash-alt"></i>
-									</button>
+									</GuardedButton>
 								</div>
 							</td>
 						</tr>
@@ -290,11 +291,11 @@
 				<tfoot>
 					<tr>
 						<td colspan="4">
-							<button class="button is-variant-secondary flex m-auto" type="button"
+							<GuardedButton permission="waf.set" class="button is-variant-secondary flex m-auto"
 								onclick={addRule}>
 								<i class="fa-solid fa-plus mr-3"></i>
 								<span>Add Rule</span>
-							</button>
+							</GuardedButton>
 						</td>
 					</tr>
 				</tfoot>
@@ -352,14 +353,14 @@
 							</td>
 							<td>
 								<div class="flex gap-1 justify-end">
-									<button class="icon-button" type="button" aria-label="Edit rate limit"
+									<GuardedButton permission="waf.set" class="icon-button" aria-label="Edit rate limit"
 										onclick={() => editLimit(limit)}>
 										<i class="fa-solid fa-pencil"></i>
-									</button>
-									<button class="icon-button" type="button" aria-label="Remove rate limit"
+									</GuardedButton>
+									<GuardedButton permission="waf.set" class="icon-button" aria-label="Remove rate limit"
 										onclick={() => removeLimit(i)}>
 										<i class="fa-solid fa-trash-alt"></i>
-									</button>
+									</GuardedButton>
 								</div>
 							</td>
 						</tr>
@@ -375,11 +376,11 @@
 				<tfoot>
 					<tr>
 						<td colspan="5">
-							<button class="button is-variant-secondary flex m-auto" type="button"
+							<GuardedButton permission="waf.set" class="button is-variant-secondary flex m-auto"
 								onclick={addLimit}>
 								<i class="fa-solid fa-plus mr-3"></i>
 								<span>Add Limit</span>
-							</button>
+							</GuardedButton>
 						</td>
 					</tr>
 				</tfoot>
@@ -387,7 +388,7 @@
 		</div>
 
 		<DangerZone description="Disable the firewall in this location and permanently remove all of its rules and rate limits.">
-			<button class="button is-variant-negative" type="button" onclick={deleteZone}>Disable firewall</button>
+			<GuardedButton permission="waf.delete" class="button is-variant-negative" onclick={deleteZone}>Disable firewall</GuardedButton>
 		</DangerZone>
 	</div>
 </div>

--- a/src/routes/(auth)/(project)/workload-identity/+page.svelte
+++ b/src/routes/(auth)/(project)/workload-identity/+page.svelte
@@ -17,7 +17,7 @@
 		<h4><strong>Workload Identities</strong></h4>
 		<p class="page-sub">{workloadIdentities.length} {workloadIdentities.length === 1 ? 'workload identity' : 'workload identities'}</p>
 	</div>
-	<GuardedButton permission="workloadIdentity.create" class="button is-icon-left" href="/workload-identity/create?project={project}">
+	<GuardedButton permission="workloadidentity.create" class="button is-icon-left" href="/workload-identity/create?project={project}">
 		<i class="fa-solid fa-plus"></i>
 		Create
 	</GuardedButton>

--- a/src/routes/(auth)/(project)/workload-identity/+page.svelte
+++ b/src/routes/(auth)/(project)/workload-identity/+page.svelte
@@ -3,6 +3,7 @@
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as format from '$lib/format'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -16,10 +17,10 @@
 		<h4><strong>Workload Identities</strong></h4>
 		<p class="page-sub">{workloadIdentities.length} {workloadIdentities.length === 1 ? 'workload identity' : 'workload identities'}</p>
 	</div>
-	<a class="button is-icon-left" href="/workload-identity/create?project={project}">
+	<GuardedButton permission="workloadIdentity.create" class="button is-icon-left" href="/workload-identity/create?project={project}">
 		<i class="fa-solid fa-plus"></i>
 		Create
-	</a>
+	</GuardedButton>
 </div>
 <div class="panel is-level-300">
 	<div class="table-container">

--- a/src/routes/(auth)/(project)/workload-identity/create/+page.svelte
+++ b/src/routes/(auth)/(project)/workload-identity/create/+page.svelte
@@ -3,6 +3,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -88,6 +89,6 @@
 			</div>
 		</div>
 		<hr>
-		<button class="button mr-auto" class:is-loading={saving}>Create</button>
+		<GuardedButton permission="workloadIdentity.create" type="submit" class="button mr-auto" loading={saving}>Create</GuardedButton>
 	</form>
 </div>

--- a/src/routes/(auth)/(project)/workload-identity/create/+page.svelte
+++ b/src/routes/(auth)/(project)/workload-identity/create/+page.svelte
@@ -89,6 +89,6 @@
 			</div>
 		</div>
 		<hr>
-		<GuardedButton permission="workloadIdentity.create" type="submit" class="button mr-auto" loading={saving}>Create</GuardedButton>
+		<GuardedButton permission="workloadidentity.create" type="submit" class="button mr-auto" loading={saving}>Create</GuardedButton>
 	</form>
 </div>

--- a/src/routes/(auth)/(project)/workload-identity/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/workload-identity/detail/+page.svelte
@@ -6,6 +6,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
 
@@ -95,7 +96,7 @@
 		</div>
 
 		<DangerZone description="Permanently delete this workload identity. Deployments using it will lose GCP access.">
-			<button class="button is-variant-negative" onclick={deleteItem}>Delete</button>
+			<GuardedButton permission="workloadIdentity.delete" class="button is-variant-negative" onclick={deleteItem}>Delete</GuardedButton>
 		</DangerZone>
 	</div>
 </div>

--- a/src/routes/(auth)/(project)/workload-identity/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/workload-identity/detail/+page.svelte
@@ -96,7 +96,7 @@
 		</div>
 
 		<DangerZone description="Permanently delete this workload identity. Deployments using it will lose GCP access.">
-			<GuardedButton permission="workloadIdentity.delete" class="button is-variant-negative" onclick={deleteItem}>Delete</GuardedButton>
+			<GuardedButton permission="workloadidentity.delete" class="button is-variant-negative" onclick={deleteItem}>Delete</GuardedButton>
 		</DangerZone>
 	</div>
 </div>

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -48,6 +48,13 @@ export function defaultMocks () {
 			ok: true,
 			result: { authorized: true }
 		},
+		// Effective grants used by the (project) layout to drive GuardedButton.
+		// Default to the '*' wildcard (full access) so action buttons render
+		// enabled; tests that need a denied state override with a restricted set.
+		'/me.permissions': {
+			ok: true,
+			result: { permissions: ['*'], admin: false }
+		},
 		'/project.list': {
 			ok: true,
 			result: { items: [defaultProject] }

--- a/tests/github.spec.js
+++ b/tests/github.spec.js
@@ -432,9 +432,11 @@ test.describe('github link page', () => {
 
 	test('when role perms are denied the grant checkbox is disabled/unchecked with a note, and Create & select skips role.bind', async ({ page }) => {
 		await mocks({
-			// Deny role.bind and role.create up front; serviceAccount.create stays
-			// authorized so the "New" button is still enabled.
-			'me.authorized': { ok: true, result: {}, __authorizedDeny: ['role.bind', 'role.create'] },
+			// Deny role.bind and role.create via the effective grant set; keep
+			// serviceAccount.create so the "New" button is still enabled. The
+			// (project) layout reads me.permissions during SSR load() to drive the
+			// gating, so denying here gates the grant path off.
+			'me.permissions': { ok: true, result: { permissions: ['serviceAccount.create', 'role.get'], admin: false } },
 			'serviceAccount.create': { ok: true, result: {} }
 		})
 
@@ -472,8 +474,10 @@ test.describe('github link page', () => {
 
 	test('when serviceAccount.create is denied the "New" button is disabled', async ({ page }) => {
 		await mocks({
-			// Deny serviceAccount.create only — the other probes stay authorized.
-			'me.authorized': { ok: true, result: {}, __authorizedDeny: ['serviceAccount.create'] }
+			// Deny serviceAccount.create via the effective grant set; keep the
+			// role grants so only the "New" button is gated off. The (project)
+			// layout reads me.permissions during SSR load() to drive the gating.
+			'me.permissions': { ok: true, result: { permissions: ['role.bind', 'role.create', 'role.get'], admin: false } }
 		})
 
 		await page.goto('/github/link?project=test-project')

--- a/tests/permission.spec.js
+++ b/tests/permission.spec.js
@@ -1,0 +1,54 @@
+// Unit tests for the pure permission helper. permission.js has no SvelteKit or
+// browser dependencies, so it imports cleanly into a plain Node-run Playwright
+// spec (the repo's only test runner) via a relative path — the $lib alias is
+// not resolved here. These cases mirror the server's effective-grant matching.
+
+import { test, expect } from '@playwright/test'
+import { hasPermission, denyTooltip } from '../src/lib/permission.js'
+
+test.describe('hasPermission', () => {
+	test('admin holds everything', () => {
+		expect(hasPermission([], true, 'deployment.deploy')).toBe(true)
+		expect(hasPermission(undefined, true, 'anything.at.all')).toBe(true)
+	})
+
+	test("the '*' wildcard grants every permission", () => {
+		expect(hasPermission(['*'], false, 'deployment.deploy')).toBe(true)
+		expect(hasPermission(['*'], false, 'role.bind')).toBe(true)
+	})
+
+	test("a '<resource>.*' wildcard grants all actions on that resource", () => {
+		expect(hasPermission(['deployment.*'], false, 'deployment.deploy')).toBe(true)
+		expect(hasPermission(['deployment.*'], false, 'deployment.delete')).toBe(true)
+		// ...but not actions on a different resource
+		expect(hasPermission(['deployment.*'], false, 'role.bind')).toBe(false)
+	})
+
+	test('an exact grant matches', () => {
+		expect(hasPermission(['serviceAccount.create'], false, 'serviceAccount.create')).toBe(true)
+		expect(hasPermission(['role.bind', 'role.get'], false, 'role.get')).toBe(true)
+	})
+
+	test('a missing grant does not match', () => {
+		expect(hasPermission(['role.get'], false, 'role.bind')).toBe(false)
+		// a prefix that is not a '<resource>.*' wildcard must not match
+		expect(hasPermission(['deployment'], false, 'deployment.deploy')).toBe(false)
+	})
+
+	test('empty or undefined grants deny everything (non-admin)', () => {
+		expect(hasPermission([], false, 'deployment.deploy')).toBe(false)
+		expect(hasPermission(undefined, false, 'deployment.deploy')).toBe(false)
+	})
+
+	test('a permission with no dot still falls back to an exact match', () => {
+		expect(hasPermission(['legacy'], false, 'legacy')).toBe(true)
+		expect(hasPermission(['*'], false, 'legacy')).toBe(true)
+		expect(hasPermission(['other'], false, 'legacy')).toBe(false)
+	})
+
+	test('denyTooltip names the required permission', () => {
+		expect(denyTooltip('deployment.deploy')).toBe(
+			"You don't have permission to do this (requires deployment.deploy)."
+		)
+	})
+})

--- a/tests/permission.spec.js
+++ b/tests/permission.spec.js
@@ -24,8 +24,17 @@ test.describe('hasPermission', () => {
 		expect(hasPermission(['deployment.*'], false, 'role.bind')).toBe(false)
 	})
 
+	test("a '<resource>.*' wildcard does NOT cover a three-segment permission", () => {
+		// Mirrors the server: iam.validPermissions only applies the wildcard for
+		// two-segment permissions, so serviceaccount.* does not grant
+		// serviceaccount.key.create — only an exact grant or '*' does.
+		expect(hasPermission(['serviceaccount.*'], false, 'serviceaccount.key.create')).toBe(false)
+		expect(hasPermission(['serviceaccount.key.create'], false, 'serviceaccount.key.create')).toBe(true)
+		expect(hasPermission(['*'], false, 'serviceaccount.key.create')).toBe(true)
+	})
+
 	test('an exact grant matches', () => {
-		expect(hasPermission(['serviceAccount.create'], false, 'serviceAccount.create')).toBe(true)
+		expect(hasPermission(['serviceaccount.create'], false, 'serviceaccount.create')).toBe(true)
 		expect(hasPermission(['role.bind', 'role.get'], false, 'role.get')).toBe(true)
 	})
 


### PR DESCRIPTION
Generalizes the permission check from console#196 to **every action across the project pages**: if the user lacks the permission, the control is disabled with a hover tooltip explaining which permission is needed — instead of letting them click and fail.

## Foundation
- Loads the caller's effective permissions once in `(project)/+layout.js` via the new **`me.permissions`** RPC (api#51 / apiserver#110, both merged), cached alongside `projectInfo`; a non-ok response gates everything off rather than breaking the page.
- `src/lib/permission.js` — `hasPermission(permissions, admin, perm)` mirrors the server's wildcard rules exactly (`admin`, `*`, `<resource>.*`, exact).
- A reactive `can()` is exposed via Svelte context from the project layout.
- `GuardedButton.svelte` — drop-in gated control; when denied it renders a disabled button **wrapped in a title-bearing span** so the hover tooltip is reliable across browsers (native disabled-button tooltips are not).

## Rollout
- 40 `(project)` page files; Create / Deploy / Delete / Update / Rollback / Bind / Grant / Revoke / Resize / Pause / Resume / Rotate / Purge controls gated on their RPC permission.
- Buttons styled by **global** classes use `GuardedButton`. Controls relying on **component-scoped** CSS (the deployment masthead `.mast-btn`) are gated **in-place** with `can()` + a title span, because moving a scoped-class element into a child component breaks Svelte's CSS scoping — caught during review (the only such case).
- The GitHub link page (console#196) keeps its existing flags, now sourced from the same foundation.

## Scope
`(project)` pages only — billing and project-creation use a different permission scope and are out of scope here.

## Verification
`bun lint` 0, `bun check` 0 errors / **0 warnings** (the scoped-CSS regression was found and fixed), `bun run test` **181 passed**. Denied + allowed states verified visually in mock mode (disk Create disabled with tooltip; deployment masthead retains `.mast-btn` styling while gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)