### PR TITLE
GitHub workflow generator: root folder, env, env groups, pull secret

### DIFF
--- a/src/routes/(auth)/(project)/github/+page.js
+++ b/src/routes/(auth)/(project)/github/+page.js
@@ -1,16 +1,40 @@
 import api from '$lib/api'
+import { hasPermission } from '$lib/permission'
 
 export async function load ({ parent, fetch }) {
-	const { project } = await parent()
+	const { project, permissions, permissionsAdmin } = await parent()
 
-	const [links, locations] = await Promise.all([
+	const [links, locations, envGroups, pullSecrets, githubPullRole] = await Promise.all([
 		api.invoke('github.list', { project }, fetch),
-		api.invoke('location.list', { project }, fetch)
+		api.invoke('location.list', { project }, fetch),
+		api.invoke('envGroup.list', { project }, fetch),
+		// No location => every location's pull secrets; the generator filters by
+		// the selected location client-side.
+		api.invoke('pullSecret.list', { project }, fetch),
+		// Decides whether provisioning the dedicated pull service account still
+		// needs role.create (vs. the shared github-pull role already existing).
+		api.invoke('role.get', { project, role: 'github-pull' }, fetch)
 	])
+
+	const githubPullRoleExists = githubPullRole.ok && !!githubPullRole.result
+	// The "create dedicated pull secret" flow needs to: make a pull-only service
+	// account, mint a key, bind the registry.pull role, and create the pull
+	// secret. Gate the affordance on that whole set (lowercase canonical names,
+	// matching the server's effective grants), plus role.create only when the
+	// shared github-pull role doesn't exist yet.
+	const canProvisionPullSecret =
+		hasPermission(permissions, permissionsAdmin, 'serviceaccount.create') &&
+		hasPermission(permissions, permissionsAdmin, 'serviceaccount.key.create') &&
+		hasPermission(permissions, permissionsAdmin, 'pullsecret.create') &&
+		hasPermission(permissions, permissionsAdmin, 'role.bind') &&
+		(githubPullRoleExists || hasPermission(permissions, permissionsAdmin, 'role.create'))
 
 	return {
 		links: links.result?.items ?? [],
 		locations: locations.result?.items ?? [],
+		envGroups: envGroups.result?.items ?? [],
+		pullSecrets: pullSecrets.result?.items ?? [],
+		canProvisionPullSecret,
 		error: links.error
 	}
 }

--- a/src/routes/(auth)/(project)/github/+page.svelte
+++ b/src/routes/(auth)/(project)/github/+page.svelte
@@ -6,6 +6,7 @@
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import { denyTooltip } from '$lib/permission'
 	import * as format from '$lib/format'
 	import { setupCopy } from '$lib/clipboard'
 
@@ -13,9 +14,13 @@
 
 	const project = $derived(data.project)
 	const locations = $derived(data.locations)
+	const envGroups = $derived(data.envGroups)
+	const canProvisionPullSecret = $derived(data.canProvisionPullSecret)
 	const error = $derived(data.error)
 
 	let links = $state(untrack(() => data.links))
+	// Mutable so a freshly-provisioned pull secret is selectable without a reload.
+	let pullSecrets = $state(untrack(() => data.pullSecrets))
 
 	const locationOptions = $derived(locations.map((l) => ({ value: l.id, label: l.id })))
 
@@ -57,7 +62,14 @@
 		buildCommand: '',
 		outputDir: 'public',
 		spa: false,
-		notFound: '404.html'
+		notFound: '404.html',
+		// shared config
+		workingDirectory: '',
+		env: '',
+		/** @type {string[]} */
+		envGroups: [],
+		// container-only
+		pullSecret: ''
 	})))
 	const genRepoOptions = $derived(links.map((l) => ({ value: l.repository, label: l.repository })))
 	const genBranch = $derived(links.find((l) => l.repository === gen.repository)?.productionBranch || 'main')
@@ -72,15 +84,213 @@
 		{ value: 'node', label: 'Node' }
 	]
 
-	const dockerfileYaml = $derived(`name: Deploy
+	// --- env groups (multi-select) ---
+	const envGroupOptions = $derived(
+		envGroups
+			.filter((g) => !gen.envGroups.includes(g.name))
+			.map((g) => ({ value: g.name, label: g.name }))
+	)
+
+	/** @param {string} name */
+	function addEnvGroup (name) {
+		const n = name.trim()
+		if (!n || gen.envGroups.includes(n)) return
+		gen.envGroups = [...gen.envGroups, n]
+	}
+
+	/** @param {string} name */
+	function removeEnvGroup (name) {
+		gen.envGroups = gen.envGroups.filter((g) => g !== name)
+	}
+
+	// --- pull secret (container deploys only) ---
+	const locationPullSecrets = $derived(pullSecrets.filter((p) => p.location === gen.location))
+	const pullSecretOptions = $derived([
+		{ value: '', label: 'No pull secret' },
+		...locationPullSecrets.map((p) => ({ value: p.name, label: p.name }))
+	])
+
+	// Drop a selection that doesn't exist in the chosen location (e.g. after
+	// switching location). Setting it to '' once is stable — the guard then fails.
+	$effect(() => {
+		if (gen.pullSecret && !locationPullSecrets.some((p) => p.name === gen.pullSecret)) {
+			gen.pullSecret = ''
+		}
+	})
+
+	const PULL_SA_SID = 'github-pull'
+	const PULL_SA_NAME = 'GitHub Pull'
+	const PULL_ROLE = 'github-pull'
+	const PULL_SECRET_NAME = 'github-pull'
+	const REGISTRY_SERVER = 'https://registry.deploys.app'
+
+	let creatingPullSecret = $state(false)
+	let pullSecretError = $state('')
+
+	// Provision a dedicated pull-only service account (registry.pull), mint a
+	// key, and create a pull secret for it in the selected location — then select
+	// it in the generator. Idempotent: reuses an existing github-pull secret,
+	// service account, role, or key rather than duplicating them.
+	async function createPullSecret () {
+		if (creatingPullSecret) return
+		const location = gen.location
+		if (!location) {
+			pullSecretError = 'Select a location first.'
+			return
+		}
+
+		creatingPullSecret = true
+		pullSecretError = ''
+		try {
+			// Already provisioned in this location? Just select it.
+			const existing = pullSecrets.find((p) => p.name === PULL_SECRET_NAME && p.location === location)
+			if (existing) {
+				gen.pullSecret = existing.name
+				return
+			}
+
+			// 1. Dedicated pull-only service account (tolerate an existing one).
+			const saResp = await api.invoke('serviceAccount.create', { project, sid: PULL_SA_SID, name: PULL_SA_NAME }, fetch)
+			if (!saResp.ok && !/already exist/i.test(saResp.error?.message ?? '')) {
+				pullSecretError = saResp.error?.message ?? 'Failed to create the pull service account.'
+				return
+			}
+
+			// 2. Resolve the SA email + existing keys.
+			let getResp = await api.invoke('serviceAccount.get', { project, id: PULL_SA_SID }, fetch)
+			if (!getResp.ok) {
+				pullSecretError = getResp.error?.message ?? 'Failed to read the pull service account.'
+				return
+			}
+			const email = getResp.result?.email
+			if (!email) {
+				pullSecretError = 'The pull service account has no email.'
+				return
+			}
+
+			// 3. Ensure the github-pull role (registry.pull) exists, then bind it.
+			const roleResp = await api.invoke('role.get', { project, role: PULL_ROLE }, fetch)
+			if (!roleResp.ok && roleResp.error?.notFound) {
+				const roleCreate = await api.invoke('role.create', {
+					project,
+					role: PULL_ROLE,
+					name: PULL_SA_NAME,
+					permissions: ['registry.pull']
+				}, fetch)
+				if (!roleCreate.ok && !/already exist/i.test(roleCreate.error?.message ?? '')) {
+					pullSecretError = roleCreate.error?.message ?? 'Failed to create the github-pull role.'
+					return
+				}
+			}
+			const bindResp = await api.invoke('role.bind', { project, email, roles: [PULL_ROLE] }, fetch)
+			if (!bindResp.ok) {
+				pullSecretError = bindResp.error?.message ?? 'Failed to bind the github-pull role.'
+				return
+			}
+
+			// 4. Reuse a key if the SA already has one; otherwise mint one and
+			//    re-read (createKey returns no secret).
+			let keys = getResp.result?.keys ?? []
+			if (keys.length === 0) {
+				const keyResp = await api.invoke('serviceAccount.createKey', { project, id: PULL_SA_SID }, fetch)
+				if (!keyResp.ok) {
+					pullSecretError = keyResp.error?.message ?? 'Failed to create a service account key.'
+					return
+				}
+				getResp = await api.invoke('serviceAccount.get', { project, id: PULL_SA_SID }, fetch)
+				if (!getResp.ok) {
+					pullSecretError = getResp.error?.message ?? 'Failed to read the new key.'
+					return
+				}
+				keys = getResp.result?.keys ?? []
+			}
+			// Newest key by createdAt.
+			const newest = keys.reduce((a, b) => (new Date(b.createdAt) > new Date(a.createdAt) ? b : a), keys[0])
+			const secret = newest?.secret
+			if (!secret) {
+				pullSecretError = 'Could not read the service account key secret.'
+				return
+			}
+
+			// 5. Create the pull secret in the selected location.
+			const psResp = await api.invoke('pullSecret.create', {
+				project,
+				location,
+				name: PULL_SECRET_NAME,
+				spec: { server: REGISTRY_SERVER, username: email, password: secret }
+			}, fetch)
+			if (!psResp.ok && !/already exist/i.test(psResp.error?.message ?? '')) {
+				pullSecretError = psResp.error?.message ?? 'Failed to create the pull secret.'
+				return
+			}
+
+			// 6. Reflect it locally + select it.
+			if (!pullSecrets.some((p) => p.name === PULL_SECRET_NAME && p.location === location)) {
+				pullSecrets = [...pullSecrets, { name: PULL_SECRET_NAME, location }]
+			}
+			gen.pullSecret = PULL_SECRET_NAME
+		} catch (e) {
+			pullSecretError = e instanceof Error ? e.message : 'Failed to create the pull secret.'
+		} finally {
+			creatingPullSecret = false
+		}
+	}
+
+	// --- workflow YAML ---
+	const permissionsBlock = $derived(gen.buildType === 'static'
+		? `permissions:
+  id-token: write   # required — this is the credential
+  contents: read
+  pull-requests: write   # sticky PR preview comment`
+		: `permissions:
+  id-token: write   # required — this is the credential
+  contents: read`)
+
+	// Build the action's `with:` block, emitting only the keys the user set so
+	// the generated workflow stays minimal.
+	function withBlock () {
+		const out = []
+		out.push(`        project: ${project}`)
+		out.push(`        location: ${gen.location}`)
+		out.push(`        name: ${gen.name || 'web'}`)
+
+		if (gen.buildType === 'static') {
+			out.push('        mode: static')
+			out.push(`        framework: ${gen.framework || 'auto'}`)
+			if (gen.buildCommand.trim()) out.push(`        buildCommand: ${gen.buildCommand.trim()}`)
+			out.push(`        outputDir: ${gen.outputDir || 'public'}`)
+			out.push(`        spa: ${gen.spa ? 'true' : 'false'}`)
+			out.push(`        notFound: ${gen.notFound || '404.html'}`)
+		} else {
+			out.push(`        port: ${Number(gen.port) || 8080}`)
+		}
+
+		const wd = gen.workingDirectory.trim()
+		if (wd && wd !== '.') out.push(`        workingDirectory: ${wd}`)
+
+		const envLines = gen.env.split('\n').map((l) => l.trim()).filter(Boolean)
+		if (envLines.length) {
+			out.push('        env: |')
+			for (const l of envLines) out.push(`          ${l}`)
+		}
+
+		if (gen.envGroups.length) out.push(`        envGroups: ${gen.envGroups.join(',')}`)
+
+		// Pull secret only applies to container deploys — static has no pod.
+		if (gen.buildType === 'dockerfile' && gen.pullSecret) {
+			out.push(`        pullSecret: ${gen.pullSecret}`)
+		}
+
+		return out.join('\n')
+	}
+
+	const workflowYaml = $derived(`name: Deploy
 on:
   push:
     branches: [${genBranch}]
   pull_request:
 
-permissions:
-  id-token: write   # required — this is the credential
-  contents: read
+${permissionsBlock}
 
 jobs:
   deploy:
@@ -89,41 +299,8 @@ jobs:
     - uses: actions/checkout@v4
     - uses: deploys-app/build-deploy-action@v1
       with:
-        project: ${project}
-        location: ${gen.location}
-        name: ${gen.name || 'web'}
-        port: ${Number(gen.port) || 8080}
+${withBlock()}
 `)
-
-	const staticYaml = $derived(`name: Deploy
-on:
-  push:
-    branches: [${genBranch}]
-  pull_request:
-
-permissions:
-  id-token: write   # required — this is the credential
-  contents: read
-  pull-requests: write   # sticky PR preview comment
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: deploys-app/build-deploy-action@v1
-      with:
-        project: ${project}
-        location: ${gen.location}
-        name: ${gen.name || 'web'}
-        mode: static
-        framework: ${gen.framework || 'auto'}
-${gen.buildCommand.trim() ? `        buildCommand: ${gen.buildCommand.trim()}\n` : ''}        outputDir: ${gen.outputDir || 'public'}
-        spa: ${gen.spa ? 'true' : 'false'}
-        notFound: ${gen.notFound || '404.html'}
-`)
-
-	const workflowYaml = $derived(gen.buildType === 'static' ? staticYaml : dockerfileYaml)
 
 	const createOnGitHubURL = $derived(gen.repository
 		? `https://github.com/${gen.repository}/new/main?filename=.github/workflows/deploy.yml&value=${encodeURIComponent(workflowYaml)}`
@@ -265,6 +442,86 @@ ${gen.buildCommand.trim() ? `        buildCommand: ${gen.buildCommand.trim()}\n`
 					</div>
 				</div>
 			{/if}
+			<div class="field">
+				<label for="gen-working-directory">Root folder</label>
+				<div class="input">
+					<input id="gen-working-directory" class="font-mono" bind:value={gen.workingDirectory} placeholder=". (monorepo: apps/web)">
+				</div>
+			</div>
+		</div>
+
+		<div class="grid gap-4 lg:grid-cols-2">
+			<div class="field">
+				<label for="gen-env">Environment variables</label>
+				<div class="textarea">
+					<textarea id="gen-env" class="font-mono" rows="4" bind:value={gen.env} placeholder="KEY=value&#10;ANOTHER=thing"></textarea>
+				</div>
+				<p class="text-content/50 text-sm mt-1">One <span class="font-mono">KEY=VALUE</span> per line.</p>
+			</div>
+
+			<div class="field">
+				<label for="gen-env-group">Env groups</label>
+				{#key gen.envGroups}
+					<Select
+						id="gen-env-group"
+						placeholder="Add an env group"
+						resetOnSelect
+						disabled={envGroupOptions.length === 0}
+						onchange={(v) => addEnvGroup(String(v))}
+						options={envGroupOptions} />
+				{/key}
+				{#if gen.envGroups.length > 0}
+					<div class="flex flex-wrap gap-2 mt-2">
+						{#each gen.envGroups as name (name)}
+							<span class="env-group-chip font-mono text-sm">
+								{name}
+								<button type="button" class="chip-remove" aria-label={`Remove ${name}`} onclick={() => removeEnvGroup(name)}>
+									<i class="fa-solid fa-xmark"></i>
+								</button>
+							</span>
+						{/each}
+					</div>
+				{/if}
+				<p class="text-content/50 text-sm mt-1">Each group must already exist in this project.</p>
+			</div>
+
+			{#if gen.buildType === 'dockerfile'}
+				<div class="field">
+					<label for="gen-pull-secret">Pull secret</label>
+					<div class="flex items-center gap-2">
+						<div class="flex-1">
+							<Select id="gen-pull-secret" bind:value={gen.pullSecret} options={pullSecretOptions} />
+						</div>
+						{#if canProvisionPullSecret}
+							<button
+								class="button is-variant-secondary"
+								class:is-loading={creatingPullSecret}
+								disabled={creatingPullSecret || !gen.location}
+								onclick={createPullSecret}
+								title="Create a dedicated pull-only service account and pull secret in this location"
+								type="button">
+								<i class="fa-solid fa-plus mr-2"></i>
+								New
+							</button>
+						{:else}
+							<span class="inline-flex" title={denyTooltip('pullsecret.create')}>
+								<button class="button is-variant-secondary" type="button" disabled aria-disabled="true">
+									<i class="fa-solid fa-plus mr-2"></i>
+									New
+								</button>
+							</span>
+						{/if}
+					</div>
+					{#if pullSecretError}
+						<p class="text-negative text-sm mt-1">{pullSecretError}</p>
+					{:else}
+						<p class="text-content/50 text-sm mt-1">
+							For a private image registry. <strong>New</strong> provisions a dedicated
+							pull-only service account and secret for <span class="font-mono">registry.deploys.app</span>.
+						</p>
+					{/if}
+				</div>
+			{/if}
 		</div>
 
 		<pre class="workflow-yaml font-mono text-sm">{workflowYaml}</pre>
@@ -296,5 +553,24 @@ ${gen.buildCommand.trim() ? `        buildCommand: ${gen.buildCommand.trim()}\n`
 
 	:root:not(.dark) .workflow-yaml {
 		background-color: hsl(var(--hsl-base-100) / 0.6);
+	}
+
+	.env-group-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		padding: 0.125rem 0.5rem;
+		border-radius: var(--radius-md);
+		border: 1px solid hsl(var(--hsl-line));
+		background-color: hsl(var(--hsl-base-400) / 0.12);
+	}
+
+	.chip-remove {
+		display: inline-flex;
+		color: hsl(var(--hsl-content) / 0.5);
+	}
+
+	.chip-remove:hover {
+		color: hsl(var(--hsl-negative));
 	}
 </style>


### PR DESCRIPTION
Extends the GitHub Actions **Workflow** generator (project → GitHub) with the deployment config the new [build-deploy-action inputs](https://github.com/deploys-app/build-deploy-action/pull/3) accept, so the generated `deploy.yml` covers monorepos and richer config without hand-editing.

## New generator fields

- **Root folder** (`workingDirectory`) — for monorepos (e.g. `apps/web`); emitted for both dockerfile and static build types. Omitted from the YAML when left at the default.
- **Environment variables** — a `KEY=VALUE` textarea rendered as an `env: |` block.
- **Env groups** — multi-select of the project's env groups (chips with remove), emitted as `envGroups: a,b`. Each must already exist.
- **Pull secret** (container builds only) — a select of the location's pull secrets, plus a **New** button that provisions a **dedicated pull-only service account** and pull secret, then selects it.

## Dedicated pull secret provisioning

The **New** button (gated on the full permission set: `serviceaccount.create`, `serviceaccount.key.create`, `pullsecret.create`, `role.bind`, and `role.create` unless the role already exists) runs an idempotent flow:

1. Create the `github-pull` service account (tolerates an existing one).
2. Ensure the `github-pull` role (`registry.pull`) exists and bind it to the SA.
3. Reuse an existing key or mint one, then read the secret back (`serviceAccount.createKey` returns no secret, so it re-reads via `serviceAccount.get`).
4. Create a `github-pull` pull secret in the selected location pointing at `registry.deploys.app` (username = SA email, password = key secret).
5. Reflect it locally and select it.

An already-provisioned `github-pull` secret in that location is reused rather than duplicated.

## Loader

`+page.js` now also fetches `envGroup.list`, `pullSecret.list` (all locations, filtered to the selected location client-side), and `role.get github-pull` to compute the provisioning affordance.

## Verification

- `bun lint` + `bun check` clean.
- Rendered against the mock and exercised end-to-end: filled root folder/env/env-group and confirmed the generated YAML; clicked **New** and confirmed the flow sets `pullSecret: github-pull`; confirmed static mode omits `port`/`pullSecret` while keeping the shared fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
