### PR TITLE
Grant site.publish in the github-deploy role (static-web deploys)

### DIFF
--- a/src/lib/components/CreateServiceAccountModal.svelte
+++ b/src/lib/components/CreateServiceAccountModal.svelte
@@ -42,7 +42,9 @@
 		if (e.target === e.currentTarget) close()
 	}
 
-	const DEPLOY_PERMISSIONS = ['deployment.deploy', 'deployment.get', 'deployment.delete', 'registry.push']
+	// site.publish lets GitHub Actions publish static-web releases (mode: static
+	// in build-deploy-action); without it a static deploy 403s at /sites/*.
+	const DEPLOY_PERMISSIONS = ['deployment.deploy', 'deployment.get', 'deployment.delete', 'registry.push', 'site.publish']
 
 	async function create () {
 		if (!canSubmit) return
@@ -133,7 +135,7 @@
 			<div class="field">
 				<div class="checkbox">
 					<input id="create-sa-grant" type="checkbox" bind:checked={grantRole} disabled={!canGrantRole}>
-					<label for="create-sa-grant">Grant deploy role — deployment.deploy, deployment.get, deployment.delete, registry.push</label>
+					<label for="create-sa-grant">Grant deploy role — deployment.deploy, deployment.get, deployment.delete, registry.push, site.publish</label>
 				</div>
 				{#if !canGrantRole}
 					<p class="text-warning text-sm mt-1">

--- a/src/routes/(auth)/(project)/github/link/+page.svelte
+++ b/src/routes/(auth)/(project)/github/link/+page.svelte
@@ -199,8 +199,9 @@
 			Workflows deploy as the linked service account — it needs
 			<span class="font-mono">deployment.deploy</span>,
 			<span class="font-mono">deployment.get</span>,
-			<span class="font-mono">deployment.delete</span> and
-			<span class="font-mono">registry.push</span>.
+			<span class="font-mono">deployment.delete</span>,
+			<span class="font-mono">registry.push</span> and
+			<span class="font-mono">site.publish</span> (static-web publishing).
 		</p>
 	</div>
 


### PR DESCRIPTION
## Why
A GitHub Actions **static** deploy (`build-deploy-action` `mode: static`) calls the apiserver's `/sites/*` publish endpoints, which require the **`site.publish`** permission (added in api #54). The `github-deploy` role the create-service-account modal provisions only grants `deployment.deploy`/`get`/`delete` + `registry.push`, so a static publish **403s** at the upload-session step (`POST /sites/{project}/{name}/uploads`).

This is what's failing the docs static deploy right now.

## Change
- Add `site.publish` to `DEPLOY_PERMISSIONS` in `CreateServiceAccountModal.svelte`, so newly-created `github-deploy` roles can publish static releases.
- Update the permission help text in the modal and on the link page.

`bun lint` + `bun check` clean.

## Note — existing roles need a manual grant
This only affects roles created **after** this ships. A project whose `github-deploy` role already exists (e.g. `deploys-app`) won't gain `site.publish` automatically — an owner must add it to that role (the role editor now offers it since `site.publish` is in the api permission list, or via `deploys role` CLI). That's the immediate unblock for the docs deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
