### PR TITLE
Hide container-only detail sections for static deployments

### DIFF
--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -621,25 +621,30 @@
 						<i class="fa-light fa-copy"></i>
 					</span>
 				</div>
-				<div class="spec">
-					<span class="spec__label">Pull Secret</span>
-					{#if deployment.pullSecret}
-						<span class="spec__value is-mono">{deployment.pullSecret}</span>
-					{:else}
-						<span class="spec__value is-dim">—</span>
-					{/if}
-					<span></span>
-				</div>
-				{#if location.features.workloadIdentity}
+				<!-- Pull secret and workload identity bind a container image to a
+				     registry / GCP identity — neither applies to a Static deployment,
+				     which serves a content-addressed release with no pods. -->
+				{#if !isStatic}
 					<div class="spec">
-						<span class="spec__label">Workload Identity</span>
-						{#if deployment.workloadIdentity}
-							<span class="spec__value is-mono">{deployment.workloadIdentity}</span>
+						<span class="spec__label">Pull Secret</span>
+						{#if deployment.pullSecret}
+							<span class="spec__value is-mono">{deployment.pullSecret}</span>
 						{:else}
 							<span class="spec__value is-dim">—</span>
 						{/if}
 						<span></span>
 					</div>
+					{#if location.features.workloadIdentity}
+						<div class="spec">
+							<span class="spec__label">Workload Identity</span>
+							{#if deployment.workloadIdentity}
+								<span class="spec__value is-mono">{deployment.workloadIdentity}</span>
+							{:else}
+								<span class="spec__value is-dim">—</span>
+							{/if}
+							<span></span>
+						</div>
+					{/if}
 				{/if}
 			</div>
 		</section>
@@ -661,16 +666,20 @@
 					<span class="spec__value is-mono">{deployment.createdBy}</span>
 					<span></span>
 				</div>
-				<div class="spec">
-					<span class="spec__label">Allocated Price</span>
-					<span class="spec__value">
-						<span class="spec__value is-mono" style="font-family: var(--ffml-mono);">
-							{deployment.allocatedPrice.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+				<!-- Allocated price is per running replica — a Static deployment runs
+				     no replicas, so it carries no allocation cost to show. -->
+				{#if !isStatic}
+					<div class="spec">
+						<span class="spec__label">Allocated Price</span>
+						<span class="spec__value">
+							<span class="spec__value is-mono" style="font-family: var(--ffml-mono);">
+								{deployment.allocatedPrice.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+							</span>
+							THB / month / replica
 						</span>
-						THB / month / replica
-					</span>
-					<span></span>
-				</div>
+						<span></span>
+					</div>
+				{/if}
 				{#if deployment.ttl === -1}
 					<div class="spec">
 						<span class="spec__label">Auto-delete</span>
@@ -698,6 +707,10 @@
 	</div>
 </div>
 
+<!-- Env groups, env vars and mount data all inject configuration into a running
+     container. A Static deployment has no container, so none of these apply —
+     hide all three shells for it. -->
+{#if !isStatic}
 <!-- ─── ENV GROUPS shell ─── -->
 <div class="shell">
 	<header class="rail">
@@ -803,6 +816,7 @@
 		</section>
 	</div>
 </div>
+{/if}
 
 <DangerZone description="Permanently delete this deployment. All running instances will be stopped and removed.">
 	<GuardedButton permission="deployment.delete" class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</GuardedButton>

--- a/tests/deployment.spec.js
+++ b/tests/deployment.spec.js
@@ -387,6 +387,27 @@ test.describe('deployment detail — static', () => {
 		await expect(main.getByText('vCPU (second)')).toHaveCount(0)
 		await expect(main.getByText('Memory (bytes)')).toHaveCount(0)
 	})
+
+	test('hides the container-only detail sections', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleStaticDeployment },
+			'location.get': { ok: true, result: defaultLocation }
+		})
+
+		await page.goto('/deployment/detail?project=test-project&location=gke&name=website')
+
+		const main = page.locator('.content-wrapper')
+
+		// Whole shells that only make sense for a running container are gone.
+		await expect(main.getByRole('heading', { name: 'Env Groups' })).toHaveCount(0)
+		await expect(main.getByRole('heading', { name: 'Env Vars' })).toHaveCount(0)
+		await expect(main.getByRole('heading', { name: 'Mount Data' })).toHaveCount(0)
+
+		// Individual container-only spec rows are gone too.
+		await expect(main.locator('.spec').filter({ hasText: 'Pull Secret' })).toHaveCount(0)
+		await expect(main.locator('.spec').filter({ hasText: 'Workload Identity' })).toHaveCount(0)
+		await expect(main.locator('.spec').filter({ hasText: 'Allocated Price' })).toHaveCount(0)
+	})
 })
 
 test.describe('deployment detail — non-static keeps pod surface', () => {
@@ -406,6 +427,23 @@ test.describe('deployment detail — non-static keeps pod surface', () => {
 		const main = page.locator('.content-wrapper')
 		await expect(main.getByText('vCPU (second)')).toBeVisible()
 		await expect(main.getByText('Memory (bytes)')).toBeVisible()
+	})
+
+	test('WebService keeps the container-only detail sections', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleDeployment },
+			'location.get': { ok: true, result: defaultLocation }
+		})
+
+		await page.goto('/deployment/detail?project=test-project&location=gke&name=web')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Env Groups' })).toBeVisible()
+		await expect(main.getByRole('heading', { name: 'Env Vars' })).toBeVisible()
+		await expect(main.getByRole('heading', { name: 'Mount Data' })).toBeVisible()
+		await expect(main.locator('.spec').filter({ hasText: 'Pull Secret' })).toBeVisible()
+		await expect(main.locator('.spec').filter({ hasText: 'Workload Identity' })).toBeVisible()
+		await expect(main.locator('.spec').filter({ hasText: 'Allocated Price' })).toBeVisible()
 	})
 })
 


### PR DESCRIPTION
## What

On the deployment **detail** page, hide the sections that only describe a running container when the deployment `type` is `Static`:

- **Env Groups**, **Env Vars**, **Mount Data** shells — configuration injected into a container.
- **Pull Secret** and **Workload Identity** rows — bind a container image to a registry / GCP identity.
- **Allocated Price** row — cost is per running replica, and a Static deployment runs none.

## Why

A Static deployment serves a content-addressed release through the static-gateway with no pods, so these container-oriented fields are always empty/irrelevant for it. This continues the pod-only UI hiding started in #206 (which handled the Logs/Events tabs, CPU/Memory charts, and the readiness status icon).

The non-static (WebService/TCPService/CronJob/…) rendering path is unchanged — every gated block reappears verbatim inside the new `!isStatic` guard.

## Tests

- `deployment detail — static › hides the container-only detail sections` — asserts all six are absent for a Static deployment.
- `deployment detail — non-static keeps pod surface › WebService keeps the container-only detail sections` — asserts all six remain for a WebService.

`bun lint`, `bun check`, and the full `tests/deployment.spec.js` suite (20 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)