### PR TITLE
Make the role permission dropdown searchable

### DIFF
--- a/src/lib/components/OptionSelect.svelte
+++ b/src/lib/components/OptionSelect.svelte
@@ -28,6 +28,13 @@
 	 *                                   isn't one of `options` (e.g. an HTTP method
 	 *                                   outside the known set). Off for closed sets
 	 *                                   like country codes.
+	 * @property {(value: string) => void} [onchange] notified with the committed
+	 *                                   value whenever an option (or custom value)
+	 *                                   is picked.
+	 * @property {boolean} [resetOnSelect] single mode — don't rest on the pick:
+	 *                                   clear the field and keep the menu open so the
+	 *                                   next value can be typed right away, turning
+	 *                                   the control into an "add to a list" picker.
 	 */
 
 	/** @type {Props} */
@@ -39,7 +46,9 @@
 		id,
 		placeholder = 'Search',
 		emptyText = 'No matches',
-		allowCustom = false
+		allowCustom = false,
+		onchange,
+		resetOnSelect = false
 	} = $props()
 
 	/** Resting/chip label for a stored value (falls back to the bare value). */
@@ -114,11 +123,18 @@
 			query = ''
 			activeIndex = 0
 			inputEl?.focus()
+		} else if (resetOnSelect) {
+			// Adder mode: surface the pick, then clear the field and keep the menu
+			// open so the next value can be typed without reopening.
+			query = ''
+			activeIndex = 0
+			inputEl?.focus()
 		} else {
 			value = o.value
 			query = labelOf(o.value)
 			close()
 		}
+		onchange?.(o.value)
 	}
 
 	// Commit the typed text as a brand-new value (creatable mode).
@@ -130,11 +146,16 @@
 			query = ''
 			activeIndex = 0
 			inputEl?.focus()
+		} else if (resetOnSelect) {
+			query = ''
+			activeIndex = 0
+			inputEl?.focus()
 		} else {
 			value = v
 			query = labelOf(v)
 			close()
 		}
+		onchange?.(v)
 	}
 
 	/** @param {number} i */
@@ -186,12 +207,13 @@
 			open ? moveActive(-1) : openMenu()
 			break
 		case 'Enter':
-			if (open && activeIndex >= 0 && matches[activeIndex]) {
+			// While the menu is open, Enter belongs to the combobox — never let it
+			// submit a surrounding form. Commit a highlighted option or the typed
+			// custom value if there is one; otherwise just swallow it.
+			if (open) {
 				e.preventDefault()
-				commit(matches[activeIndex])
-			} else if (open && customValue) {
-				e.preventDefault()
-				commitCustom()
+				if (activeIndex >= 0 && matches[activeIndex]) commit(matches[activeIndex])
+				else if (customValue) commitCustom()
 			}
 			break
 		case 'Escape':

--- a/src/routes/(auth)/(project)/role/create/+page.svelte
+++ b/src/routes/(auth)/(project)/role/create/+page.svelte
@@ -4,7 +4,7 @@
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
-	import Select from '$lib/components/Select.svelte'
+	import OptionSelect from '$lib/components/OptionSelect.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
 	const { data } = $props()
@@ -116,8 +116,10 @@
 			<h6><strong>Permissions</strong></h6>
 
 			<div class="field flex mb-3">
-				<Select
-					placeholder="Select Permission"
+				<OptionSelect
+					id="input-permission"
+					placeholder="Search permissions"
+					emptyText="No matching permission"
 					resetOnSelect
 					onchange={(v) => addPermission(String(v))}
 					options={permissions.filter((x) => !form.permissions.includes(x)).map((it) => ({ value: it, label: it }))} />

--- a/tests/role.spec.js
+++ b/tests/role.spec.js
@@ -23,4 +23,57 @@ test.describe('roles', () => {
 		const main = page.locator('.content-wrapper')
 		await expect(main.getByText('Nothing here yet')).toBeVisible()
 	})
+
+	test('searchable permission picker filters, adds, and resets', async ({ page }) => {
+		await setMocks({
+			'role.permissions': {
+				ok: true,
+				result: [
+					'project.get', 'project.update',
+					'deployment.list', 'deployment.get', 'deployment.deploy',
+					'domain.list', 'domain.create'
+				]
+			}
+		})
+
+		await page.goto('/role/create?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Create role' })).toBeVisible()
+
+		// Fill the required fields so the form could submit — lets us prove the
+		// picker's Enter handling, not native validation, is what holds it back.
+		await page.fill('#input-role', 'auditor')
+		await page.fill('#input-name', 'Auditor')
+
+		const picker = page.locator('#input-permission')
+		const listbox = page.locator('#input-permission-listbox')
+
+		// Opening shows the full list.
+		await picker.click()
+		await expect(listbox.getByRole('option', { name: 'deployment.list', exact: true })).toBeVisible()
+		await expect(listbox.getByRole('option', { name: 'domain.create', exact: true })).toBeVisible()
+
+		// Typing filters the list down to matches.
+		await picker.fill('domain')
+		await expect(listbox.getByRole('option', { name: 'domain.create', exact: true })).toBeVisible()
+		await expect(listbox.getByRole('option', { name: 'deployment.list', exact: true })).toHaveCount(0)
+
+		// A query that matches nothing shows the empty state, and Enter on it must
+		// not submit the surrounding form (stays on the create page).
+		await picker.fill('nope')
+		await expect(listbox.getByText('No matching permission')).toBeVisible()
+		await picker.press('Enter')
+		await expect(main.getByRole('heading', { name: 'Create role' })).toBeVisible()
+
+		// Picking adds it to the table, clears the field, and drops it from the list.
+		await picker.fill('domain.create')
+		await listbox.getByRole('option', { name: 'domain.create', exact: true }).click()
+		await expect(main.getByRole('cell', { name: 'domain.create', exact: true })).toBeVisible()
+		await expect(picker).toHaveValue('')
+
+		await picker.fill('domain')
+		await expect(listbox.getByRole('option', { name: 'domain.create', exact: true })).toHaveCount(0)
+		await expect(listbox.getByRole('option', { name: 'domain.list', exact: true })).toBeVisible()
+	})
 })


### PR DESCRIPTION
## What

The create/edit **role** page listed every permission in a plain dropdown, so picking one meant scrolling a long flat list. This makes that picker **type-to-filter searchable** while leaving the rest of the page untouched.

- Swaps the permission adder from `Select` to the codebase's searchable `OptionSelect` — the same component behind the WAF country and HTTP-method pickers.
- The selected-permissions table (with its remove buttons) is unchanged; only the *dropdown* gained search.

## How

`OptionSelect` gains two opt-in props that mirror `Select`'s existing API, so the two select components stay consistent and the page diff stays tiny:

- `onchange` — fired with the committed value when an option is picked.
- `resetOnSelect` — single-mode "adder" behavior: after a pick, clear the field and keep the menu open so the next permission can be typed right away, instead of resting on the selection.

Both default off, so the existing `OptionSelect`/`CountrySelect` callers (WAF country/method pickers) are unaffected.

## Also fixed

While wiring the picker into the role `<form>`, `/scrutinize` caught that `OptionSelect` only called `preventDefault` on `Enter` when it committed something. Typing a non-matching query and pressing Enter would therefore bubble up and **submit the surrounding form** (creating the role prematurely). `Enter` is now always swallowed while the menu is open — matching `Select`'s editable mode, which already guards against this.

## Testing

- `bun lint` and `bun check` — clean.
- New Playwright test in `tests/role.spec.js`: filters the list, shows the empty state, verifies Enter on a non-match does **not** submit the form, picks an option (added to the table, field reset, dropped from the list).
- Re-ran the WAF/country specs to confirm the `OptionSelect` Enter change is regression-free (76 passed).
- Verified visually in mock mode (open list → typed filter → multi-add into the table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)