### PR TITLE
Console: Static build-type selector + release history (static web PR 8)

### DIFF
--- a/src/lib/format/index.js
+++ b/src/lib/format/index.js
@@ -97,7 +97,8 @@ export function deploymentType (t) {
 		TCPService: 'TCP Service',
 		InternalTCPService: 'Internal TCP Service',
 		Worker: 'Worker',
-		CronJob: 'Cron Job'
+		CronJob: 'Cron Job',
+		Static: 'Static'
 	}[t] || t
 }
 
@@ -107,6 +108,22 @@ export function deploymentType (t) {
  */
 export function shortDigest (s) {
 	return s.replace(/^sha256:/, '').slice(0, 12)
+}
+
+/**
+ * releaseSha extracts a Static deployment's release-sha. A Static deployment
+ * carries its release pointer either as a `site://<bucket>/<project>/<name>@<sha>`
+ * URI (the `site` field) or as a bare digest (`siteManifestDigest`). Pass both;
+ * the URI's trailing `@<sha>` wins, falling back to the bare digest, then to the
+ * raw site string.
+ * @param {{ site?: string, siteManifestDigest?: string }} [d]
+ * @returns {string}
+ */
+export function releaseSha (d) {
+	const site = d?.site ?? ''
+	const at = site.lastIndexOf('@')
+	if (at >= 0) return site.slice(at + 1)
+	return d?.siteManifestDigest || site
 }
 
 /**

--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -187,8 +187,41 @@ function deployment (project = 'acme') {
 	}
 }
 
+// A Static (bucket-native static web) deployment: no container image/port — it
+// references a content-addressed release via `site` (site://…@<release-sha>) and
+// `siteManifestDigest`. Lets the detail/revision pages exercise the Release row
+// and release-sha rollback offline.
+const STATIC_RELEASE_SHA = 'a1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff00'
+
+/**
+ * @param {string} [project]
+ * @param {string} [releaseSha]
+ */
+function staticDeployment (project = 'acme', releaseSha = STATIC_RELEASE_SHA) {
+	return {
+		...deployment(project),
+		name: 'website',
+		type: 'Static',
+		image: '',
+		site: `site://deploys-static/${project}/website@${releaseSha}`,
+		siteManifestDigest: releaseSha,
+		command: [],
+		args: [],
+		minReplicas: 0,
+		maxReplicas: 0,
+		port: 0,
+		protocol: '',
+		pullSecret: '',
+		workloadIdentity: '',
+		internalUrl: '',
+		internalAddress: '',
+		url: 'website.acme.rcf2.deploys.app'
+	}
+}
+
 const deployments = [
 	deployment('acme'),
+	staticDeployment('acme'),
 	{
 		...deployment('acme'),
 		name: 'web-paused',
@@ -886,6 +919,15 @@ const handlers = {
 	// deployment.get), with per-revision differences so the rollback modal's
 	// config diff has something to show.
 	'deployment.get': (args) => {
+		// Static deployment: distinct release-sha per historical revision so the
+		// rollback comparison shows release-sha old → new.
+		if (args?.name === 'website') {
+			const base = { ...staticDeployment(args?.project), location: args?.location ?? LOCATION_ID }
+			const revision = Number(args?.revision ?? 0)
+			if (!revision || revision >= base.revision) return ok(base)
+			const sha = `${revision}`.repeat(64).slice(0, 64)
+			return ok({ ...base, revision, site: `site://deploys-static/${args?.project ?? 'acme'}/website@${sha}`, siteManifestDigest: sha })
+		}
 		const base = { ...deployment(args?.project), name: args?.name ?? 'web', location: args?.location ?? LOCATION_ID }
 		const revision = Number(args?.revision ?? 0)
 		if (!revision || revision >= base.revision) return ok(base)
@@ -903,16 +945,32 @@ const handlers = {
 	'deployment.pause': () => ok({}),
 	'deployment.resume': () => ok({}),
 	'deployment.rollback': () => ok({}),
-	'deployment.revisions': (args) => list([7, 6, 5].map((revision) => {
-		const base = deployment(args?.project)
-		return {
-			...base,
-			name: args?.name ?? 'web',
-			location: args?.location ?? LOCATION_ID,
-			revision,
-			image: revision === base.revision ? base.image : base.image.replace(/:latest$/, `:v${revision}`)
+	'deployment.revisions': (args) => {
+		// Static deployment: per-revision release-shas, no image.
+		if (args?.name === 'website') {
+			const base = staticDeployment(args?.project)
+			return list([7, 6, 5].map((revision) => {
+				const sha = revision === base.revision ? STATIC_RELEASE_SHA : `${revision}`.repeat(64).slice(0, 64)
+				return {
+					...base,
+					location: args?.location ?? LOCATION_ID,
+					revision,
+					site: `site://deploys-static/${args?.project ?? 'acme'}/website@${sha}`,
+					siteManifestDigest: sha
+				}
+			}))
 		}
-	})),
+		return list([7, 6, 5].map((revision) => {
+			const base = deployment(args?.project)
+			return {
+				...base,
+				name: args?.name ?? 'web',
+				location: args?.location ?? LOCATION_ID,
+				revision,
+				image: revision === base.revision ? base.image : base.image.replace(/:latest$/, `:v${revision}`)
+			}
+		}))
+	},
 	'deployment.metrics': () => ok({
 		cpuUsage: metricPodLines(0.3),
 		cpuLimit: metricPodLines(0.5),

--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -32,6 +32,11 @@
 	const hasExternalTCPAddress = $derived(['TCPService'].includes(deployment.type))
 	const hasInternalTCPAddress = $derived(['WebService', 'TCPService', 'InternalTCPService'].includes(deployment.type))
 
+	// Static deployments reference a content-addressed release instead of a
+	// container image — surface the release-sha under a "Release" label.
+	const isStatic = $derived(deployment.type === 'Static')
+	const release = $derived(format.releaseSha(deployment))
+
 	onMount(() => setupCopy('.copy'))
 
 	function deleteItem () {
@@ -413,7 +418,7 @@
 				<span class="section__rule"></span>
 			</div>
 			<div class="spec-grid is-full">
-				{#if deployment.type === 'WebService' && !deployment.internal}
+				{#if (deployment.type === 'WebService' && !deployment.internal) || deployment.type === 'Static'}
 					<div class="spec">
 						<span class="spec__label">URL</span>
 						<a class="spec__link" href={`https://${deployment.url}`} target="_blank" rel="noopener">
@@ -484,31 +489,46 @@
 					</span>
 					<span></span>
 				</div>
-				<div class="spec">
-					<span class="spec__label">Image</span>
-					<span class="spec__value is-mono">{deployment.image}</span>
-					<span class="spec__copy copy" data-clipboard-text={deployment.image} title="Copy image">
-						<i class="fa-light fa-copy"></i>
-					</span>
-				</div>
-				<div class="spec">
-					<span class="spec__label">Command</span>
-					{#if deployment.command.length}
-						<span class="spec__value is-mono">{deployment.command.join(' ')}</span>
-					{:else}
-						<span class="spec__value is-dim">—</span>
-					{/if}
-					<span></span>
-				</div>
-				<div class="spec">
-					<span class="spec__label">Args</span>
-					{#if deployment.args.length}
-						<span class="spec__value is-mono">{deployment.args.join(' ')}</span>
-					{:else}
-						<span class="spec__value is-dim">—</span>
-					{/if}
-					<span></span>
-				</div>
+				{#if isStatic}
+					<div class="spec">
+						<span class="spec__label">Release</span>
+						{#if release}
+							<span class="spec__value is-mono">{release}</span>
+							<span class="spec__copy copy" data-clipboard-text={release} title="Copy release">
+								<i class="fa-light fa-copy"></i>
+							</span>
+						{:else}
+							<span class="spec__value is-dim">—</span>
+							<span></span>
+						{/if}
+					</div>
+				{:else}
+					<div class="spec">
+						<span class="spec__label">Image</span>
+						<span class="spec__value is-mono">{deployment.image}</span>
+						<span class="spec__copy copy" data-clipboard-text={deployment.image} title="Copy image">
+							<i class="fa-light fa-copy"></i>
+						</span>
+					</div>
+					<div class="spec">
+						<span class="spec__label">Command</span>
+						{#if deployment.command.length}
+							<span class="spec__value is-mono">{deployment.command.join(' ')}</span>
+						{:else}
+							<span class="spec__value is-dim">—</span>
+						{/if}
+						<span></span>
+					</div>
+					<div class="spec">
+						<span class="spec__label">Args</span>
+						{#if deployment.args.length}
+							<span class="spec__value is-mono">{deployment.args.join(' ')}</span>
+						{:else}
+							<span class="spec__value is-dim">—</span>
+						{/if}
+						<span></span>
+					</div>
+				{/if}
 				{#if deployment.type === 'CronJob'}
 					<div class="spec">
 						<span class="spec__label">Schedule</span>
@@ -519,7 +539,8 @@
 			</div>
 		</section>
 
-		<!-- ─── Resources ─── -->
+		<!-- ─── Resources ─── (container-only; not shown for Static) -->
+		{#if !isStatic}
 		<section class="section">
 			<div class="section__head">
 				<span class="section__title">Resources</span>
@@ -584,6 +605,7 @@
 				{/if}
 			</div>
 		</section>
+		{/if}
 
 		<!-- ─── Integration ─── -->
 		<section class="section">

--- a/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
@@ -14,6 +14,25 @@
 	const deployment = $derived(data.deployment)
 	const revisions = $derived(data.revisions)
 
+	// Static deployments reference a content-addressed release per revision
+	// instead of a container image; render the per-revision release-sha in its
+	// place. The rollback flow itself is unchanged (deployment.rollback re-points
+	// the Site).
+	const isStatic = $derived(deployment.type === 'Static')
+
+	/**
+	 * Per-revision artifact label: the release-sha for Static, else the image.
+	 * @param {Api.Deployment} it
+	 * @returns {string}
+	 */
+	function artifact (it) {
+		return isStatic ? format.releaseSha(it) : it.image
+	}
+
+	// Noun used in the rollback prose so the "what changes" copy reads sensibly
+	// for static (release-sha) vs container (image) deployments.
+	const artifactNoun = $derived(isStatic ? 'release' : 'image')
+
 	let now = $state(Date.now())
 	onMount(() => {
 		const t = setInterval(() => { now = Date.now() }, 30_000)
@@ -88,8 +107,9 @@
 		return xs?.length ? xs.join(' ') : '—'
 	}
 
-	// Settings that rollback will change, current → target. Image is omitted —
-	// the comparison cards above already show it side by side.
+	// Settings that rollback will change, current → target. The artifact
+	// (image / release-sha) is omitted — the comparison cards above already show
+	// it side by side.
 	const specChanges = $derived.by(() => {
 		const t = targetSpec
 		if (!t) return []
@@ -547,7 +567,7 @@
 						<span class="rev-row__rev-tag">Active</span>
 					{/if}
 				</span>
-				<span class="rev-row__image" title={it.image}>{it.image}</span>
+				<span class="rev-row__image" title={artifact(it)}>{artifact(it)}</span>
 				<span class="rev-row__meta">
 					<span class="rev-row__when" title={it.createdAt}>
 						{format.datetime(it.createdAt)} · {relTime(it.createdAt, now)}
@@ -585,7 +605,7 @@
 					<div class="rb-side__label">Currently active</div>
 					<div class="rb-side__rev">#{activeRevision?.revision ?? deployment.revision}</div>
 					{#if activeRevision}
-						<div class="rb-side__image font-mono" title={activeRevision.image}>{activeRevision.image}</div>
+						<div class="rb-side__image font-mono" title={artifact(activeRevision)}>{artifact(activeRevision)}</div>
 						<div class="rb-side__meta" title={activeRevision.createdAt}>
 							deployed {format.datetime(activeRevision.createdAt)} by {activeRevision.createdBy}
 						</div>
@@ -597,7 +617,7 @@
 				<div class="rb-side" data-kind="to">
 					<div class="rb-side__label">Rolling back to</div>
 					<div class="rb-side__rev">#{rollbackTarget.revision}</div>
-					<div class="rb-side__image font-mono" title={rollbackTarget.image}>{rollbackTarget.image}</div>
+					<div class="rb-side__image font-mono" title={artifact(rollbackTarget)}>{artifact(rollbackTarget)}</div>
 					<div class="rb-side__meta" title={rollbackTarget.createdAt}>
 						deployed {format.datetime(rollbackTarget.createdAt)} by {rollbackTarget.createdBy}
 					</div>
@@ -615,11 +635,11 @@
 				{#if targetLoading}
 					<p class="text-content/50 text-sm"><i class="fa-solid fa-circle-notch fa-spin mr-2"></i>Loading revision #{rollbackTarget.revision}…</p>
 				{:else if !targetSpec}
-					<p class="text-content/50 text-sm">Couldn’t load revision #{rollbackTarget.revision}’s configuration — only the image comparison above is shown.</p>
+					<p class="text-content/50 text-sm">Couldn’t load revision #{rollbackTarget.revision}’s configuration — only the {artifactNoun} comparison above is shown.</p>
 				{:else if !hasChanges}
 					<p class="text-content/50 text-sm">
 						<i class="fa-solid fa-circle-check mr-2 text-positive"></i>
-						Same configuration — only the image differs.
+						Same configuration — only the {artifactNoun} differs.
 					</p>
 				{:else}
 					<div class="table-container rb-diff__table">
@@ -657,12 +677,20 @@
 				{/if}
 			</div>
 
-			<p class="text-content/60 text-sm mt-4">
-				This redeploys revision <strong>#{rollbackTarget.revision}</strong>’s image and
-				configuration (env, scaling, command, disks, schedule) as a new revision.
-				Sidecars and mounted files keep their current configuration. No history is
-				deleted.
-			</p>
+			{#if isStatic}
+				<p class="text-content/60 text-sm mt-4">
+					This re-points the site to revision <strong>#{rollbackTarget.revision}</strong>’s
+					release as a new revision — an instant pointer swap, no rebuild or re-upload.
+					No history is deleted.
+				</p>
+			{:else}
+				<p class="text-content/60 text-sm mt-4">
+					This redeploys revision <strong>#{rollbackTarget.revision}</strong>’s image and
+					configuration (env, scaling, command, disks, schedule) as a new revision.
+					Sidecars and mounted files keep their current configuration. No history is
+					deleted.
+				</p>
+			{/if}
 		{/if}
 
 		<div class="flex items-center gap-3 mt-6">

--- a/src/routes/(auth)/(project)/github/+page.svelte
+++ b/src/routes/(auth)/(project)/github/+page.svelte
@@ -48,12 +48,31 @@
 		repository: data.links[0]?.repository ?? '',
 		location: data.locations[0]?.id ?? '',
 		name: 'web',
-		port: 8080
+		// 'dockerfile' (default) emits today's container workflow; 'static' emits
+		// a bucket-native static-web workflow (mode: static).
+		buildType: 'dockerfile',
+		port: 8080,
+		// static fields — only used when buildType === 'static'
+		framework: 'auto',
+		buildCommand: '',
+		outputDir: 'public',
+		spa: false,
+		notFound: '404.html'
 	})))
 	const genRepoOptions = $derived(links.map((l) => ({ value: l.repository, label: l.repository })))
 	const genBranch = $derived(links.find((l) => l.repository === gen.repository)?.productionBranch || 'main')
 
-	const workflowYaml = $derived(`name: Deploy
+	const buildTypeOptions = [
+		{ value: 'dockerfile', label: 'Dockerfile' },
+		{ value: 'static', label: 'Static' }
+	]
+	const frameworkOptions = [
+		{ value: 'auto', label: 'Auto-detect' },
+		{ value: 'hugo', label: 'Hugo' },
+		{ value: 'node', label: 'Node' }
+	]
+
+	const dockerfileYaml = $derived(`name: Deploy
 on:
   push:
     branches: [${genBranch}]
@@ -75,6 +94,36 @@ jobs:
         name: ${gen.name || 'web'}
         port: ${Number(gen.port) || 8080}
 `)
+
+	const staticYaml = $derived(`name: Deploy
+on:
+  push:
+    branches: [${genBranch}]
+  pull_request:
+
+permissions:
+  id-token: write   # required — this is the credential
+  contents: read
+  pull-requests: write   # sticky PR preview comment
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: deploys-app/build-deploy-action@v1
+      with:
+        project: ${project}
+        location: ${gen.location}
+        name: ${gen.name || 'web'}
+        mode: static
+        framework: ${gen.framework || 'auto'}
+${gen.buildCommand.trim() ? `        buildCommand: ${gen.buildCommand.trim()}\n` : ''}        outputDir: ${gen.outputDir || 'public'}
+        spa: ${gen.spa ? 'true' : 'false'}
+        notFound: ${gen.notFound || '404.html'}
+`)
+
+	const workflowYaml = $derived(gen.buildType === 'static' ? staticYaml : dockerfileYaml)
 
 	const createOnGitHubURL = $derived(gen.repository
 		? `https://github.com/${gen.repository}/new/main?filename=.github/workflows/deploy.yml&value=${encodeURIComponent(workflowYaml)}`
@@ -176,11 +225,46 @@ jobs:
 				</div>
 			</div>
 			<div class="field">
-				<label for="gen-port">Port</label>
-				<div class="input">
-					<input id="gen-port" type="number" min="1" bind:value={gen.port} placeholder="8080">
-				</div>
+				<label for="gen-build-type">Build type</label>
+				<Select id="gen-build-type" bind:value={gen.buildType} options={buildTypeOptions} />
 			</div>
+			{#if gen.buildType === 'dockerfile'}
+				<div class="field">
+					<label for="gen-port">Port</label>
+					<div class="input">
+						<input id="gen-port" type="number" min="1" bind:value={gen.port} placeholder="8080">
+					</div>
+				</div>
+			{:else}
+				<div class="field">
+					<label for="gen-framework">Framework</label>
+					<Select id="gen-framework" bind:value={gen.framework} options={frameworkOptions} />
+				</div>
+				<div class="field">
+					<label for="gen-build-command">Build command</label>
+					<div class="input">
+						<input id="gen-build-command" class="font-mono" bind:value={gen.buildCommand} placeholder="preset (e.g. hugo --minify)">
+					</div>
+				</div>
+				<div class="field">
+					<label for="gen-output-dir">Output directory</label>
+					<div class="input">
+						<input id="gen-output-dir" class="font-mono" bind:value={gen.outputDir} placeholder="public">
+					</div>
+				</div>
+				<div class="field">
+					<label for="gen-not-found">404 document</label>
+					<div class="input">
+						<input id="gen-not-found" class="font-mono" bind:value={gen.notFound} placeholder="404.html">
+					</div>
+				</div>
+				<div class="field self-end">
+					<div class="checkbox">
+						<input id="gen-spa" type="checkbox" bind:checked={gen.spa}>
+						<label for="gen-spa">SPA fallback to index.html</label>
+					</div>
+				</div>
+			{/if}
 		</div>
 
 		<pre class="workflow-yaml font-mono text-sm">{workflowYaml}</pre>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -285,7 +285,8 @@ declare namespace Api {
         'TCPService' |
         'InternalTCPService' |
         'Worker' |
-        'CronJob'
+        'CronJob' |
+        'Static'
 
     export type DeploymentAction =
         'deploy' |
@@ -305,6 +306,11 @@ declare namespace Api {
         type: DeploymentType
         revision: number
         image: string
+        // Static deployments carry a content-addressed release pointer instead
+        // of a container image. `site` is the `site://<bucket>/<project>/<name>@<release-sha>`
+        // URI; `siteManifestDigest` is the bare release-sha.
+        site?: string
+        siteManifestDigest?: string
         env: Env
         envGroups: string[]
         command: string[]

--- a/tests/deployment.spec.js
+++ b/tests/deployment.spec.js
@@ -2,7 +2,9 @@ import { test, expect, setMocks } from './helpers.js'
 import {
 	defaultLocation,
 	sampleCloudSqlProxySidecar,
-	sampleDeployment
+	sampleDeployment,
+	sampleStaticDeployment,
+	sampleStaticReleaseSha
 } from './fixtures/mocks.js'
 
 test.describe('deployments', () => {
@@ -315,5 +317,81 @@ test.describe('deployment detail — environment variables', () => {
 
 		await expect(main.getByText('topsecret-value')).toBeHidden()
 		await expect(main.getByText('https://example.test')).toBeHidden()
+	})
+})
+
+test.describe('deployment detail — static', () => {
+	test('shows the Release (release-sha), not an Image row', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleStaticDeployment },
+			'location.get': { ok: true, result: defaultLocation }
+		})
+
+		await page.goto('/deployment/detail?project=test-project&location=gke&name=website')
+
+		const main = page.locator('.content-wrapper')
+
+		// The Runtime section shows a Release row carrying the release-sha; no
+		// container Image row is rendered for a Static deployment.
+		const release = main.locator('.spec').filter({ hasText: 'Release' })
+		await expect(release).toBeVisible()
+		await expect(release).toContainText(sampleStaticReleaseSha)
+		await expect(main.locator('.spec').filter({ hasText: /^Image/ })).toHaveCount(0)
+
+		// Type renders as Static and the public URL is shown.
+		await expect(main.locator('.spec').filter({ hasText: 'Type' })).toContainText('Static')
+		await expect(main.getByRole('link', { name: 'https://website.test-project.app.in.th' })).toBeVisible()
+	})
+})
+
+test.describe('deployment revision — static rollback', () => {
+	test('revision list and rollback comparison render release-shas', async ({ page }) => {
+		const shaActive = sampleStaticReleaseSha
+		const shaPrev = 'b'.repeat(64)
+
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleStaticDeployment },
+			'location.get': { ok: true, result: defaultLocation },
+			'deployment.revisions': {
+				ok: true,
+				result: {
+					items: [
+						{ ...sampleStaticDeployment, revision: 2, site: `site://deploys-static/test-project/website@${shaActive}`, siteManifestDigest: shaActive },
+						{ ...sampleStaticDeployment, revision: 1, site: `site://deploys-static/test-project/website@${shaPrev}`, siteManifestDigest: shaPrev }
+					]
+				}
+			}
+		})
+
+		await page.goto('/deployment/revision?project=test-project&location=gke&name=website')
+
+		const main = page.locator('.content-wrapper')
+
+		// Each revision row renders its release-sha (not an image).
+		await expect(main.locator('.rev-row__image').first()).toHaveText(shaActive)
+		await expect(main.locator('.rev-row__image').nth(1)).toHaveText(shaPrev)
+		await expect(main.getByText(':latest')).toHaveCount(0)
+
+		// The deployment.get for revision 1 (rollback target spec) must return the
+		// historical release so the comparison reads sensibly.
+		await setMocks({
+			'deployment.get': {
+				ok: true,
+				result: { ...sampleStaticDeployment, revision: 1, site: `site://deploys-static/test-project/website@${shaPrev}`, siteManifestDigest: shaPrev }
+			}
+		})
+
+		// Open the rollback modal for the older revision.
+		await main.getByRole('button', { name: 'Rollback' }).click()
+
+		const modal = page.locator('.modal.is-active')
+		await expect(modal).toBeVisible()
+
+		// Comparison cards show release-shas old → new.
+		await expect(modal.locator('.rb-side[data-kind="from"] .rb-side__image')).toHaveText(shaActive)
+		await expect(modal.locator('.rb-side[data-kind="to"] .rb-side__image')).toHaveText(shaPrev)
+
+		// The static prose reads "re-points the site … release", not "image".
+		await expect(modal.getByText(/re-points the site/)).toBeVisible()
 	})
 })

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -197,6 +197,29 @@ export const sampleCloudSqlProxySidecar = {
 	}
 }
 
+// A Static (bucket-native static web) deployment: no container image/port — it
+// references a content-addressed release via `site` (site://…@<release-sha>) and
+// `siteManifestDigest`.
+export const sampleStaticReleaseSha =
+	'a1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff00'
+
+export const sampleStaticDeployment = {
+	...sampleDeployment,
+	name: 'website',
+	type: 'Static',
+	image: '',
+	site: `site://deploys-static/test-project/website@${sampleStaticReleaseSha}`,
+	siteManifestDigest: sampleStaticReleaseSha,
+	command: [],
+	args: [],
+	minReplicas: 0,
+	maxReplicas: 0,
+	port: 0,
+	protocol: '',
+	url: 'website.test-project.app.in.th',
+	internalUrl: ''
+}
+
 export const sampleDomain = {
 	project: 'test-project',
 	location: 'gke',

--- a/tests/github.spec.js
+++ b/tests/github.spec.js
@@ -132,6 +132,55 @@ test.describe('github', () => {
 		await expect(yaml).toContainText('branches: [main]')
 	})
 
+	test('Static build type emits a mode: static workflow with framework/outputDir and no dockerfile/port', async ({ page }) => {
+		await mocks()
+
+		await page.goto('/github?project=test-project')
+		const main = page.locator('.content-wrapper')
+		const yaml = main.locator('.workflow-yaml')
+
+		// Default is Dockerfile mode — the container workflow carries port.
+		await expect(yaml).toContainText('port:')
+		await expect(yaml).not.toContainText('mode: static')
+
+		// Switch the build type to Static.
+		await main.locator('#gen-build-type').click()
+		await page.getByRole('option', { name: 'Static' }).click()
+
+		// The static workflow carries mode: static + framework/outputDir/spa/notFound,
+		// and the production branch filter is preserved.
+		await expect(yaml).toContainText('mode: static')
+		await expect(yaml).toContainText('framework: auto')
+		await expect(yaml).toContainText('outputDir: public')
+		await expect(yaml).toContainText('spa: false')
+		await expect(yaml).toContainText('notFound: 404.html')
+		await expect(yaml).toContainText('branches: [release]')
+		await expect(yaml).toContainText('pull-requests: write')
+
+		// No Dockerfile-mode inputs leak into the static workflow.
+		await expect(yaml).not.toContainText('port:')
+		await expect(yaml).not.toContainText('dockerfile')
+
+		// buildCommand is omitted until the user fills it in.
+		await expect(yaml).not.toContainText('buildCommand:')
+		await main.locator('#gen-build-command').fill('hugo --minify')
+		await expect(yaml).toContainText('buildCommand: hugo --minify')
+
+		// Static framework + spa selections flow through to the YAML.
+		await main.locator('#gen-framework').click()
+		await page.getByRole('option', { name: 'Hugo' }).click()
+		await expect(yaml).toContainText('framework: hugo')
+		await main.locator('#gen-spa').check()
+		await expect(yaml).toContainText('spa: true')
+
+		// Copy + Create-on-GitHub deep-link carry the static YAML.
+		const copyText = await main.locator('.copy-workflow').getAttribute('data-clipboard-text')
+		expect(copyText).toContain('mode: static')
+		const href = await main.getByRole('link', { name: 'Create on GitHub' }).getAttribute('href')
+		expect(decodeURIComponent(href ?? '')).toContain('mode: static')
+		expect(decodeURIComponent(href ?? '')).toContain('framework: hugo')
+	})
+
 	test('unlinks after confirmation', async ({ page }) => {
 		await mocks({ 'github.unlink': { ok: true, result: {} } })
 


### PR DESCRIPTION
PR 8 of **GitHub App — Static Web Deploys** (SPEC §2.3, §5.5).

- **Workflow generator** (`/github`): a **Dockerfile vs Static** toggle. Static reveals `framework`/`buildCommand`/`outputDir`/`spa`/`notFound` and emits a `mode: static` workflow (reusing the link's `productionBranch` for `on.push.branches`); Copy + Create-on-GitHub carry the static YAML.
- **Deployment detail**: a Static deployment shows its **Release** (the release-sha from `site://…@<sha>`) instead of an Image row, and the container-only **Resources** section (CPU/Memory/Disk) is hidden for Static.
- **Revision / rollback**: per-revision rows + the rollback comparison render release-shas for Static; the rollback flow is unchanged (`deployment.rollback`, which re-points Site).
- Types (`'Static'` + `site`/`siteManifestDigest`), a `releaseSha()` format helper, mock fixtures, and tests.

`bun lint`/`bun check` clean; full Playwright suite **185 passed** (3 new). Static detail + generator verified visually in mock mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)