### PR TITLE
Hide pod-only UI for static deployments

### DIFF
--- a/src/lib/components/DeploymentStatusIcon.svelte
+++ b/src/lib/components/DeploymentStatusIcon.svelte
@@ -35,8 +35,9 @@
 
 	// Pod readiness only changes the icon for a running (non-paused) success
 	// deployment; every other state is resolved from props alone, so there's no
-	// reason to hit statusUrl for it.
-	const needsPodStatus = $derived(status === 'success' && action !== 'pause')
+	// reason to hit statusUrl for it. Static deployments have no pods (served by
+	// the static-gateway, no statusUrl), so they never poll either.
+	const needsPodStatus = $derived(status === 'success' && action !== 'pause' && type !== 'Static')
 
 	/**
 	 * @returns {string}
@@ -48,6 +49,11 @@
 
 		if (action === 'pause') {
 			return 'fa-solid fa-pause text-warning'
+		}
+
+		if (type === 'Static') {
+			// No pods to wait on — a successful release is simply done.
+			return 'fa-solid fa-check-circle text-positive/80'
 		}
 
 		if (!podStatus) {

--- a/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
@@ -9,13 +9,19 @@
 	const project = $derived(data.project)
 	const deployment = $derived(data.deployment)
 
-	const tabs = [
+	// A Static deployment runs no pods, so it has no logs or k8s events — hide
+	// those tabs (the metrics tab stays but drops the pod-only charts).
+	const tabs = $derived([
 		{ label: 'Metrics', path: '/deployment/metrics' },
 		{ label: 'Details', path: '/deployment/detail' },
 		{ label: 'Revisions', path: '/deployment/revision' },
-		{ label: 'Logs', path: '/deployment/logs' },
-		{ label: 'Events', path: '/deployment/events' }
-	]
+		...(deployment.type === 'Static'
+			? []
+			: [
+				{ label: 'Logs', path: '/deployment/logs' },
+				{ label: 'Events', path: '/deployment/events' }
+			])
+	])
 
 	/** @param {string} path */
 	function tabHref (path) {

--- a/src/routes/(auth)/(project)/deployment/(detail)/events/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/events/+page.svelte
@@ -20,6 +20,11 @@
 	let now = $state(Date.now())
 
 	onMount(() => {
+		// Static deployments have no pods and no eventUrl. The Events tab is
+		// hidden for them, but guard direct navigation so we don't poll
+		// fetch('') against this page every few seconds.
+		if (!deployment.eventUrl) return
+
 		reload()
 		const poll = setInterval(reload, POLL_INTERVAL_MS)
 		const ticker = setInterval(() => { now = Date.now() }, 1000)

--- a/src/routes/(auth)/(project)/deployment/(detail)/logs/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/logs/+page.svelte
@@ -107,6 +107,11 @@
 	})
 
 	onMount(() => {
+		// Static deployments have no pods and no logUrl. The Logs tab is hidden
+		// for them, but guard direct navigation so we don't open EventSource('')
+		// (which resolves to this page and would reconnect-loop on it).
+		if (!deployment.logUrl) return
+
 		const source = new EventSource(deployment.logUrl)
 		source.addEventListener('open', () => {
 			connected = true

--- a/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
@@ -309,8 +309,12 @@
 </header>
 
 <div class="metric-grid">
-	<Chart title="vCPU (second)" unit="seconds" series={cpu} range={filter.range} />
-	<Chart title="Memory (bytes)" unit="bytes" series={memory} range={filter.range} />
+	<!-- Static deployments run no pods, so there is no CPU/memory to chart —
+	     only egress (bytes served by the static-gateway) applies. -->
+	{#if deployment.type !== 'Static'}
+		<Chart title="vCPU (second)" unit="seconds" series={cpu} range={filter.range} />
+		<Chart title="Memory (bytes)" unit="bytes" series={memory} range={filter.range} />
+	{/if}
 	{#if deployment.type === 'WebService'}
 		<Chart title="Request (rps)" unit="rps" series={request} range={filter.range} />
 	{/if}

--- a/tests/deployment.spec.js
+++ b/tests/deployment.spec.js
@@ -342,6 +342,71 @@ test.describe('deployment detail — static', () => {
 		await expect(main.locator('.spec').filter({ hasText: 'Type' })).toContainText('Static')
 		await expect(main.getByRole('link', { name: 'https://website.test-project.app.in.th' })).toBeVisible()
 	})
+
+	test('status icon shows success without polling for pod readiness', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleStaticDeployment },
+			'location.get': { ok: true, result: defaultLocation }
+		})
+
+		await page.goto('/deployment/detail?project=test-project&location=gke&name=website')
+
+		// A successful Static deployment is done immediately — the header icon is
+		// the success check, not a readiness spinner.
+		await expect(page.locator('.masthead__icon i.fa-check-circle')).toBeVisible()
+		await expect(page.locator('.masthead__icon i.fa-spinner')).toHaveCount(0)
+	})
+
+	test('hides the Logs and Events tabs', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleStaticDeployment },
+			'location.get': { ok: true, result: defaultLocation }
+		})
+
+		await page.goto('/deployment/detail?project=test-project&location=gke&name=website')
+
+		const tabs = page.locator('.tabs')
+		await expect(tabs.getByRole('link', { name: 'Metrics' })).toBeVisible()
+		await expect(tabs.getByRole('link', { name: 'Details' })).toBeVisible()
+		await expect(tabs.getByRole('link', { name: 'Revisions' })).toBeVisible()
+		await expect(tabs.getByRole('link', { name: 'Logs' })).toHaveCount(0)
+		await expect(tabs.getByRole('link', { name: 'Events' })).toHaveCount(0)
+	})
+
+	test('metrics tab hides the CPU and Memory charts but keeps Egress', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleStaticDeployment },
+			'location.get': { ok: true, result: defaultLocation },
+			'deployment.metrics': { ok: true, result: {} }
+		})
+
+		await page.goto('/deployment/metrics?project=test-project&location=gke&name=website')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('Egress (bytes)')).toBeVisible()
+		await expect(main.getByText('vCPU (second)')).toHaveCount(0)
+		await expect(main.getByText('Memory (bytes)')).toHaveCount(0)
+	})
+})
+
+test.describe('deployment detail — non-static keeps pod surface', () => {
+	test('WebService keeps the Logs and Events tabs and the CPU/Memory charts', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleDeployment },
+			'location.get': { ok: true, result: defaultLocation },
+			'deployment.metrics': { ok: true, result: {} }
+		})
+
+		await page.goto('/deployment/detail?project=test-project&location=gke&name=web')
+		const tabs = page.locator('.tabs')
+		await expect(tabs.getByRole('link', { name: 'Logs' })).toBeVisible()
+		await expect(tabs.getByRole('link', { name: 'Events' })).toBeVisible()
+
+		await page.goto('/deployment/metrics?project=test-project&location=gke&name=web')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('vCPU (second)')).toBeVisible()
+		await expect(main.getByText('Memory (bytes)')).toBeVisible()
+	})
 })
 
 test.describe('deployment revision — static rollback', () => {


### PR DESCRIPTION
## What

A **Static** deployment runs no k8s pods (it's served by the static-gateway), so the pod-derived UI doesn't apply. For Static deployments this:

- **Status icon** — shows the success check immediately for a successful Static deployment, instead of polling a (nonexistent) `statusUrl` for pod readiness. Previously the icon spun forever because pod readiness never arrives.
- **Detail page** — hides the **Logs** and **Events** tabs, and the **CPU** and **Memory** metric charts. The **Egress** chart (bytes served by the static-gateway) stays.
- **Robustness** — guards direct navigation to the now-hidden `logs`/`events` routes so an empty `logUrl`/`eventUrl` can't open `EventSource('')` / `fetch('')` against the page itself (which would reconnect/poll-loop on it).

All gating keys on `deployment.type === 'Static'` (or the absence of the URL), the established pattern already used on the detail page for the Release-vs-Image row.

## Screenshots (mock data)

- Detail page for a Static deployment: green success icon in the header; tabs are **Metrics / Details / Revisions** only (no Logs/Events); Metrics shows only the Egress chart.
- Deployment list: the Static `website` row shows the success check, while a `worker` row still spins (non-static behavior unchanged).

## Testing

`tests/deployment.spec.js`:
- Static: status icon shows success (no readiness spinner); Logs/Events tabs hidden; Metrics hides CPU+Memory but keeps Egress.
- Contrast: a WebService keeps the Logs/Events tabs and the CPU/Memory charts.

`bun lint` and `bun check` clean; full `tests/deployment.spec.js` suite (18 tests) passes.

## Companion

Apiserver PR `static-no-log-url` stops returning the URLs server-side. Independent of this PR (the console gates on type), can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)