### PR TITLE
Return to the requested page after sign-in

### DIFF
--- a/src/lib/server/redirect.js
+++ b/src/lib/server/redirect.js
@@ -1,0 +1,31 @@
+/**
+ * sanitizeRedirect validates a post-login return path.
+ *
+ * The value travels through a query param and a cookie before it is emitted as
+ * a `Location` header, so it is an open-redirect sink: an attacker who can craft
+ * the sign-in URL must not be able to bounce the user to another origin after a
+ * successful login. We therefore accept only same-origin absolute paths:
+ *
+ *  - must start with a single "/" (a path, never an absolute or scheme-relative URL)
+ *  - must not start with "//" (protocol-relative — browsers treat these as URLs)
+ *  - must not contain backslashes (some parsers fold "\" to "/") or control characters
+ *    (CR/LF would enable header injection)
+ *  - must not point back at the auth endpoints themselves (avoids a sign-in loop)
+ *
+ * Returns the safe path, or '' when the input is missing or fails any check.
+ *
+ * @param {string | null | undefined} value
+ * @returns {string}
+ */
+export function sanitizeRedirect (value) {
+	if (!value) return ''
+	if (!value.startsWith('/')) return ''
+	if (value.startsWith('//')) return ''
+	if (value.includes('\\')) return ''
+	for (let i = 0; i < value.length; i++) {
+		const c = value.charCodeAt(i)
+		if (c <= 0x1f || c === 0x7f) return '' // C0 control characters and DEL
+	}
+	if (value === '/auth' || value.startsWith('/auth/')) return ''
+	return value
+}

--- a/src/routes/(auth)/+layout.js
+++ b/src/routes/(auth)/+layout.js
@@ -1,7 +1,7 @@
 import { redirect, error } from '@sveltejs/kit'
 import api from '$lib/api'
 
-export async function load ({ fetch }) {
+export async function load ({ fetch, url }) {
 	/** @type {[Api.Response<Api.Profile>, Api.Response<Api.List<Api.Project>>]} */
 	const [
 		me,
@@ -11,7 +11,15 @@ export async function load ({ fetch }) {
 		api.invoke('project.list', {}, fetch)
 	])
 	if (!me.ok) {
-		if (me.error?.unauth) redirect(302, '/auth/signin')
+		if (me.error?.unauth) {
+			// Remember where the user was headed so the OAuth round-trip can land
+			// them back here instead of dumping them on the dashboard. The path is
+			// same-origin by construction; signin/callback re-validate it.
+			const next = url.pathname + url.search
+			redirect(302, next && next !== '/'
+				? `/auth/signin?redirect=${encodeURIComponent(next)}`
+				: '/auth/signin')
+		}
 		error(500, me.error?.message)
 	}
 	if (!projects.ok) error(500, projects.error?.message)

--- a/src/routes/auth/callback/+server.js
+++ b/src/routes/auth/callback/+server.js
@@ -1,4 +1,5 @@
 import { env } from '$env/dynamic/private'
+import { sanitizeRedirect } from '$lib/server/redirect'
 
 const authEndpoint = env.AUTH_ENDPOINT || 'https://auth.deploys.app'
 
@@ -47,10 +48,20 @@ export async function GET ({ cookies, url }) {
 		secure: import.meta.env.PROD
 	})
 
+	// Return the user to where they were headed before sign-in. Re-validate at the
+	// point of use (the cookie is the open-redirect sink) and fall back to home.
+	const redirectTo = sanitizeRedirect(cookies.get('redirect')) || '/'
+	cookies.delete('redirect', {
+		httpOnly: true,
+		sameSite: 'lax',
+		path: '/',
+		secure: import.meta.env.PROD
+	})
+
 	return new Response(undefined, {
 		status: 302,
 		headers: {
-			location: '/'
+			location: redirectTo
 		}
 	})
 }

--- a/src/routes/auth/signin/+server.js
+++ b/src/routes/auth/signin/+server.js
@@ -1,4 +1,5 @@
 import { env } from '$env/dynamic/private'
+import { sanitizeRedirect } from '$lib/server/redirect'
 
 const authEndpoint = env.AUTH_ENDPOINT || 'https://auth.deploys.app'
 
@@ -20,6 +21,9 @@ export async function GET ({ cookies, url }) {
 
 	const callback = new URL(url.toString())
 	callback.pathname = '/auth/callback'
+	// The OAuth redirect_uri must match exactly what the provider has registered —
+	// strip our own `?redirect=` (and anything else) so it never leaks upstream.
+	callback.search = ''
 
 	const q = new URLSearchParams()
 	q.set('response_type', 'code')
@@ -34,6 +38,27 @@ export async function GET ({ cookies, url }) {
 		path: '/',
 		secure: import.meta.env.PROD
 	})
+
+	// Stash the post-login destination first-party (it never travels to the OAuth
+	// provider). Clear any stale value when this sign-in has no target so an
+	// abandoned attempt can't bounce a later login somewhere unexpected.
+	const redirectTo = sanitizeRedirect(url.searchParams.get('redirect'))
+	if (redirectTo) {
+		cookies.set('redirect', redirectTo, {
+			httpOnly: true,
+			maxAge: 60 * 60,
+			sameSite: 'lax',
+			path: '/',
+			secure: import.meta.env.PROD
+		})
+	} else {
+		cookies.delete('redirect', {
+			httpOnly: true,
+			sameSite: 'lax',
+			path: '/',
+			secure: import.meta.env.PROD
+		})
+	}
 
 	return new Response(undefined, {
 		status: 302,

--- a/tests/auth.spec.js
+++ b/tests/auth.spec.js
@@ -1,16 +1,20 @@
 import { test, unauthedTest, expect, setMocks } from './helpers.js'
 
 unauthedTest.describe('unauthenticated access', () => {
-	unauthedTest('redirects to /auth/signin when there is no token', async ({ page }) => {
+	unauthedTest('redirects to /auth/signin (remembering the path) when there is no token', async ({ page }) => {
 		const resp = await page.request.get('/?project=test-project', { maxRedirects: 0 })
 		expect([301, 302, 303, 307, 308]).toContain(resp.status())
-		expect(resp.headers().location).toBe('/auth/signin')
+		const loc = new URL(resp.headers().location, 'http://localhost')
+		expect(loc.pathname).toBe('/auth/signin')
+		expect(loc.searchParams.get('redirect')).toBe('/?project=test-project')
 	})
 
 	unauthedTest('redirects to /auth/signin from the project list as well', async ({ page }) => {
 		const resp = await page.request.get('/project', { maxRedirects: 0 })
 		expect([301, 302, 303, 307, 308]).toContain(resp.status())
-		expect(resp.headers().location).toBe('/auth/signin')
+		const loc = new URL(resp.headers().location, 'http://localhost')
+		expect(loc.pathname).toBe('/auth/signin')
+		expect(loc.searchParams.get('redirect')).toBe('/project')
 	})
 
 	unauthedTest('/auth/signin redirects to the OAuth provider', async ({ page }) => {
@@ -23,6 +27,64 @@ unauthedTest.describe('unauthenticated access', () => {
 		expect(location).toMatch(/client_id=test-client/)
 		expect(location).toMatch(/redirect_uri=/)
 		expect(location).toMatch(/state=[0-9a-f]+/)
+		// our own ?redirect= must never leak into the OAuth redirect_uri
+		const redirectUri = new URL(location).searchParams.get('redirect_uri') || ''
+		expect(redirectUri).not.toContain('redirect=')
+	})
+})
+
+unauthedTest.describe('post-login redirect', () => {
+	/** Read a Set-Cookie value off an APIResponse, undoing SvelteKit's encoding. */
+	function readSetCookie (resp, name) {
+		const header = resp.headersArray()
+			.filter((h) => h.name.toLowerCase() === 'set-cookie')
+			.map((h) => h.value)
+			.find((v) => v.startsWith(`${name}=`))
+		if (!header) return undefined
+		return decodeURIComponent(header.split(';')[0].slice(name.length + 1))
+	}
+
+	unauthedTest('signin records a safe redirect target', async ({ page }) => {
+		const target = '/deployment?project=foo'
+		const resp = await page.request.get('/auth/signin?redirect=' + encodeURIComponent(target), { maxRedirects: 0 })
+		expect(resp.status()).toBe(302)
+		expect(readSetCookie(resp, 'redirect')).toBe(target)
+	})
+
+	unauthedTest('signin refuses an off-site redirect target', async ({ page }) => {
+		const resp = await page.request.get('/auth/signin?redirect=' + encodeURIComponent('https://evil.example/phish'), { maxRedirects: 0 })
+		expect(resp.status()).toBe(302)
+		// either no redirect cookie, or a cleared one — never the off-site value
+		expect(readSetCookie(resp, 'redirect') || '').toBe('')
+	})
+
+	unauthedTest('callback returns the user to the remembered page', async ({ context, page }) => {
+		await context.addCookies([
+			{ name: 'state', value: 'test-state', domain: 'localhost', path: '/', sameSite: 'Lax' },
+			{ name: 'redirect', value: '/deployment?project=foo', domain: 'localhost', path: '/', sameSite: 'Lax' }
+		])
+		const resp = await page.request.get('/auth/callback?code=test-code&state=test-state', { maxRedirects: 0 })
+		expect(resp.status()).toBe(302)
+		expect(resp.headers().location).toBe('/deployment?project=foo')
+	})
+
+	unauthedTest('callback falls back to home without a remembered page', async ({ context, page }) => {
+		await context.addCookies([
+			{ name: 'state', value: 'test-state', domain: 'localhost', path: '/', sameSite: 'Lax' }
+		])
+		const resp = await page.request.get('/auth/callback?code=test-code&state=test-state', { maxRedirects: 0 })
+		expect(resp.status()).toBe(302)
+		expect(resp.headers().location).toBe('/')
+	})
+
+	unauthedTest('callback ignores an unsafe remembered value', async ({ context, page }) => {
+		await context.addCookies([
+			{ name: 'state', value: 'test-state', domain: 'localhost', path: '/', sameSite: 'Lax' },
+			{ name: 'redirect', value: 'https://evil.example/phish', domain: 'localhost', path: '/', sameSite: 'Lax' }
+		])
+		const resp = await page.request.get('/auth/callback?code=test-code&state=test-state', { maxRedirects: 0 })
+		expect(resp.status()).toBe(302)
+		expect(resp.headers().location).toBe('/')
 	})
 })
 

--- a/tests/mock-server.js
+++ b/tests/mock-server.js
@@ -61,6 +61,16 @@ const server = http.createServer(async (req, res) => {
 			return
 		}
 
+		// Stand-in for the OAuth provider's token endpoint. `AUTH_ENDPOINT` is set
+		// to `${MOCK_URL}/__auth`, so the sign-in callback exchanges its code here.
+		// Always hand back a refresh token so the callback can complete.
+		if (path === '/__auth/token' && req.method === 'POST') {
+			await readBody(req)
+			res.writeHead(200, { 'content-type': 'application/json' })
+			res.end(JSON.stringify({ access_token: 'test-access', refresh_token: 'test-token' }))
+			return
+		}
+
 		const body = await readBody(req)
 		requestLog.push({ path, method: req.method, body })
 


### PR DESCRIPTION
## Problem

Opening a console deep link while signed out drops the user on the dashboard after authenticating instead of the page they asked for. The original location was lost at the very first hop: `(auth)/+layout.js` redirected to a bare `/auth/signin`, and the OAuth callback always landed on `/`.

## Fix

Thread the intended destination through the OAuth round-trip with a first-party `redirect` cookie, mirroring the existing `state` cookie pattern:

- **`(auth)/+layout.js`** — on the unauth bounce, capture `pathname + search` and pass it as `/auth/signin?redirect=…`.
- **`/auth/signin`** — validate the target, stash it in the `redirect` cookie (clearing any stale value otherwise), and strip its own query from the OAuth `redirect_uri` so the param never leaks to the provider (keeps exact-match registration valid).
- **`/auth/callback`** — re-validate the cookie and return the user there, defaulting to `/`.

This also fixes the token-expiry path for free: `onUnauth` → `location.reload()` reloads the current deep URL, which the layout then captures.

## Security

`sanitizeRedirect` (new `$lib/server/redirect.js`) is a shared open-redirect guard — accepts same-origin absolute paths only, rejecting `//host`, scheme/protocol-relative URLs, backslashes, control/CRLF characters, and `/auth/*` (sign-in loop guard). It runs at **both** the query-param boundary and the `Location` sink (defense in depth).

## Tests

- The mock server gains a stand-in OAuth token endpoint so the callback flow is exercisable end-to-end.
- `auth.spec.js` covers path capture, the round-trip return, the default-home and unsafe-value fallbacks, and the `redirect_uri` non-leak.
- Full suite (198 tests) green in both dev and `PLAYWRIGHT_USE_BUILD` (PROD / `Secure`-cookie) configurations; `bun lint` and `bun check` clean.

## Known minor limitation

A deep route hit *without* `?project=` while logged out can resolve to `/project` first (the `(project)` layout's own redirect), so the original path isn't preserved in that degenerate case. Real console deep links always carry `?project=`, which is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)