### PR TITLE
Show the Requests chart for static deployments

### DIFF
--- a/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
@@ -76,7 +76,7 @@
 				{ prefix: 'Allocated', lines: resp.result.memory ?? [] },
 				{ prefix: 'Limit', lines: resp.result.memoryLimit ?? [], dashStyle: 'LongDash', color: 'red' }
 			]
-			if (deployment.type === 'WebService') {
+			if (deployment.type === 'WebService' || deployment.type === 'Static') {
 				request = [{ prefix: 'Requests', lines: resp.result.requests ?? [] }]
 			}
 			egress = [{ prefix: 'Egress', lines: resp.result.egress ?? [] }]
@@ -315,7 +315,9 @@
 		<Chart title="vCPU (second)" unit="seconds" series={cpu} range={filter.range} />
 		<Chart title="Memory (bytes)" unit="bytes" series={memory} range={filter.range} />
 	{/if}
-	{#if deployment.type === 'WebService'}
+	<!-- Static deployments have no pods, but the static-gateway reports their
+	     per-site request rate, so Requests applies to them too. -->
+	{#if deployment.type === 'WebService' || deployment.type === 'Static'}
 		<Chart title="Request (rps)" unit="rps" series={request} range={filter.range} />
 	{/if}
 	<Chart title="Egress (bytes)" unit="bytes" series={egress} range={filter.range} />

--- a/tests/deployment.spec.js
+++ b/tests/deployment.spec.js
@@ -373,7 +373,7 @@ test.describe('deployment detail — static', () => {
 		await expect(tabs.getByRole('link', { name: 'Events' })).toHaveCount(0)
 	})
 
-	test('metrics tab hides the CPU and Memory charts but keeps Egress', async ({ page }) => {
+	test('metrics tab hides CPU and Memory but keeps Requests and Egress', async ({ page }) => {
 		await setMocks({
 			'deployment.get': { ok: true, result: sampleStaticDeployment },
 			'location.get': { ok: true, result: defaultLocation },
@@ -383,6 +383,9 @@ test.describe('deployment detail — static', () => {
 		await page.goto('/deployment/metrics?project=test-project&location=gke&name=website')
 
 		const main = page.locator('.content-wrapper')
+		// The static-gateway reports per-site request rate, so Requests applies;
+		// CPU/Memory don't (no pods). Egress stays.
+		await expect(main.getByText('Request (rps)')).toBeVisible()
 		await expect(main.getByText('Egress (bytes)')).toBeVisible()
 		await expect(main.getByText('vCPU (second)')).toHaveCount(0)
 		await expect(main.getByText('Memory (bytes)')).toHaveCount(0)


### PR DESCRIPTION
## What

Shows the **Request (rps)** chart on the metrics tab for **Static** deployments (previously WebService-only).

Static deployments run no pods, so CPU/Memory stay hidden — but the static-gateway now reports their per-site request rate (collected into the deployment's `requests` usage), so the Requests chart applies. Egress stays as before.

## Testing

`bun lint` + `bun check` clean. Updated the static metrics e2e test to assert the Request chart is visible (alongside Egress, with CPU/Memory still hidden); full `deployment.spec.js` (18 tests) passes.

## Dependencies

This is the visible end of the pipeline: deploys-app/api#59 (`CollectorProject.SID`), apiserver (read static usage by display name), collector (sync the gateway counter), static-gateway (emit `static_gateway_requests_total` + the required Prometheus scrape config). The chart renders regardless, but only fills in once those land and the gateway is scraped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)