### PR TITLE
Add Cache (edge cache-override) console feature

### DIFF
--- a/src/lib/cache/overrides.js
+++ b/src/lib/cache/overrides.js
@@ -1,0 +1,155 @@
+// Shared override helpers for the cache list + edit pages. Override ids are
+// auto-generated and stable for the life of an override (they appear in
+// parapet's logs/metrics as override_id), so they must survive reordering.
+// Order = match order, with `priority` derived from index on every whole-zone
+// write — first match wins, lower priority first.
+
+/**
+ * @typedef {Object} OverrideForm
+ * @property {string} id
+ * @property {string} description
+ * @property {'cache' | 'bypass'} action
+ * @property {string} filter
+ * @property {string} ttl
+ * @property {'conservative' | 'balanced' | 'aggressive'} policy
+ * @property {string} staleWhileRevalidate
+ * @property {string} staleIfError
+ * @property {number[]} status
+ * @property {'enforce' | 'shadow'} mode
+ */
+
+export const DEFAULT_POLICY = 'balanced'
+export const DEFAULT_TTL = '1h'
+
+/** @type {Record<string, string>} */
+export const actionLabels = {
+	cache: 'Cache',
+	bypass: 'Bypass'
+}
+
+/** @type {Record<string, string>} */
+export const policyLabels = {
+	conservative: 'Conservative',
+	balanced: 'Balanced',
+	aggressive: 'Aggressive'
+}
+
+/** @type {Record<string, string>} */
+export const modeLabels = {
+	enforce: 'Enforce',
+	shadow: 'Shadow'
+}
+
+// TTL presets covering the API's allowed 1s..720h range. Zones loaded with a
+// ttl outside this list still render — the edit page appends the loaded value
+// as an extra option.
+/** @type {{ value: string, label: string }[]} */
+export const ttlOptions = [
+	{ value: '1m', label: '1 minute' },
+	{ value: '5m', label: '5 minutes' },
+	{ value: '1h', label: '1 hour' },
+	{ value: '6h', label: '6 hours' },
+	{ value: '24h', label: '24 hours' },
+	{ value: '168h', label: '7 days' }
+]
+
+/**
+ * @param {Api.CacheOverride} [override]
+ * @returns {OverrideForm}
+ */
+export function overrideForm (override) {
+	return {
+		id: override?.id ?? '',
+		description: override?.description ?? '',
+		action: override?.action ?? 'cache',
+		filter: override?.filter ?? '',
+		ttl: override?.ttl ?? DEFAULT_TTL,
+		policy: /** @type {OverrideForm['policy']} */ (override?.policy ?? DEFAULT_POLICY),
+		staleWhileRevalidate: override?.staleWhileRevalidate ?? '',
+		staleIfError: override?.staleIfError ?? '',
+		status: override?.status ?? [],
+		mode: override?.mode ?? 'enforce'
+	}
+}
+
+/**
+ * Generate a stable, unique override id that doesn't collide with `taken`.
+ * @param {string[]} taken
+ * @returns {string}
+ */
+export function genId (taken) {
+	let id
+	do {
+		id = 'override-' + Math.random().toString(36).slice(2, 8)
+	} while (taken.includes(id))
+	return id
+}
+
+// Map API overrides to form rows: order by priority (lower matches first) so
+// the visible order is the match order, and give every row a unique id.
+/**
+ * @param {Api.CacheOverride[]} [apiOverrides]
+ * @returns {OverrideForm[]}
+ */
+export function normalizeOverrides (apiOverrides) {
+	const sorted = [...(apiOverrides ?? [])].sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0))
+	/** @type {string[]} */
+	const taken = []
+	return sorted.map((o) => {
+		const f = overrideForm(o)
+		if (!f.id || taken.includes(f.id)) f.id = genId(taken)
+		taken.push(f.id)
+		return f
+	})
+}
+
+// Map form rows back to the API override shape. Priority follows row order —
+// the top override matches first. For action 'bypass' the API rejects
+// ttl/policy/status/stale_*, so those are OMITTED; for action 'cache' they
+// are included.
+/**
+ * @param {OverrideForm[]} overrides
+ * @returns {Api.CacheOverride[]}
+ */
+export function toApiOverrides (overrides) {
+	return overrides.map((o, i) => {
+		/** @type {Api.CacheOverride} */
+		const base = {
+			id: o.id,
+			description: o.description,
+			action: o.action,
+			filter: (o.filter ?? '').trim(),
+			mode: o.mode === 'shadow' ? 'shadow' : 'enforce',
+			priority: i
+		}
+		if (o.action === 'bypass') {
+			// Bypass skips the cache entirely — ttl/policy/status/stale_* are
+			// meaningless and rejected by the API, so omit them.
+			return base
+		}
+		/** @type {number[]} */
+		const status = (o.status ?? [])
+			.map((s) => Number(s))
+			.filter((s) => Number.isInteger(s) && s > 0)
+		return {
+			...base,
+			ttl: o.ttl,
+			policy: o.policy || DEFAULT_POLICY,
+			...(o.staleWhileRevalidate?.trim() ? { staleWhileRevalidate: o.staleWhileRevalidate.trim() } : {}),
+			...(o.staleIfError?.trim() ? { staleIfError: o.staleIfError.trim() } : {}),
+			...(status.length ? { status } : {})
+		}
+	})
+}
+
+/**
+ * Human summary of an override for the manage table, e.g. "Cache 1h (balanced)"
+ * or "Bypass".
+ * @param {OverrideForm} o
+ * @returns {string}
+ */
+export function describeOverride (o) {
+	if (o.action === 'bypass') return 'Bypass'
+	const policy = policyLabels[o.policy] ?? o.policy
+	return `Cache ${o.ttl} (${(policy ?? '').toLowerCase()})`
+}

--- a/src/lib/nav.js
+++ b/src/lib/nav.js
@@ -19,6 +19,7 @@ export const projectMenu = [
 	{ id: 'domain', title: 'Domains', icon: 'fa-globe', link: '/domain' },
 	{ id: 'route', title: 'Routes', icon: 'fa-router', link: '/route' },
 	{ id: 'waf', title: 'Firewall', icon: 'fa-shield-halved', link: '/waf', preview: true },
+	{ id: 'cache', title: 'Cache', icon: 'fa-bolt', link: '/cache', preview: true },
 	{ id: 'workload-identity', title: 'Workload Identities', icon: 'fa-network-wired', link: '/workload-identity' },
 	{ id: 'disk', title: 'Disks', icon: 'fa-hdd', link: '/disk' },
 	{ id: 'pull-secret', title: 'Pull Secrets', icon: 'fa-key', link: '/pull-secret' },

--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -105,7 +105,7 @@ const locations = [
 		cname: 'rcf2.deploys.app.',
 		cpuAllocatable: ['100m', '250m', '500m', '1000m', '2000m'],
 		memoryAllocatable: ['128Mi', '256Mi', '512Mi', '1Gi', '2Gi'],
-		features: { workloadIdentity: true, disk: {}, waf: {} },
+		features: { workloadIdentity: true, disk: {}, waf: {}, cache: {} },
 		createdAt: CREATED_AT
 	},
 	{
@@ -115,7 +115,7 @@ const locations = [
 		cname: 'sg1.deploys.app.',
 		cpuAllocatable: ['100m', '250m', '500m', '1000m', '2000m'],
 		memoryAllocatable: ['128Mi', '256Mi', '512Mi', '1Gi', '2Gi'],
-		features: { workloadIdentity: true, disk: {}, waf: {} },
+		features: { workloadIdentity: true, disk: {}, waf: {}, cache: {} },
 		createdAt: CREATED_AT
 	}
 ]
@@ -492,6 +492,122 @@ function wafConfiguredZone (location, advance = false) {
 		description: entry.description,
 		rules: [],
 		limits: [],
+		status,
+		action: 'create',
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL
+	}
+}
+
+const cacheZone = {
+	project: 'acme',
+	location: LOCATION_ID,
+	description: 'Force-cache static assets, bypass the admin area',
+	overrides: [
+		{
+			id: 'static-assets',
+			description: 'Force long-lived caching for static assets',
+			action: 'cache',
+			filter: "request.path.startsWith('/static/')",
+			ttl: '1h',
+			policy: 'balanced',
+			staleWhileRevalidate: '30s',
+			status: [200],
+			mode: 'enforce',
+			priority: 0
+		},
+		{
+			id: 'bypass-admin',
+			description: 'Never cache the admin area',
+			action: 'bypass',
+			filter: "request.path.startsWith('/admin')",
+			mode: 'enforce',
+			priority: 1
+		},
+		{
+			id: 'shadow-api',
+			description: 'Trial caching of API GETs (shadow only)',
+			action: 'cache',
+			filter: "request.path.startsWith('/api/') && request.method == 'GET'",
+			ttl: '5m',
+			policy: 'aggressive',
+			mode: 'shadow',
+			priority: 2
+		}
+	],
+	status: 'success',
+	action: 'create',
+	createdAt: CREATED_AT,
+	createdBy: USER_EMAIL
+}
+
+// Synthetic cache decision metrics for the seed zone, so the cache index
+// sparkline + total and the metrics page have something to draw. Scatters
+// counts across the requested window per (override, action, result), mirroring
+// cache.metrics' shape (sparse buckets, grand total). Reuses wafRangeSeconds.
+/** @param {string} [timeRange] */
+function cacheMetrics (timeRange) {
+	const now = Math.floor(Date.now() / 1000)
+	const windowSeconds = wafRangeSeconds[timeRange ?? '1d'] ?? wafRangeSeconds['1d']
+
+	/**
+	 * @param {string} overrideId
+	 * @param {Api.CacheAction} action
+	 * @param {Api.CacheMetricsSeries['result']} result
+	 * @param {number} buckets  // how many active samples
+	 * @param {number} scale    // max count per sample
+	 */
+	const makeSeries = (overrideId, action, result, buckets, scale) => {
+		/** @type {[number, number][]} */
+		const points = []
+		let total = 0
+		for (let i = 0; i < buckets; i++) {
+			const ts = now - Math.floor(Math.random() * windowSeconds)
+			const v = 1 + Math.floor(Math.random() * scale)
+			points.push([ts, v])
+			total += v
+		}
+		points.sort((a, b) => a[0] - b[0])
+		return { overrideId, action, result, total, points }
+	}
+
+	const series = [
+		makeSeries('static-assets', 'cache', 'applied', 90, 8),
+		makeSeries('static-assets', 'cache', 'error', 12, 2),
+		makeSeries('bypass-admin', 'bypass', 'applied', 40, 3),
+		makeSeries('shadow-api', 'cache', 'shadow', 70, 5)
+	]
+	const total = series.reduce((acc, s) => acc + s.total, 0)
+	return { series, total }
+}
+
+// Locations (besides the seed LOCATION_ID) that have had cache configured in
+// this dev session, mapped to { description, polls }. Mirrors wafConfigured —
+// the simulated deployer flips a freshly created zone from pending → success
+// after the first list read, so the index spinner resolves on its own.
+/** @type {Map<string, { description: string, polls: number }>} */
+const cacheConfigured = new Map()
+
+/**
+ * Build a cache zone for a session-created location. `advance` simulates the
+ * deployer: set on cache.list reads (the index poll) so the first list shows
+ * pending/create and the next list settles to success. cache.get reads observe
+ * the same state without advancing it.
+ * @param {string} location
+ * @param {boolean} [advance]
+ */
+function cacheConfiguredZone (location, advance = false) {
+	const entry = cacheConfigured.get(location) ?? { description: '', polls: 0 }
+	const status = entry.polls > 0 ? 'success' : 'pending'
+	if (advance) {
+		entry.polls += 1
+		cacheConfigured.set(location, entry)
+	}
+	return {
+		project: 'acme',
+		location,
+		description: entry.description,
+		overrides: [],
 		status,
 		action: 'create',
 		createdAt: CREATED_AT,
@@ -1049,6 +1165,47 @@ const handlers = {
 	},
 	'waf.delete': (args) => {
 		if (args?.location) wafConfigured.delete(args.location)
+		return ok({})
+	},
+
+	// The seed location starts configured and live; every other location is
+	// "cache not configured yet" (not-found) until created. A freshly created
+	// location starts as { status: 'pending', action: 'create' } and the
+	// simulated deployer flips it to 'success' after the first read (see
+	// cacheConfiguredZone), so the index spinner resolves on its own. cache.set
+	// and cache.delete keep the index/create/manage flows coherent within a
+	// session.
+	'cache.list': () => {
+		const items = [{ ...cacheZone, location: LOCATION_ID }]
+		for (const location of cacheConfigured.keys()) {
+			items.push(cacheConfiguredZone(location, true))
+		}
+		return ok({ project: 'acme', items })
+	},
+	'cache.get': (args) => {
+		const location = args?.location ?? LOCATION_ID
+		if (location === LOCATION_ID) return ok({ ...cacheZone, location: LOCATION_ID })
+		if (cacheConfigured.has(location)) {
+			return ok(cacheConfiguredZone(location))
+		}
+		return err('api: cache zone not found')
+	},
+	'cache.set': (args) => {
+		const location = args?.location
+		if (location && location !== LOCATION_ID) {
+			cacheConfigured.set(location, { description: args?.description ?? '', polls: 0 })
+		}
+		return ok({})
+	},
+	'cache.metrics': (args) => {
+		// Seed zone has activity; session-created zones read empty (shows the "—"
+		// no-traffic state on the index).
+		const location = args?.location ?? LOCATION_ID
+		if (location === LOCATION_ID) return ok(cacheMetrics(args?.timeRange))
+		return ok({ series: [], total: 0 })
+	},
+	'cache.delete': (args) => {
+		if (args?.location) cacheConfigured.delete(args.location)
 		return ok({})
 	},
 

--- a/src/routes/(auth)/(project)/cache/+layout.js
+++ b/src/routes/(auth)/(project)/cache/+layout.js
@@ -1,0 +1,6 @@
+export function load () {
+	return {
+		menu: 'cache',
+		overrideRedirect: '/cache'
+	}
+}

--- a/src/routes/(auth)/(project)/cache/+page.js
+++ b/src/routes/(auth)/(project)/cache/+page.js
@@ -1,0 +1,14 @@
+import api from '$lib/api'
+
+export async function load ({ parent, fetch }) {
+	const { project } = await parent()
+
+	/** @type {Api.Response<Api.CacheZoneList>} */
+	const res = await api.invoke('cache.list', { project }, fetch)
+
+	return {
+		project,
+		zones: res.result?.items ?? [],
+		error: res.error
+	}
+}

--- a/src/routes/(auth)/(project)/cache/+page.svelte
+++ b/src/routes/(auth)/(project)/cache/+page.svelte
@@ -1,0 +1,203 @@
+<script>
+	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import Sparkline from '$lib/components/Sparkline.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import { onMount } from 'svelte'
+	import api from '$lib/api'
+	import * as format from '$lib/format'
+
+	const { data } = $props()
+
+	const project = $derived(data.project)
+	const zones = $derived(data.zones)
+	const error = $derived(data.error)
+
+	const hasPending = $derived(zones.some((/** @type {Api.CacheZone} */ z) => z.status === 'pending'))
+
+	// While any zone is still being applied/removed by the deployer, poll
+	// cache.list so the spinner resolves to its settled state on its own. Mirrors
+	// the WAF list polling pattern (api.intervalInvalidate in onMount).
+	onMount(() => api.intervalInvalidate(async () => {
+		if (!hasPending) return
+		await api.invalidate('cache.list')
+	}, 3000))
+
+	// Last 24h of cache decision activity per location, shown as an inline
+	// sparkline + total. Fetched client-side (one cache.metrics per zone, in
+	// parallel) so the table renders immediately and the charts fill in.
+	/**
+	 * @typedef {Object} Metrics
+	 * @property {boolean} loading
+	 * @property {number} total
+	 * @property {[number, number][]} points
+	 */
+	/** @type {Record<string, Metrics>} */
+	const metrics = $state({})
+
+	// Fixed 24h x-domain so bars sit at the right time-of-day even when the zone
+	// only has a few active minutes.
+	const to = Math.floor(Date.now() / 1000)
+	const from = to - 24 * 60 * 60
+
+	onMount(() => {
+		Promise.all(zones.map(async (/** @type {Api.CacheZone} */ z) => {
+			metrics[z.location] = { loading: true, total: 0, points: [] }
+
+			/** @type {Api.Response<Api.CacheMetricsResult>} */
+			const res = await api.invoke('cache.metrics',
+				{ project, location: z.location, timeRange: '1d' }, fetch)
+
+			metrics[z.location] = {
+				loading: false,
+				total: res.result?.total ?? 0,
+				points: aggregate(res.result?.series ?? [])
+			}
+		}))
+	})
+
+	// Collapse the per-(override, action, result) series into one total-decisions
+	// line: sum every series' value at each timestamp, then sort by time.
+	/**
+	 * @param {Api.CacheMetricsSeries[]} series
+	 * @returns {[number, number][]}
+	 */
+	function aggregate (series) {
+		/** @type {Record<number, number>} */
+		const byTs = {}
+		for (const s of series) {
+			for (const [ts, v] of s.points ?? []) {
+				byTs[ts] = (byTs[ts] ?? 0) + v
+			}
+		}
+		return Object.entries(byTs)
+			.map(([ts, v]) => /** @type {[number, number]} */ ([Number(ts), v]))
+			.sort((a, b) => a[0] - b[0])
+	}
+</script>
+
+<div class="page-head">
+	<div>
+		<h4><strong>Cache</strong></h4>
+		<p class="page-sub">
+			{zones.length} {zones.length === 1 ? 'cache zone' : 'cache zones'}
+		</p>
+	</div>
+	<GuardedButton permission="cache.set" class="button is-icon-left" href={`/cache/create?project=${project}`}>
+		<i class="fa-solid fa-plus"></i>
+		Configure cache
+	</GuardedButton>
+</div>
+
+<div class="panel is-level-300">
+	<div class="table-container">
+		<table class="table is-variant-compact">
+			<thead>
+				<tr>
+					<th>Location</th>
+					<th>Status</th>
+					<th>Description</th>
+					<th>Overrides</th>
+					<th>Decisions (24h)</th>
+					<th class="is-collapse is-align-right"></th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each zones as zone (zone.location)}
+					<tr>
+						<td>
+							<a href={`/cache/metrics?project=${project}&location=${encodeURIComponent(zone.location)}`} class="link font-mono">{zone.location}</a>
+						</td>
+						<td>
+							{#if zone.status === 'pending'}
+								<span class="inline-flex items-center gap-2 text-content/70">
+									<i class="fa-solid fa-spinner-third fa-spin"></i>
+									{zone.action === 'delete' ? 'Removing' : 'Deploying'}
+								</span>
+							{:else if zone.status === 'error'}
+								<span class="inline-flex items-center gap-2 text-negative/80">
+									<i class="fa-solid fa-times"></i>
+									Error
+								</span>
+							{:else}
+								<span class="inline-flex items-center gap-2 text-positive/80">
+									<i class="fa-solid fa-check-circle"></i>
+									Active
+								</span>
+							{/if}
+						</td>
+						<td>
+							{#if zone.description}
+								{zone.description}
+							{:else}
+								<span class="text-content/40">—</span>
+							{/if}
+						</td>
+						<td>{zone.overrides?.length ?? 0}</td>
+						<td>
+							<!-- Reserve the loaded size in every state so the row/column keeps
+							     its dimensions while the async sparkline fills in (no layout shift). -->
+							<div class="matches-cell">
+								{#if metrics[zone.location]?.loading}
+									<span class="text-content/30"><i class="fa-solid fa-spinner-third fa-spin"></i></span>
+								{:else if (metrics[zone.location]?.total ?? 0) > 0}
+									<a class="matches-link flex items-center gap-3"
+										href={`/cache/metrics?project=${project}&location=${encodeURIComponent(zone.location)}`}
+										title={`${metrics[zone.location].total.toLocaleString()} cache decisions in the last 24h — view metrics`}>
+										<span class="font-mono text-sm tabular-nums">
+											{format.count(metrics[zone.location].total)}
+										</span>
+										<Sparkline points={metrics[zone.location].points} {from} {to} />
+									</a>
+								{:else}
+									<span class="text-content/40">—</span>
+								{/if}
+							</div>
+						</td>
+						<td>
+							<div class="flex gap-1 justify-end">
+								<a class="button is-variant-secondary is-size-small"
+									href={`/cache/manage?project=${project}&location=${encodeURIComponent(zone.location)}`}>
+									Manage
+								</a>
+							</div>
+						</td>
+					</tr>
+				{/each}
+				<NoDataRow
+					span={6}
+					list={zones}
+					icon="fa-bolt"
+					message="No cache zones yet"
+					hint="Configure cache to start overriding edge caching in a location."
+					ctaLabel="Configure cache"
+					ctaHref={`/cache/create?project=${project}`} />
+				<ErrorRow span={6} {error} />
+			</tbody>
+		</table>
+	</div>
+</div>
+
+<style>
+	/* Hold a fixed box across the loading / loaded / empty states: min-height
+	   matches the Sparkline's height (28px) and min-width its count + chart, so
+	   the row doesn't grow taller or the column wider when the chart loads. */
+	.matches-cell {
+		display: flex;
+		align-items: center;
+		min-height: 28px;
+		min-width: 10rem;
+	}
+
+	/* The decisions total + sparkline doubles as a shortcut into the metrics view. */
+	.matches-link {
+		width: fit-content;
+		color: inherit;
+		border-radius: 0.375rem;
+		transition: color var(--timing-fastest) ease;
+	}
+
+	.matches-link:hover {
+		color: hsl(var(--hsl-primary));
+	}
+</style>

--- a/src/routes/(auth)/(project)/cache/create/+page.js
+++ b/src/routes/(auth)/(project)/cache/create/+page.js
@@ -1,0 +1,30 @@
+import api from '$lib/api'
+
+export async function load ({ parent, fetch }) {
+	const { project, locations } = await parent()
+
+	// Only locations whose backend supports caching can host a cache zone; drop
+	// the rest before the fan-out (also saves a cache.get per unsupported
+	// location).
+	const supported = locations.filter(
+		(/** @type {Api.Location} */ loc) => loc.features.cache
+	)
+
+	// No "list zones" endpoint per-location — fan out cache.get to discover which
+	// locations are already configured, then offer only the unconfigured ones for
+	// create.
+	const configured = await Promise.all(
+		supported.map(async (/** @type {Api.Location} */ loc) => {
+			/** @type {Api.Response<Api.CacheZone>} */
+			const res = await api.invoke('cache.get', { project, location: loc.id }, fetch)
+			return res.ok && res.result ? loc.id : null
+		})
+	)
+	const configuredSet = configured.filter((id) => id != null)
+
+	const available = supported.filter(
+		(/** @type {Api.Location} */ loc) => !configuredSet.includes(loc.id)
+	)
+
+	return { project, locations: available }
+}

--- a/src/routes/(auth)/(project)/cache/create/+page.svelte
+++ b/src/routes/(auth)/(project)/cache/create/+page.svelte
@@ -1,0 +1,98 @@
+<script>
+	import { goto } from '$app/navigation'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+
+	const { data } = $props()
+
+	const project = $derived(data.project)
+	const locations = $derived(data.locations)
+
+	const form = $state({
+		location: '',
+		description: ''
+	})
+
+	let saving = $state(false)
+
+	/** @param {Event} e */
+	async function save (e) {
+		e.preventDefault()
+		if (saving) return
+
+		saving = true
+		try {
+			const resp = await api.invoke('cache.set', {
+				project,
+				location: form.location,
+				description: form.description,
+				overrides: []
+			}, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+			goto(`/cache/manage?project=${project}&location=${encodeURIComponent(form.location)}`)
+		} finally {
+			saving = false
+		}
+	}
+
+	function cancel () {
+		goto(`/cache?project=${project}`)
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/cache?project=${project}`} class="link"><h6>Cache</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<h6>Configure</h6>
+	</div>
+</div>
+
+<br>
+
+<div class="page-head">
+	<div>
+		<h4><strong>Configure cache</strong></h4>
+		<p class="page-sub">Enable edge cache overrides in a location.</p>
+	</div>
+</div>
+
+<div class="panel is-level-300 grid gap-6">
+	{#if locations.length === 0}
+		<p class="text-content/60">
+			Every location already has cache configured. Manage an existing one
+			from the <a href={`/cache?project=${project}`} class="link">cache list</a>.
+		</p>
+	{:else}
+		<form class="grid gap-4 w-full" onsubmit={save}>
+			<div class="field">
+				<label for="input-location">Location</label>
+				<Select
+					id="input-location"
+					bind:value={form.location}
+					required
+					placeholder="Select Location"
+					options={locations.map((it) => ({ value: it.id, label: it.id }))} />
+			</div>
+			<div class="field">
+				<label for="input-description">Description</label>
+				<div class="input">
+					<input id="input-description" bind:value={form.description} placeholder="Optional description">
+				</div>
+			</div>
+
+			<hr>
+
+			<div class="flex gap-3">
+				<GuardedButton permission="cache.set" type="submit" loading={saving}>Save</GuardedButton>
+				<button type="button" class="button is-variant-secondary" onclick={cancel}>Cancel</button>
+			</div>
+		</form>
+	{/if}
+</div>

--- a/src/routes/(auth)/(project)/cache/edit/+page.js
+++ b/src/routes/(auth)/(project)/cache/edit/+page.js
@@ -1,0 +1,39 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+
+export async function load ({ url, parent, fetch }) {
+	const { project } = await parent()
+	const location = url.searchParams.get('location') ?? ''
+	const overrideId = url.searchParams.get('override')
+
+	if (!location) {
+		redirect(302, `/cache?project=${project}`)
+	}
+
+	const manageUrl = `/cache/manage?project=${project}&location=${encodeURIComponent(location)}`
+
+	/** @type {Api.Response<Api.CacheZone>} */
+	const res = await api.invoke('cache.get', { project, location }, fetch)
+	// A missing zone is the normal "cache not configured yet" state — render an
+	// empty editor (create mode). Surface anything else.
+	if (!res.ok && !res.error?.notFound) {
+		error(500, res.error?.message)
+	}
+	const zone = res.result ?? null
+
+	// Editing a specific override requires its zone + override to exist;
+	// otherwise send the user back to the list for this location.
+	if (overrideId) {
+		const found = zone?.overrides?.some((o) => o.id === overrideId)
+		if (!found) {
+			redirect(302, manageUrl)
+		}
+	}
+
+	return {
+		project,
+		location,
+		overrideId,
+		zone
+	}
+}

--- a/src/routes/(auth)/(project)/cache/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/cache/edit/+page.svelte
@@ -1,0 +1,392 @@
+<script>
+	import { untrack } from 'svelte'
+	import { goto } from '$app/navigation'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import WafConditionBuilder from '$lib/components/WafConditionBuilder.svelte'
+	import { parseExpression } from '$lib/waf/expression'
+	import {
+		overrideForm,
+		genId,
+		normalizeOverrides,
+		toApiOverrides,
+		ttlOptions
+	} from '$lib/cache/overrides'
+
+	const { data } = $props()
+
+	const project = $derived(data.project)
+	const location = $derived(data.location)
+
+	const actionOptions = [
+		{ value: 'cache', label: 'Cache — force a caching policy onto matching responses' },
+		{ value: 'bypass', label: 'Bypass — skip the cache entirely for matching requests' }
+	]
+
+	const policyOptions = [
+		{ value: 'conservative', label: 'Conservative — respect the origin’s Cache-Control most' },
+		{ value: 'balanced', label: 'Balanced' },
+		{ value: 'aggressive', label: 'Aggressive — override the origin’s Cache-Control hardest' }
+	]
+
+	const modeOptions = [
+		{ value: 'enforce', label: 'Enforce — change caching for matching requests' },
+		{ value: 'shadow', label: 'Shadow — only count, never change caching' }
+	]
+
+	// The whole loaded zone's overrides (ordered) are held in memory so Save can
+	// rewrite the entire zone with the edited override in place — cache.set
+	// replaces the zone, so the rest must be echoed back untouched.
+	const overrides = untrack(() => normalizeOverrides(data.zone?.overrides))
+	const description = untrack(() => data.zone?.description ?? '')
+	// Index of the override being edited, or -1 when adding a brand-new one.
+	const editIndex = untrack(() => (data.overrideId ? overrides.findIndex((o) => o.id === data.overrideId) : -1))
+	const isCreate = editIndex === -1
+
+	// Working-copy draft — Cancel discards it without touching the server.
+	const draft = $state(untrack(() => {
+		if (isCreate) {
+			const taken = overrides.map((o) => o.id)
+			return { ...overrideForm(), id: genId(taken) }
+		}
+		const seed = overrides[editIndex]
+		return { ...seed, status: [...seed.status] }
+	}))
+
+	// The status list is edited as a comma-separated string of HTTP statuses
+	// (cache action only). Seed it from the draft and parse on save.
+	let statusText = $state(untrack(() => draft.status.join(', ')))
+
+	let saving = $state(false)
+
+	// Filter editing mode — Visual (condition builder) or Expression (raw CEL
+	// textarea), same pattern as the WAF editors. The filter is optional: empty
+	// means the override applies to every request.
+	const canUseVisual = $derived(parseExpression(draft.filter) !== null)
+	let filterMode = $state(/** @type {'visual' | 'raw'} */ (
+		untrack(() => (parseExpression(draft.filter) !== null ? 'visual' : 'raw'))
+	))
+
+	// If we're in Visual but the filter becomes non-representable, fall back to
+	// raw so the disabled Visual tab can't show stale rows.
+	$effect(() => {
+		if (filterMode === 'visual' && !canUseVisual) filterMode = 'raw'
+	})
+
+	/** @type {{ clearExpression: () => void } | undefined} */
+	let filterBuilder = $state()
+
+	function clearFilter () {
+		if (filterMode === 'visual' && filterBuilder) filterBuilder.clearExpression()
+		else draft.filter = ''
+	}
+
+	// A loaded zone may carry a ttl outside the presets (the API accepts any
+	// 1s..720h Go duration) — keep it selectable so editing preserves it.
+	const allTtlOptions = $derived(
+		ttlOptions.some((o) => o.value === draft.ttl)
+			? ttlOptions
+			: [...ttlOptions, { value: draft.ttl, label: draft.ttl }]
+	)
+
+	// Save gate: a cache override needs a ttl; bypass needs nothing extra.
+	const canSave = $derived(draft.action === 'bypass' || !!draft.ttl)
+
+	function backToManage () {
+		return goto(`/cache/manage?project=${project}&location=${encodeURIComponent(location)}`)
+	}
+
+	/** @param {Event} e */
+	async function save (e) {
+		e.preventDefault()
+		if (saving || !canSave) return
+
+		// Parse the comma-separated status list into positive integers (cache only).
+		/** @type {number[]} */
+		const status = statusText
+			.split(',')
+			.map((s) => Number(s.trim()))
+			.filter((s) => Number.isInteger(s) && s > 0)
+
+		const edited = { ...draft, status }
+
+		saving = true
+		try {
+			// Rebuild the zone's override list with the edited override replaced by
+			// id (or appended for create), then write the whole zone.
+			let nextOverrides
+			if (isCreate) {
+				nextOverrides = [...overrides, edited]
+			} else {
+				nextOverrides = overrides.map((o) => (o.id === edited.id ? edited : o))
+			}
+
+			const resp = await api.invoke('cache.set', {
+				project,
+				location,
+				description,
+				overrides: toApiOverrides(nextOverrides)
+			}, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+			await backToManage()
+		} finally {
+			saving = false
+		}
+	}
+
+	function cancel () {
+		backToManage()
+	}
+
+	// Enter inside a text field (description, ttl/stale inputs, status list) must
+	// not implicitly submit the override. Saving is deliberate, via the Save
+	// button (a <button>, where Enter still works) and the raw-CEL <textarea>.
+	/** @param {HTMLFormElement} node */
+	function blockEnterSubmit (node) {
+		/** @param {KeyboardEvent} e */
+		function onKeydown (e) {
+			if (e.key === 'Enter' && e.target instanceof HTMLInputElement) e.preventDefault()
+		}
+		node.addEventListener('keydown', onKeydown)
+		return { destroy: () => node.removeEventListener('keydown', onKeydown) }
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/cache?project=${project}`} class="link"><h6>Cache</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<a href={`/cache/manage?project=${project}&location=${encodeURIComponent(location)}`} class="link"><h6 class="font-mono">{location}</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<h6>{isCreate ? 'Add override' : 'Edit override'}</h6>
+	</div>
+</div>
+
+<br>
+<div class="panel is-level-300 grid gap-6">
+	<div class="grid grid-cols-1 gap-3">
+		<div class="flex items-center">
+			<h3 class="mr-6 mb-4 xl:mb-0"><strong>{isCreate ? 'Add override' : 'Edit override'}</strong></h3>
+		</div>
+		<p class="page-sub">Cache override in <span class="font-mono">{location}</span></p>
+	</div>
+
+	<hr>
+
+	<form class="grid gap-6 w-full" onsubmit={save} use:blockEnterSubmit>
+		<div class="field">
+			<label for="override-description">Description</label>
+			<div class="input">
+				<input id="override-description" bind:value={draft.description} placeholder="Optional description">
+			</div>
+		</div>
+
+		<hr>
+
+		<div class="grid gap-4">
+			<div class="flex flex-wrap items-start justify-between gap-3">
+				<div>
+					<h6><strong>Apply to matching requests</strong></h6>
+					<p class="text-content/50 text-sm mt-1">
+						Optional — leave empty to apply this override to every request.
+						Only matching requests are affected.
+					</p>
+				</div>
+				<div class="flex flex-col items-end gap-1">
+					<div class="flex items-center gap-2">
+						<div class="tabs is-variant-underline" role="tablist">
+							<button type="button" class="tab-button" class:is-active={filterMode === 'visual'}
+								role="tab" aria-selected={filterMode === 'visual'}
+								disabled={!canUseVisual}
+								title={canUseVisual ? undefined : 'This expression can’t be shown in the visual editor'}
+								onclick={() => { if (canUseVisual) filterMode = 'visual' }}>
+								<i class="fa-solid fa-sliders mr-2"></i>
+								<span>Visual</span>
+							</button>
+							<button type="button" class="tab-button" class:is-active={filterMode === 'raw'}
+								role="tab" aria-selected={filterMode === 'raw'}
+								onclick={() => (filterMode = 'raw')}>
+								<i class="fa-solid fa-code mr-2"></i>
+								<span>Expression</span>
+							</button>
+						</div>
+						<button type="button" class="button is-variant-tertiary is-size-small"
+							disabled={!draft.filter}
+							onclick={clearFilter}>
+							<i class="fa-solid fa-eraser mr-2"></i>
+							<span>Clear</span>
+						</button>
+					</div>
+					{#if !canUseVisual}
+						<p class="text-content/50 text-xs text-right max-w-xs">
+							This expression can’t be shown in the visual editor — edit it as raw CEL.
+						</p>
+					{/if}
+				</div>
+			</div>
+
+			{#if filterMode === 'visual'}
+				<WafConditionBuilder bind:this={filterBuilder} bind:expression={draft.filter} />
+			{:else}
+				<p class="text-content/60 text-sm">
+					Match on
+					<code class="font-mono">request.method</code>,
+					<code class="font-mono">.path</code>,
+					<code class="font-mono">.host</code>,
+					<code class="font-mono">.query</code>,
+					<code class="font-mono">.uri</code>,
+					<code class="font-mono">.scheme</code>,
+					<code class="font-mono">.user_agent</code>,
+					<code class="font-mono">.referer</code>,
+					<code class="font-mono">.remote_ip</code>,
+					<code class="font-mono">.country</code>,
+					<code class="font-mono">.asn</code>,
+					<code class="font-mono">.content_length</code>,
+					<code class="font-mono">.headers[…]</code>,
+					<code class="font-mono">.args[…]</code>,
+					<code class="font-mono">.cookies[…]</code>.
+					<code class="font-mono">request.body</code> is always empty here — cache decisions run before the body is read.
+				</p>
+				<div class="field">
+					<label for="override-filter-raw">Filter (CEL)</label>
+					<div class="textarea">
+						<textarea id="override-filter-raw" class="font-mono" rows="5" bind:value={draft.filter}
+							placeholder="e.g. request.path.startsWith(&quot;/static/&quot;)"></textarea>
+					</div>
+				</div>
+			{/if}
+		</div>
+
+		<hr>
+
+		<div class="grid gap-4">
+			<div>
+				<h6><strong>Then take action</strong></h6>
+				<p class="text-content/50 text-sm mt-1">
+					Choose how matching requests are cached at the edge.
+				</p>
+			</div>
+
+			<div class="grid gap-4 sm:grid-cols-2">
+				<div class="field">
+					<label for="override-action">Action</label>
+					<Select id="override-action" bind:value={draft.action} options={actionOptions} />
+				</div>
+			</div>
+		</div>
+
+		{#if draft.action === 'cache'}
+			<hr>
+
+			<div class="grid gap-4">
+				<div>
+					<h6><strong>Caching policy</strong></h6>
+					<p class="text-content/50 text-sm mt-1">
+						Force matching responses to be cached for this lifetime, overriding
+						the origin’s Cache-Control to the chosen degree.
+					</p>
+				</div>
+
+				<div class="grid gap-4 sm:grid-cols-2">
+					<!-- fixed width so the row doesn't reflow when the selected
+					     ttl label changes length (e.g. 1 minute → 7 days) -->
+					<div class="field">
+						<label for="override-ttl">Cache lifetime (TTL)</label>
+						<Select id="override-ttl" bind:value={draft.ttl} options={allTtlOptions} editable
+							placeholder="e.g. 1h" />
+					</div>
+					<div class="field">
+						<label for="override-policy">Policy</label>
+						<Select id="override-policy" bind:value={draft.policy} options={policyOptions} />
+					</div>
+				</div>
+			</div>
+
+			<hr>
+
+			<div class="grid gap-4">
+				<div>
+					<h6><strong>Stale serving</strong></h6>
+					<p class="text-content/50 text-sm mt-1">
+						Optional RFC 5861 windows — serve a stale response while revalidating
+						in the background, or when the origin errors.
+					</p>
+				</div>
+
+				<div class="grid gap-4 sm:grid-cols-2">
+					<div class="field">
+						<label for="override-swr">Stale while revalidate</label>
+						<div class="input">
+							<input id="override-swr" class="font-mono" bind:value={draft.staleWhileRevalidate}
+								placeholder="e.g. 30s">
+						</div>
+					</div>
+					<div class="field">
+						<label for="override-sie">Stale if error</label>
+						<div class="input">
+							<input id="override-sie" class="font-mono" bind:value={draft.staleIfError}
+								placeholder="e.g. 1h">
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<hr>
+
+			<div class="grid gap-4">
+				<div>
+					<h6><strong>Origin statuses</strong></h6>
+					<p class="text-content/50 text-sm mt-1">
+						Optional — force only these origin response statuses. Leave empty to
+						force every cacheable status. Comma-separated, e.g. <code class="font-mono">200, 301</code>.
+					</p>
+				</div>
+
+				<div class="field sm:max-w-md">
+					<label for="override-status">Statuses</label>
+					<div class="input">
+						<input id="override-status" class="font-mono" bind:value={statusText}
+							placeholder="e.g. 200, 301, 404">
+					</div>
+				</div>
+			</div>
+		{/if}
+
+		<hr>
+
+		<div class="grid gap-4">
+			<div>
+				<h6><strong>Mode</strong></h6>
+				<p class="text-content/50 text-sm mt-1">
+					Shadow mode counts matches without changing caching — size an override
+					here before enforcing it.
+				</p>
+			</div>
+
+			<div class="grid gap-4 sm:grid-cols-2">
+				<div class="field">
+					<label for="override-mode">Mode</label>
+					<Select id="override-mode" bind:value={draft.mode} options={modeOptions} />
+				</div>
+			</div>
+		</div>
+
+		<hr>
+
+		<div class="flex items-center gap-3">
+			<GuardedButton permission="cache.set" type="submit" loading={saving} disabled={saving || !canSave}
+				title={canSave ? undefined : 'Set a cache lifetime before saving'}>Save</GuardedButton>
+			<button type="button" class="button is-variant-secondary" onclick={cancel}>Cancel</button>
+			{#if !canSave}
+				<p class="text-content/50 text-sm">Set a cache lifetime (TTL) to save this override.</p>
+			{/if}
+		</div>
+	</form>
+</div>

--- a/src/routes/(auth)/(project)/cache/manage/+page.js
+++ b/src/routes/(auth)/(project)/cache/manage/+page.js
@@ -1,0 +1,27 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+
+export async function load ({ url, parent, fetch }) {
+	const { project } = await parent()
+	const location = url.searchParams.get('location') ?? ''
+
+	if (!location) {
+		redirect(302, `/cache?project=${project}`)
+	}
+
+	/** @type {Api.Response<Api.CacheZone>} */
+	const res = await api.invoke('cache.get', { project, location }, fetch)
+	// You only reach manage for a configured location — a missing zone means
+	// cache isn't configured here, so send the user back to the index.
+	if (!res.ok) {
+		if (res.error?.notFound) redirect(302, `/cache?project=${project}`)
+		error(500, res.error?.message)
+	}
+	if (!res.result) redirect(302, `/cache?project=${project}`)
+
+	return {
+		project,
+		location,
+		zone: res.result
+	}
+}

--- a/src/routes/(auth)/(project)/cache/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/cache/manage/+page.svelte
@@ -1,0 +1,339 @@
+<script>
+	import { untrack } from 'svelte'
+	import { goto } from '$app/navigation'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import DangerZone from '$lib/components/DangerZone.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import {
+		actionLabels,
+		modeLabels,
+		describeOverride,
+		normalizeOverrides,
+		toApiOverrides
+	} from '$lib/cache/overrides'
+
+	const { data } = $props()
+
+	const project = $derived(data.project)
+	const location = $derived(data.location)
+
+	// The list reflects SERVER state for this location. Navigating away and back
+	// (e.g. from the edit page) reloads the loader, which re-seeds this copy.
+	let description = $state(untrack(() => data.zone?.description ?? ''))
+	let overrides = $state(untrack(() => normalizeOverrides(data.zone?.overrides)))
+
+	let loadedLocation = untrack(() => data.location ?? '')
+
+	// Re-seed local state whenever the loader returns a different location/zone
+	// (after navigation). Track only `data` so optimistic in-place edits aren't
+	// clobbered.
+	$effect(() => {
+		const next = data
+		untrack(() => {
+			if (next.location !== loadedLocation) {
+				loadedLocation = next.location ?? ''
+				description = next.zone?.description ?? ''
+				overrides = normalizeOverrides(next.zone?.overrides)
+			}
+		})
+	})
+
+	let savingDescription = $state(false)
+
+	async function reloadZone () {
+		/** @type {Api.Response<Api.CacheZone>} */
+		const resp = await api.invoke('cache.get', { project, location }, fetch)
+		if (!resp.ok) {
+			if (resp.error?.notFound) {
+				// The zone disappeared underneath us — back to the index.
+				goto(`/cache?project=${project}`)
+				return
+			}
+			modal.error({ error: resp.error })
+			return
+		}
+		const zone = resp.result ?? null
+		description = zone?.description ?? ''
+		overrides = normalizeOverrides(zone?.overrides)
+	}
+
+	// Persist the whole zone (priority follows row order). cache.set replaces the
+	// entire zone, so every override must always travel together. On error,
+	// surface it and reload from the server so the UI matches reality.
+	/**
+	 * @param {import('$lib/cache/overrides').OverrideForm[]} nextOverrides
+	 */
+	async function persistZone (nextOverrides) {
+		const resp = await api.invoke('cache.set', {
+			project,
+			location,
+			description,
+			overrides: toApiOverrides(nextOverrides)
+		}, fetch)
+		if (!resp.ok) {
+			modal.error({ error: resp.error })
+			await reloadZone()
+			return false
+		}
+		return true
+	}
+
+	/**
+	 * @param {number} i
+	 * @param {-1 | 1} dir
+	 */
+	async function moveOverride (i, dir) {
+		const j = i + dir
+		if (j < 0 || j >= overrides.length) return
+		const next = [...overrides]
+		;[next[i], next[j]] = [next[j], next[i]]
+		overrides = next
+		await persistZone(next)
+	}
+
+	/** @param {number} i */
+	function removeOverride (i) {
+		const override = overrides[i]
+		if (!override) return
+		modal.confirm({
+			title: `Delete override ${override.id}?`,
+			yes: 'Delete',
+			callback: async () => {
+				const next = overrides.filter((_, k) => k !== i)
+				overrides = next
+				await persistZone(next)
+			}
+		})
+	}
+
+	/** @param {import('$lib/cache/overrides').OverrideForm} override */
+	function editOverride (override) {
+		goto(`/cache/edit?project=${project}&location=${encodeURIComponent(location)}&override=${encodeURIComponent(override.id)}`)
+	}
+
+	function addOverride () {
+		goto(`/cache/edit?project=${project}&location=${encodeURIComponent(location)}`)
+	}
+
+	async function saveDescription () {
+		if (savingDescription) return
+		savingDescription = true
+		try {
+			await persistZone(overrides)
+		} finally {
+			savingDescription = false
+		}
+	}
+
+	function deleteZone () {
+		modal.confirm({
+			title: `Disable cache in ${location}? All overrides will be removed.`,
+			yes: 'Disable',
+			callback: async () => {
+				const resp = await api.invoke('cache.delete', { project, location }, fetch)
+				if (!resp.ok) {
+					modal.error({ error: resp.error })
+					return
+				}
+				goto(`/cache?project=${project}`)
+			}
+		})
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/cache?project=${project}`} class="link"><h6>Cache</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<a href={`/cache/metrics?project=${project}&location=${encodeURIComponent(location)}`} class="link"><h6 class="font-mono">{location}</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<h6>Manage</h6>
+	</div>
+</div>
+
+<br>
+
+<div class="page-head">
+	<div>
+		<h4><strong>Cache overrides</strong></h4>
+		<p class="page-sub">
+			Overrides that force edge caching in <span class="font-mono">{location}</span>
+		</p>
+	</div>
+	<a class="button is-variant-secondary is-icon-left"
+		href={`/cache/metrics?project=${project}&location=${encodeURIComponent(location)}`}>
+		<i class="fa-solid fa-chart-simple"></i>
+		View metrics
+	</a>
+</div>
+
+<div class="panel is-level-300 grid gap-6">
+	<div class="grid gap-4 w-full">
+		<div class="field">
+			<label for="input-location">Location</label>
+			<div class="input">
+				<input id="input-location" class="font-mono" value={location} readonly>
+			</div>
+		</div>
+
+		<div class="field">
+			<label for="input-description">Description</label>
+			<div class="input">
+				<input id="input-description" bind:value={description} placeholder="Optional description">
+			</div>
+			<div class="flex justify-self-start mt-2">
+				<GuardedButton permission="cache.set" class="button is-variant-secondary is-size-small"
+					loading={savingDescription} onclick={saveDescription}>
+					Save
+				</GuardedButton>
+			</div>
+		</div>
+
+		<br>
+		<hr>
+		<br>
+
+		<div class="flex items-center justify-between">
+			<div>
+				<h6><strong>Overrides</strong></h6>
+				<p class="text-content/50 text-sm mt-1">
+					Overrides match top to bottom — the first match wins. Use
+					<strong>Edit</strong> to change an override’s condition and caching policy.
+				</p>
+			</div>
+		</div>
+
+		<div class="table-container">
+			<table class="table is-variant-compact">
+				<thead>
+					<tr>
+						<th>ID</th>
+						<th>Description</th>
+						<th>Behavior</th>
+						<th>Mode</th>
+						<th class="is-collapse is-align-right">Actions</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each overrides as override, i (override.id)}
+						<tr>
+							<td>
+								<span class="font-mono text-sm text-content/60">{override.id}</span>
+							</td>
+							<td>
+								{#if override.description}
+									{override.description}
+								{:else}
+									<span class="text-content/40">—</span>
+								{/if}
+								{#if override.filter}
+									<div class="font-mono text-xs text-content/50 mt-1 truncate max-w-56" title={override.filter}>
+										<i class="fa-solid fa-filter mr-1"></i>{override.filter}
+									</div>
+								{/if}
+							</td>
+							<td>
+								<span class="action-badge" data-action={override.action}>
+									{actionLabels[override.action] ?? override.action}
+								</span>
+								<div class="text-sm text-content/55 mt-1">{describeOverride(override)}</div>
+							</td>
+							<td>
+								<span class="mode-badge" data-mode={override.mode}>
+									{modeLabels[override.mode] ?? override.mode}
+								</span>
+							</td>
+							<td>
+								<div class="flex gap-1 justify-end">
+									<GuardedButton permission="cache.set" class="icon-button" aria-label="Edit override"
+										onclick={() => editOverride(override)}>
+										<i class="fa-solid fa-pencil"></i>
+									</GuardedButton>
+									<GuardedButton permission="cache.set" class="icon-button" aria-label="Move override up"
+										disabled={i === 0} onclick={() => moveOverride(i, -1)}>
+										<i class="fa-solid fa-chevron-up"></i>
+									</GuardedButton>
+									<GuardedButton permission="cache.set" class="icon-button" aria-label="Move override down"
+										disabled={i === overrides.length - 1} onclick={() => moveOverride(i, 1)}>
+										<i class="fa-solid fa-chevron-down"></i>
+									</GuardedButton>
+									<GuardedButton permission="cache.set" class="icon-button" aria-label="Remove override"
+										onclick={() => removeOverride(i)}>
+										<i class="fa-solid fa-trash-alt"></i>
+									</GuardedButton>
+								</div>
+							</td>
+						</tr>
+					{/each}
+					{#if overrides.length === 0}
+						<tr>
+							<td colspan="5" class="text-center text-content/50">
+								No overrides yet. Add an override to start forcing edge caching.
+							</td>
+						</tr>
+					{/if}
+				</tbody>
+				<tfoot>
+					<tr>
+						<td colspan="5">
+							<GuardedButton permission="cache.set" class="button is-variant-secondary flex m-auto"
+								onclick={addOverride}>
+								<i class="fa-solid fa-plus mr-3"></i>
+								<span>Add override</span>
+							</GuardedButton>
+						</td>
+					</tr>
+				</tfoot>
+			</table>
+		</div>
+
+		<DangerZone description="Disable cache in this location and permanently remove all of its overrides.">
+			<GuardedButton permission="cache.delete" class="button is-variant-negative" onclick={deleteZone}>Disable cache</GuardedButton>
+		</DangerZone>
+	</div>
+</div>
+
+<style>
+	.action-badge {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.125rem 0.625rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		line-height: 1.5;
+		color: hsl(var(--hsl-content) / 0.75);
+		background-color: hsl(var(--hsl-content) / 0.08);
+	}
+
+	.action-badge[data-action='cache'] {
+		color: hsl(var(--hsl-positive));
+		background-color: hsl(var(--hsl-positive) / 0.12);
+	}
+
+	.action-badge[data-action='bypass'] {
+		color: hsl(var(--hsl-warning));
+		background-color: hsl(var(--hsl-warning) / 0.14);
+	}
+
+	.mode-badge {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.125rem 0.625rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		line-height: 1.5;
+		color: hsl(var(--hsl-content) / 0.75);
+		background-color: hsl(var(--hsl-content) / 0.08);
+	}
+
+	/* Shadow only observes — render it muted so Enforce stands out. */
+	.mode-badge[data-mode='shadow'] {
+		color: hsl(var(--hsl-content) / 0.5);
+		background-color: hsl(var(--hsl-content) / 0.05);
+	}
+</style>

--- a/src/routes/(auth)/(project)/cache/metrics/+page.js
+++ b/src/routes/(auth)/(project)/cache/metrics/+page.js
@@ -1,0 +1,30 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+
+// Metrics are fetched client-side (per time range) so the range switcher is
+// snappy and the page can auto-refresh. The loader only resolves the zone so
+// the per-override table can show override descriptions and we can bail early
+// when cache isn't configured.
+export async function load ({ url, parent, fetch }) {
+	const { project } = await parent()
+	const location = url.searchParams.get('location') ?? ''
+
+	if (!location) {
+		redirect(302, `/cache?project=${project}`)
+	}
+
+	/** @type {Api.Response<Api.CacheZone>} */
+	const res = await api.invoke('cache.get', { project, location }, fetch)
+
+	if (!res.ok) {
+		if (res.error?.notFound) redirect(302, `/cache?project=${project}`)
+		error(500, res.error?.message)
+	}
+	if (!res.result) redirect(302, `/cache?project=${project}`)
+
+	return {
+		project,
+		location,
+		zone: res.result
+	}
+}

--- a/src/routes/(auth)/(project)/cache/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/cache/metrics/+page.svelte
@@ -1,0 +1,616 @@
+<script>
+	import { onMount } from 'svelte'
+	import { page } from '$app/stores'
+	import { replaceState } from '$app/navigation'
+	import api from '$lib/api'
+	import * as modal from '$lib/modal'
+	import * as format from '$lib/format'
+	import { actionLabels, describeOverride, modeLabels, normalizeOverrides } from '$lib/cache/overrides'
+	import LineChart from '$lib/components/LineChart.svelte'
+
+	const { data } = $props()
+
+	const project = $derived(data.project)
+	const location = $derived(data.location)
+	const managePath = $derived(`/cache/manage?project=${project}&location=${encodeURIComponent(location)}`)
+
+	// Override id → its configured form, so the per-override table reads in human
+	// terms rather than raw ids.
+	const overrideMeta = $derived(new Map(
+		normalizeOverrides(data.zone?.overrides).map((o) => [o.id, o])
+	))
+
+	// The three caching results, in chart stacking/legend order.
+	/** @type {Api.CacheMetricsSeries['result'][]} */
+	const RESULT_ORDER = ['applied', 'shadow', 'error']
+	/** @type {Record<string, string>} */
+	const RESULT_LABEL = { applied: 'Applied', shadow: 'Shadow', error: 'Error' }
+	/** @type {Record<string, string>} */
+	const RESULT_COLOR = {
+		applied: 'hsl(var(--hsl-positive))',
+		shadow: 'hsl(var(--hsl-content) / 0.45)',
+		error: 'hsl(var(--hsl-negative))'
+	}
+
+	const RANGE_OPTIONS = [
+		{ value: '1h', label: '1H' },
+		{ value: '6h', label: '6H' },
+		{ value: '12h', label: '12H' },
+		{ value: '1d', label: '24H' },
+		{ value: '7d', label: '7D' },
+		{ value: '30d', label: '30D' }
+	]
+	/** @type {Record<string, number>} */
+	const RANGE_SECONDS = { '1h': 3600, '6h': 21600, '12h': 43200, '1d': 86400, '7d': 604800, '30d': 2592000 }
+	/** @type {Record<string, string>} */
+	const RANGE_LABEL = {
+		'1h': 'last hour',
+		'6h': 'last 6 hours',
+		'12h': 'last 12 hours',
+		'1d': 'last 24 hours',
+		'7d': 'last 7 days',
+		'30d': 'last 30 days'
+	}
+	// Bucket width per range — kept around 48–72 columns so lines stay legible.
+	/** @type {Record<string, number>} */
+	const BUCKET_SECONDS = { '1h': 60, '6h': 300, '12h': 600, '1d': 1800, '7d': 10800, '30d': 43200 }
+
+	const initialRange = $page.url.searchParams.get('range')
+	let range = $state(initialRange && RANGE_SECONDS[initialRange] ? initialRange : '1d')
+
+	let loading = $state(true)
+	let result = $state(/** @type {Api.CacheMetricsResult | null} */ (null))
+	// Anchor the time window to the moment of the latest fetch so the chart grid
+	// and "as of" line agree.
+	let fetchedAt = $state(Math.floor(Date.now() / 1000))
+
+	/** @type {ReturnType<typeof setTimeout> | undefined} */
+	let refreshTimer
+
+	async function fetchMetrics () {
+		loading = true
+		try {
+			/** @type {Api.Response<Api.CacheMetricsResult>} */
+			const res = await api.invoke('cache.metrics', { project, location, timeRange: range }, fetch)
+			if (!res.ok) {
+				modal.error({ error: res.error })
+				return
+			}
+			result = res.result ?? { series: [], total: 0 }
+			fetchedAt = Math.floor(Date.now() / 1000)
+		} finally {
+			loading = false
+			scheduleRefresh()
+		}
+	}
+
+	// Live-refresh only short windows — minute-level polling is meaningless for a
+	// 7d/30d view and just churns the chart.
+	function scheduleRefresh () {
+		clearTimeout(refreshTimer)
+		if (RANGE_SECONDS[range] <= RANGE_SECONDS['1d']) {
+			refreshTimer = setTimeout(fetchMetrics, 60 * 1000)
+		}
+	}
+
+	/** @param {string} r */
+	function selectRange (r) {
+		if (r === range) return
+		range = r
+		const u = new URL($page.url)
+		u.searchParams.set('range', r)
+		replaceState(u, {})
+		result = null
+		fetchMetrics()
+	}
+
+	onMount(() => {
+		fetchMetrics()
+		return () => clearTimeout(refreshTimer)
+	})
+
+	const total = $derived(result?.total ?? 0)
+
+	// Totals per result, for the KPI tiles.
+	const byResult = $derived.by(() => {
+		/** @type {Record<string, number>} */
+		const acc = { applied: 0, shadow: 0, error: 0 }
+		for (const s of result?.series ?? []) {
+			acc[s.result] = (acc[s.result] ?? 0) + s.total
+		}
+		return acc
+	})
+
+	const tiles = $derived([
+		{ key: 'total', label: 'Total decisions', value: total },
+		{ key: 'applied', label: 'Applied', value: byResult.applied },
+		{ key: 'shadow', label: 'Shadow', value: byResult.shadow },
+		{ key: 'error', label: 'Error', value: byResult.error }
+	])
+
+	const windowFrom = $derived(fetchedAt - RANGE_SECONDS[range])
+
+	// Bucket every series' sparse points onto a shared grid, summed per result, so
+	// the lines line up. Results with no traffic in the window are dropped.
+	const chartSeries = $derived.by(() => {
+		const bucket = BUCKET_SECONDS[range]
+		const from = windowFrom
+		const to = fetchedAt
+		const n = Math.max(1, Math.ceil((to - from) / bucket))
+
+		/** @type {Record<string, number[]>} */
+		const grids = { applied: new Array(n).fill(0), shadow: new Array(n).fill(0), error: new Array(n).fill(0) }
+		for (const s of result?.series ?? []) {
+			const g = grids[s.result]
+			if (!g) continue
+			for (const [ts, v] of s.points ?? []) {
+				const i = Math.floor((ts - from) / bucket)
+				if (i >= 0 && i < n) g[i] += v
+			}
+		}
+
+		/** @type {import('$lib/charts/util').LineSeries[]} */
+		return RESULT_ORDER
+			.filter((res) => byResult[res] > 0)
+			.map((res) => ({
+				name: RESULT_LABEL[res],
+				color: RESULT_COLOR[res],
+				dashed: res === 'shadow',
+				points: grids[res].map((v, i) => ({ x: (from + i * bucket) * 1000, y: v }))
+			}))
+	})
+
+	// Rank overrides by decision volume. Each (override, action, result) series
+	// collapses onto its override; the action of its largest series wins the badge.
+	const topOverrides = $derived.by(() => {
+		/** @type {Record<string, { overrideId: string, total: number, action: Api.CacheAction, top: number }>} */
+		const byOverride = {}
+		for (const s of result?.series ?? []) {
+			const cur = byOverride[s.overrideId]
+			if (cur) {
+				cur.total += s.total
+				if (s.total > cur.top) {
+					cur.top = s.total
+					cur.action = s.action
+				}
+			} else {
+				byOverride[s.overrideId] = { overrideId: s.overrideId, total: s.total, action: s.action, top: s.total }
+			}
+		}
+		return Object.values(byOverride)
+			.filter((o) => o.total > 0)
+			.sort((a, b) => b.total - a.total)
+	})
+
+	/** @param {number} v */
+	function share (v) {
+		return total > 0 ? v / total : 0
+	}
+	/** @param {number} v */
+	function pct (v) {
+		return total > 0 ? `${Math.round((v / total) * 100)}%` : '—'
+	}
+
+	const showSpinner = $derived(loading && !result)
+	const isEmpty = $derived(!loading && total === 0)
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/cache?project=${project}`} class="link"><h6>Cache</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<h6 class="font-mono">{location}</h6>
+	</div>
+</div>
+
+<br>
+
+<div class="page-head">
+	<div>
+		<h4><strong>Cache activity</strong></h4>
+		<p class="page-sub">
+			Cache decisions in <span class="font-mono">{location}</span> · {RANGE_LABEL[range]}
+		</p>
+	</div>
+	<div class="head-actions">
+		<div class="range-switch" role="group" aria-label="Time range">
+			{#each RANGE_OPTIONS as opt (opt.value)}
+				<button
+					type="button"
+					class="range-btn"
+					class:is-active={range === opt.value}
+					aria-pressed={range === opt.value}
+					onclick={() => selectRange(opt.value)}>{opt.label}</button>
+			{/each}
+		</div>
+		<a class="button is-variant-secondary is-icon-left" href={managePath}>
+			<i class="fa-solid fa-sliders"></i>
+			Manage overrides
+		</a>
+	</div>
+</div>
+
+<div class="stat-grid">
+	{#each tiles as tile (tile.key)}
+		<div class="stat-tile" data-accent={tile.key}>
+			<div class="stat-head">
+				{#if tile.key !== 'total'}<span class="dot"></span>{/if}
+				{tile.label}
+			</div>
+			<div class="stat-value">
+				{#if showSpinner}
+					<span class="text-content/25"><i class="fa-solid fa-spinner-third fa-spin"></i></span>
+				{:else}
+					{format.count(tile.value)}
+				{/if}
+			</div>
+			<div class="stat-foot">
+				{#if tile.key === 'total'}
+					<span>across {topOverrides.length} {topOverrides.length === 1 ? 'override' : 'overrides'}</span>
+				{:else}
+					<span class="share-bar"><span style={`width:${share(tile.value) * 100}%`}></span></span>
+					<span class="tabular-nums">{pct(tile.value)}</span>
+				{/if}
+			</div>
+		</div>
+	{/each}
+</div>
+
+<div class="panel is-level-300 chart-panel">
+	<div class="panel-head">
+		<h6><strong>Decisions over time</strong></h6>
+		<div class="legend">
+			{#each RESULT_ORDER as res (res)}
+				<span class="legend-item" data-result={res}>
+					<span class="legend-dot"></span>
+					{RESULT_LABEL[res]}
+				</span>
+			{/each}
+		</div>
+	</div>
+
+	<div class="chart-body">
+		{#if showSpinner}
+			<div class="chart-state text-content/40">
+				<i class="fa-solid fa-spinner-third fa-spin text-2xl"></i>
+			</div>
+		{:else if isEmpty}
+			<div class="chart-state">
+				<i class="fa-solid fa-bolt empty-icon"></i>
+				<p class="empty-title">No cache decisions in this window</p>
+				<p class="empty-sub">No override has fired in the {RANGE_LABEL[range]}.</p>
+			</div>
+		{:else}
+			<LineChart
+				series={chartSeries}
+				xType="time"
+				xDomain={[windowFrom * 1000, fetchedAt * 1000]}
+				height={320}
+				formatY={(v) => format.count(v)}
+				formatValue={(v) => v.toLocaleString()}
+				legend />
+		{/if}
+	</div>
+</div>
+
+{#if !isEmpty}
+	<div class="panel is-level-300">
+		<div class="panel-head">
+			<h6><strong>Top overrides</strong></h6>
+			<span class="page-sub">by decision volume</span>
+		</div>
+		<div class="table-container">
+			<table class="table is-variant-compact">
+				<thead>
+					<tr>
+						<th>Override</th>
+						<th>Action</th>
+						<th class="is-align-right">Decisions</th>
+						<th class="share-col">Share</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each topOverrides as override (override.overrideId)}
+						{@const meta = overrideMeta.get(override.overrideId)}
+						{@const action = meta?.action ?? override.action}
+						<tr>
+							<td>
+								<div class="rule-cell">
+									{#if meta?.description}
+										<span class="rule-desc">{meta.description}</span>
+									{/if}
+									<span class="font-mono text-sm text-content/55">{override.overrideId}</span>
+									{#if meta}
+										<span class="text-sm text-content/55">{describeOverride(meta)}{meta.mode === 'shadow' ? ` · ${modeLabels.shadow}` : ''}</span>
+									{/if}
+								</div>
+							</td>
+							<td>
+								<span class="act-badge" data-action={action}>{actionLabels[action] ?? action}</span>
+							</td>
+							<td class="is-align-right font-mono tabular-nums">{override.total.toLocaleString()}</td>
+							<td class="share-col">
+								<div class="row-share">
+									<span class="share-bar" data-action={action}>
+										<span style={`width:${share(override.total) * 100}%`}></span>
+									</span>
+									<span class="tabular-nums text-content/60">{pct(override.total)}</span>
+								</div>
+							</td>
+						</tr>
+					{/each}
+					{#if showSpinner}
+						<tr><td colspan="4" class="text-center text-content/40">
+							<i class="fa-solid fa-spinner-third fa-spin"></i>
+						</td></tr>
+					{/if}
+				</tbody>
+			</table>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.head-actions {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+
+	/* Segmented time-range control. */
+	.range-switch {
+		display: inline-flex;
+		padding: 0.1875rem;
+		gap: 0.125rem;
+		border-radius: 0.625rem;
+		background: hsl(var(--hsl-base-200));
+		border: 1px solid hsl(var(--hsl-line) / 0.7);
+	}
+
+	.range-btn {
+		padding: 0.3125rem 0.6875rem;
+		border-radius: 0.4375rem;
+		font-size: 0.75rem;
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+		color: hsl(var(--hsl-content) / 0.6);
+		transition: color var(--timing-fastest) ease, background var(--timing-fastest) ease;
+	}
+
+	.range-btn:hover {
+		color: hsl(var(--hsl-content) / 0.9);
+	}
+
+	.range-btn.is-active {
+		color: hsl(var(--hsl-primary-content));
+		background: hsl(var(--hsl-primary));
+	}
+
+	/* KPI tiles — colored by the caching result. */
+	.stat-grid {
+		display: grid;
+		gap: 1rem;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		margin-bottom: 1rem;
+	}
+
+	@media (min-width: 1024px) {
+		.stat-grid {
+			grid-template-columns: repeat(4, minmax(0, 1fr));
+		}
+	}
+
+	.stat-tile {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		gap: 0.55rem;
+		padding: 1rem 1.125rem;
+		border-radius: 0.75rem;
+		background: hsl(var(--hsl-base-200));
+		border: 1px solid hsl(var(--hsl-line) / 0.7);
+		overflow: hidden;
+	}
+
+	.stat-tile::before {
+		content: '';
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: 0;
+		width: 3px;
+		background: var(--accent, hsl(var(--hsl-content) / 0.2));
+	}
+
+	.stat-tile[data-accent='applied'] { --accent: hsl(var(--hsl-positive)); }
+	.stat-tile[data-accent='shadow'] { --accent: hsl(var(--hsl-content) / 0.45); }
+	.stat-tile[data-accent='error'] { --accent: hsl(var(--hsl-negative)); }
+
+	.stat-tile[data-accent='total'] {
+		background: linear-gradient(135deg, hsl(var(--hsl-primary) / 0.12) 0%, hsl(var(--hsl-accent) / 0.12) 100%);
+		border-color: hsl(var(--hsl-primary) / 0.2);
+	}
+
+	.stat-tile[data-accent='total']::before {
+		background: linear-gradient(hsl(var(--hsl-primary)), hsl(var(--hsl-accent)));
+	}
+
+	.stat-head {
+		display: flex;
+		align-items: center;
+		gap: 0.45rem;
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.6);
+	}
+
+	.stat-head .dot {
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 9999px;
+		background: var(--accent);
+	}
+
+	.stat-value {
+		font-size: 1.9rem;
+		font-weight: 700;
+		line-height: 1;
+		letter-spacing: -0.02em;
+		font-variant-numeric: tabular-nums;
+		color: hsl(var(--hsl-content));
+	}
+
+	.stat-tile[data-accent='total'] .stat-value {
+		color: hsl(var(--hsl-primary));
+	}
+
+	.stat-foot {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-content) / 0.55);
+	}
+
+	/* Shared mini bar — fill color follows the row/tile result accent. */
+	.share-bar {
+		flex: 1;
+		height: 0.3125rem;
+		min-width: 2rem;
+		border-radius: 9999px;
+		background: hsl(var(--hsl-content) / 0.08);
+		overflow: hidden;
+	}
+
+	.share-bar > span {
+		display: block;
+		height: 100%;
+		border-radius: inherit;
+		background: var(--accent, hsl(var(--hsl-primary)));
+		transition: width var(--timing-normal) ease;
+	}
+
+	.stat-tile[data-accent='applied'] .share-bar > span { background: hsl(var(--hsl-positive)); }
+	.stat-tile[data-accent='shadow'] .share-bar > span { background: hsl(var(--hsl-content) / 0.45); }
+	.stat-tile[data-accent='error'] .share-bar > span { background: hsl(var(--hsl-negative)); }
+
+	.share-bar[data-action='cache'] > span { background: hsl(var(--hsl-positive)); }
+	.share-bar[data-action='bypass'] > span { background: hsl(var(--hsl-warning)); }
+
+	/* Panels */
+	.panel-head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+		flex-wrap: wrap;
+		margin-bottom: 0.5rem;
+	}
+
+	.chart-panel {
+		margin-bottom: 1rem;
+	}
+
+	.chart-body {
+		min-height: 320px;
+	}
+
+	.chart-state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		min-height: 320px;
+		text-align: center;
+	}
+
+	.chart-state .empty-icon {
+		font-size: 1.75rem;
+		color: hsl(var(--hsl-positive) / 0.6);
+	}
+
+	.chart-state .empty-title {
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.8);
+	}
+
+	.chart-state .empty-sub {
+		font-size: 0.8125rem;
+		color: hsl(var(--hsl-content) / 0.55);
+		max-width: 22rem;
+	}
+
+	/* Chart legend */
+	.legend {
+		display: flex;
+		gap: 1rem;
+		flex-wrap: wrap;
+	}
+
+	.legend-item {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.6);
+	}
+
+	.legend-dot {
+		width: 0.625rem;
+		height: 0.625rem;
+		border-radius: 0.25rem;
+	}
+
+	.legend-item[data-result='applied'] .legend-dot { background: hsl(var(--hsl-positive)); }
+	.legend-item[data-result='shadow'] .legend-dot { background: hsl(var(--hsl-content) / 0.45); }
+	.legend-item[data-result='error'] .legend-dot { background: hsl(var(--hsl-negative)); }
+
+	/* Top-overrides table */
+	.rule-cell {
+		display: flex;
+		flex-direction: column;
+		gap: 0.1rem;
+	}
+
+	.rule-desc {
+		font-weight: 500;
+	}
+
+	.share-col {
+		width: 30%;
+		min-width: 9rem;
+	}
+
+	.row-share {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		font-size: 0.75rem;
+	}
+
+	.act-badge {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.125rem 0.625rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		line-height: 1.5;
+		color: hsl(var(--hsl-content) / 0.75);
+		background-color: hsl(var(--hsl-content) / 0.08);
+	}
+
+	.act-badge[data-action='cache'] {
+		color: hsl(var(--hsl-positive));
+		background-color: hsl(var(--hsl-positive) / 0.12);
+	}
+
+	.act-badge[data-action='bypass'] {
+		color: hsl(var(--hsl-warning));
+		background-color: hsl(var(--hsl-warning) / 0.14);
+	}
+</style>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -113,6 +113,7 @@ declare namespace Api {
             workloadIdentity?: boolean
             disk?: Record<string, never>
             waf?: Record<string, never>
+            cache?: Record<string, never>
         }
         createdAt: string
     }
@@ -595,6 +596,69 @@ declare namespace Api {
 
     export type WafLimitMetricsResult = {
         series: WafLimitMetricsSeries[]
+        total: number
+    }
+
+    export type CacheAction = 'cache' | 'bypass'
+
+    export type CacheOverride = {
+        id: string
+        description: string
+        // 'cache' (default) forces a caching policy onto the fill; 'bypass'
+        // skips the cache entirely for matching requests. ttl/policy/status/
+        // stale_* apply only to action 'cache'.
+        action: CacheAction
+        // Optional CEL expression (same request.* surface as WafRule.expression)
+        // scoping the override: empty applies it to every request. request.body
+        // is always '' in cache filters.
+        filter?: string
+        // Go duration; required for action 'cache' (1s..720h). The forced
+        // freshness lifetime.
+        ttl?: string
+        // 'conservative' | 'balanced' (default) | 'aggressive'. How far the
+        // force reaches over the origin's Cache-Control. cache action only.
+        policy?: string
+        // RFC 5861 windows (Go durations) riding the forced policy; need a ttl.
+        staleWhileRevalidate?: string
+        staleIfError?: string
+        // Force only these origin response statuses; empty = every cacheable
+        // status. cache action only.
+        status?: number[]
+        // shadow counts matches but never changes caching (default enforce).
+        mode?: 'enforce' | 'shadow'
+        // ascending; first match wins among cache rules. 0 -> parapet default
+        // (100). Bypass rules are not ordered against each other.
+        priority: number
+    }
+
+    export type CacheZone = {
+        project: string
+        location: string
+        description: string
+        overrides: CacheOverride[]
+        status: 'pending' | 'success' | 'error'
+        action: 'create' | 'delete'
+        createdAt: string
+        createdBy: string
+    }
+
+    export type CacheZoneList = {
+        project: string
+        items: CacheZone[]
+    }
+
+    // cache.metrics reuses WafMetricsTimeRange.
+    export type CacheMetricsSeries = {
+        overrideId: string
+        action: CacheAction
+        result: 'applied' | 'shadow' | 'error'
+        total: number
+        // [unixSeconds, count], time-ordered
+        points: [number, number][]
+    }
+
+    export type CacheMetricsResult = {
+        series: CacheMetricsSeries[]
         total: number
     }
 

--- a/tests/cache.spec.js
+++ b/tests/cache.spec.js
@@ -1,0 +1,244 @@
+import { test, expect, setMocks, getRequestLog } from './helpers.js'
+import { defaultLocation } from './fixtures/mocks.js'
+
+// A cache-capable location (the default fixture location has no `cache` feature).
+const cacheLocation = { ...defaultLocation, id: 'gke', features: { cache: true } }
+
+/** Build a cache zone fixture. */
+function cacheZone (overrides = {}) {
+	return {
+		project: 'test-project',
+		location: 'gke',
+		description: '',
+		overrides: [],
+		status: 'success',
+		action: 'create',
+		createdAt: '2024-01-01T00:00:00Z',
+		createdBy: '[email protected]',
+		...overrides
+	}
+}
+
+/** Build a cache override fixture. */
+function cacheOverride (overrides = {}) {
+	return {
+		id: 'override-aaaaaa',
+		description: '',
+		action: 'cache',
+		filter: "request.path.startsWith('/static/')",
+		ttl: '1h',
+		policy: 'balanced',
+		mode: 'enforce',
+		priority: 0,
+		...overrides
+	}
+}
+
+test.describe('cache list', () => {
+	test('renders zones with status and links to manage', async ({ page }) => {
+		await setMocks({
+			'cache.list': {
+				ok: true,
+				result: {
+					project: 'test-project',
+					items: [
+						cacheZone({ location: 'gke', description: 'prod edge', status: 'success', overrides: [cacheOverride()] }),
+						cacheZone({ location: 'sgp', status: 'pending', action: 'create', overrides: [] })
+					]
+				}
+			},
+			// The list fetches metrics per zone client-side; keep it quiet/empty.
+			'cache.metrics': { ok: true, result: { series: [], total: 0 } }
+		})
+
+		await page.goto('/cache?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Cache' })).toBeVisible()
+		await expect(main.getByRole('link', { name: 'gke', exact: true })).toBeVisible()
+		await expect(main.getByRole('link', { name: 'sgp', exact: true })).toBeVisible()
+		await expect(main.getByText('prod edge')).toBeVisible()
+		// Settled zone shows Active; the in-flight create shows Deploying.
+		await expect(main.getByText('Active')).toBeVisible()
+		await expect(main.getByText('Deploying')).toBeVisible()
+		// Manage shortcut points at the per-location manage page.
+		await expect(main.getByRole('link', { name: 'Manage' }).first())
+			.toHaveAttribute('href', /\/cache\/manage\?project=test-project&location=gke/)
+	})
+
+	test('shows the empty state when there are no zones', async ({ page }) => {
+		await setMocks({
+			'cache.list': { ok: true, result: { project: 'test-project', items: [] } }
+		})
+
+		await page.goto('/cache?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('No cache zones yet')).toBeVisible()
+		await expect(main.getByText('Configure cache to start overriding edge caching in a location.')).toBeVisible()
+	})
+})
+
+test.describe('cache create', () => {
+	test('offers only unconfigured cache locations and saves an empty zone', async ({ page }) => {
+		await setMocks({
+			'location.list': { ok: true, result: { items: [cacheLocation] } }
+			// cache.get is unmocked → 404 (notFound) → the location is unconfigured/available.
+		})
+
+		await page.goto('/cache/create?project=test-project')
+
+		// Select the available location via the custom Select.
+		await page.locator('#input-location').click()
+		await page.getByRole('option', { name: 'gke' }).click()
+		await page.locator('#input-description').fill('edge cache')
+
+		await page.getByRole('button', { name: 'Save' }).click()
+
+		// The page persists the new zone via cache.set with an empty override list.
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/cache.set')
+		}).toBe(true)
+
+		const setReq = (await getRequestLog()).find((r) => r.path === '/cache.set')
+		const body = JSON.parse(setReq?.body ?? '{}')
+		expect(body.location).toBe('gke')
+		expect(body.description).toBe('edge cache')
+		expect(body.overrides).toEqual([])
+	})
+
+	test('reports when every location already has cache configured', async ({ page }) => {
+		await setMocks({
+			'location.list': { ok: true, result: { items: [cacheLocation] } },
+			// The only supported location already has a zone → nothing to create.
+			'cache.get': { ok: true, result: cacheZone({ location: 'gke' }) }
+		})
+
+		await page.goto('/cache/create?project=test-project')
+		await expect(page.getByText('Every location already has cache configured')).toBeVisible()
+	})
+})
+
+test.describe('cache manage', () => {
+	test('lists the zone overrides with action badges', async ({ page }) => {
+		await setMocks({
+			'cache.get': {
+				ok: true,
+				result: cacheZone({
+					location: 'gke',
+					description: 'prod edge',
+					overrides: [
+						cacheOverride({ id: 'override-static', description: 'cache assets', action: 'cache', ttl: '1h', policy: 'balanced', priority: 0 }),
+						cacheOverride({ id: 'override-admin', description: 'skip admin', action: 'bypass', filter: "request.path.startsWith('/admin')", priority: 1 })
+					]
+				})
+			}
+		})
+
+		await page.goto('/cache/manage?project=test-project&location=gke')
+		const main = page.locator('.content-wrapper')
+
+		await expect(main.getByRole('heading', { name: 'Cache overrides' })).toBeVisible()
+		await expect(main.getByText('override-static')).toBeVisible()
+		await expect(main.getByText('cache assets')).toBeVisible()
+		await expect(main.getByText('skip admin')).toBeVisible()
+		// Each override shows an action badge. "Cache"/"Bypass" also appear in the
+		// breadcrumb and behavior summary, so target the badge element directly.
+		await expect(main.locator('.action-badge[data-action="cache"]')).toBeVisible()
+		await expect(main.locator('.action-badge[data-action="bypass"]')).toBeVisible()
+	})
+
+	test('disable cache confirms then calls cache.delete', async ({ page }) => {
+		await setMocks({
+			'cache.get': { ok: true, result: cacheZone({ location: 'gke', overrides: [cacheOverride()] }) },
+			'cache.delete': { ok: true, result: true },
+			'cache.list': { ok: true, result: { project: 'test-project', items: [] } }
+		})
+
+		await page.goto('/cache/manage?project=test-project&location=gke')
+
+		await page.getByRole('button', { name: 'Disable cache' }).click()
+		// Confirm in the SweetAlert dialog.
+		await page.locator('.swal2-confirm').click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/cache.delete')
+		}).toBe(true)
+
+		const delReq = (await getRequestLog()).find((r) => r.path === '/cache.delete')
+		expect(JSON.parse(delReq?.body ?? '{}').location).toBe('gke')
+	})
+})
+
+test.describe('cache override editor', () => {
+	test('builds a cache override and saves it as a whole-zone replace', async ({ page }) => {
+		await setMocks({
+			// New override editor: empty zone (no overrides configured yet).
+			'cache.get': { ok: true, result: cacheZone({ location: 'gke', overrides: [] }) }
+		})
+
+		await page.goto('/cache/edit?project=test-project&location=gke')
+
+		// Build a filter via the visual condition builder.
+		const addCondition = page.getByRole('button', { name: 'Add condition' })
+		const value = page.locator('#waf-value')
+		await expect(async () => {
+			await addCondition.click()
+			await expect(value).toBeVisible({ timeout: 1000 })
+		}).toPass()
+		await value.fill('/static/app.js')
+
+		// Action defaults to Cache; ttl defaults to 1h. Save the override.
+		const save = page.getByRole('button', { name: 'Save' })
+		await expect(save).toBeEnabled()
+		await save.click()
+
+		// The whole zone is written via cache.set; the new override carries the
+		// generated CEL filter and a cache action with a ttl.
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/cache.set')
+		}).toBe(true)
+
+		const setReq = (await getRequestLog()).find((r) => r.path === '/cache.set')
+		const body = JSON.parse(setReq?.body ?? '{}')
+		expect(body.location).toBe('gke')
+		expect(body.overrides).toHaveLength(1)
+		expect(body.overrides[0].action).toBe('cache')
+		expect(body.overrides[0].ttl).toBe('1h')
+		expect(body.overrides[0].filter).toBe('request.path == "/static/app.js"')
+	})
+
+	test('bypass override omits ttl/policy on save', async ({ page }) => {
+		await setMocks({
+			'cache.get': {
+				ok: true,
+				result: cacheZone({
+					location: 'gke',
+					overrides: [cacheOverride({ id: 'override-bp', action: 'bypass', filter: "request.path.startsWith('/admin')", priority: 0 })]
+				})
+			}
+		})
+
+		await page.goto('/cache/edit?project=test-project&location=gke&override=override-bp')
+
+		const save = page.getByRole('button', { name: 'Save' })
+		await expect(save).toBeEnabled()
+		await save.click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/cache.set')
+		}).toBe(true)
+
+		const setReq = (await getRequestLog()).find((r) => r.path === '/cache.set')
+		const body = JSON.parse(setReq?.body ?? '{}')
+		expect(body.overrides).toHaveLength(1)
+		expect(body.overrides[0].action).toBe('bypass')
+		// The API rejects ttl/policy/status/stale_* on a bypass override, so they
+		// must be omitted from the payload.
+		expect(body.overrides[0].ttl).toBeUndefined()
+		expect(body.overrides[0].policy).toBeUndefined()
+	})
+})


### PR DESCRIPTION
## What

A new **Cache** project nav section (sibling to Firewall/WAF) for managing parapet **edge cache overrides** per location. A cache zone is one CEL-filtered override set per `(project, location)` that forces or bypasses the edge response cache; `cache.set` replaces it atomically.

Completes the UI half of the feature. Pairs with api **#58**, apiserver **#116**, deployer **#16**; pinned to api commit `ef889898`.

## Pages (all mirror the WAF feature's structure + design system)

- **`/cache`** — list of zones per location: status, override count, 24h decisions sparkline, "Configure cache" CTA, pending-status polling.
- **`/cache/create`** — pick a `features.cache`-capable, not-yet-configured location + description.
- **`/cache/manage`** — description editor, the override table (priority order, reorder / edit / remove), "Add override", and a DangerZone disable.
- **`/cache/edit`** — single-override editor: reuses **`WafConditionBuilder`** for the CEL `filter` (identical `request.*` surface), action (cache | bypass), and — for `cache` only — TTL, policy, stale-while-revalidate / stale-if-error, origin statuses, and mode (enforce | shadow).
- **`/cache/metrics`** — time-range selector, applied / shadow / error KPI tiles, a decisions-over-time chart, and a top-overrides table.

## Notes

- **`$lib/cache/overrides.js`** — form normalization. Priority is derived from row order (first match wins). `toApiOverrides` **omits** ttl/policy/status/stale_* for `action: 'bypass'`, since the API rejects those on a bypass.
- **Whole-zone-replace discipline**: every `cache.set` sends the full override set — editing one override echoes the rest + the description, exactly like the WAF editor.
- All mutating actions gated with `<GuardedButton permission="cache.set"|"cache.delete">`.
- Reuses `WafConditionBuilder` + `$lib/waf/expression` rather than adding a new condition builder. Metrics uses `LineChart` (the cache series dimension is `result`, not a WAF action, so `WafActivityChart` didn't fit type-wise).
- `mock.js` gains `cache.*` handlers + a realistic fixture for offline dev (`bun dev:mock`).

## Verification

- `bun check` → 0 errors / 0 warnings.
- `bun lint` → clean.
- `bunx playwright test` → `cache.spec.js` 8/8 and `waf.spec.js` 9/9 (no regression).
- Screenshots of list / manage / edit / metrics reviewed against the design system.