### PR TITLE
Use a neutral default avatar in the navbar

### DIFF
--- a/src/routes/(auth)/Navbar.svelte
+++ b/src/routes/(auth)/Navbar.svelte
@@ -109,7 +109,7 @@
 
 		<div>
 			<div class="avatar" onclick={toggle} onkeypress={toggle} tabindex="0" role="button">
-				<img src={profile ? gravatarUrl(profile.email) : 'https://www.gravatar.com/avatar'} alt="profile" width="36" class="rounded-full" crossorigin="anonymous" draggable="false">
+				<img src={profile ? gravatarUrl(profile.email, { default: 'mp' }) : 'https://www.gravatar.com/avatar?d=mp'} alt="profile" width="36" class="rounded-full" crossorigin="anonymous" draggable="false">
 			</div>
 
 			{#if active}


### PR DESCRIPTION
The navbar avatar called `gravatarUrl(profile.email)` with **no** default, so for a user without a Gravatar, Gravatar serves its own site default (the Gravatar logo) — which users read as a broken or someone-else's photo.

Pass `{ default: 'mp' }` (the mystery-person silhouette), matching what the `role/users` list already uses, so "no avatar set" is unambiguous. Also applied `?d=mp` to the no-profile fallback.

One-line change in `Navbar.svelte`; `bun lint`/`bun check` clean.