### PR TITLE
Default GitHub workflow deployment name to the repo name

### DIFF
--- a/src/routes/(auth)/(project)/github/+page.svelte
+++ b/src/routes/(auth)/(project)/github/+page.svelte
@@ -48,11 +48,22 @@
 		})
 	}
 
+	// Derive a sensible deployment name from a `owner/name` repository: the repo
+	// name, lowercased with anything outside [a-z0-9-] folded to a hyphen.
+	/** @param {string | undefined} repository */
+	function repoToName (repository) {
+		const short = (repository ?? '').split('/').pop() ?? ''
+		return short
+			.toLowerCase()
+			.replace(/[^a-z0-9-]+/g, '-')
+			.replace(/^-+|-+$/g, '')
+	}
+
 	// workflow generator
 	const gen = $state(untrack(() => ({
 		repository: data.links[0]?.repository ?? '',
 		location: data.locations[0]?.id ?? '',
-		name: 'web',
+		name: repoToName(data.links[0]?.repository) || 'web',
 		// 'dockerfile' (default) emits today's container workflow; 'static' emits
 		// a bucket-native static-web workflow (mode: static).
 		buildType: 'dockerfile',
@@ -73,6 +84,14 @@
 	})))
 	const genRepoOptions = $derived(links.map((l) => ({ value: l.repository, label: l.repository })))
 	const genBranch = $derived(links.find((l) => l.repository === gen.repository)?.productionBranch || 'main')
+
+	// Keep the deployment name defaulting to the selected repository's name until
+	// the user edits it — switching repos then re-fills with the new repo name.
+	let nameTouched = $state(false)
+	$effect(() => {
+		const derivedName = repoToName(gen.repository)
+		if (!nameTouched && derivedName) gen.name = derivedName
+	})
 
 	const buildTypeOptions = [
 		{ value: 'dockerfile', label: 'Dockerfile' },
@@ -398,7 +417,7 @@ ${withBlock()}
 			<div class="field">
 				<label for="gen-name">Deployment name</label>
 				<div class="input">
-					<input id="gen-name" class="font-mono" bind:value={gen.name} placeholder="web">
+					<input id="gen-name" class="font-mono" bind:value={gen.name} oninput={() => nameTouched = true} placeholder="web">
 				</div>
 			</div>
 			<div class="field">


### PR DESCRIPTION
## What

In the GitHub workflow generator (`/github`), the **Deployment name** field defaulted to a static `web`. It now defaults to the selected repository's short name — `owner/console` → `console` — lowercased with anything outside `[a-z0-9-]` folded to a hyphen so it's a usable deployment name.

## Behavior

- On first render, the name seeds from the first linked repo (falls back to `web` if sanitization yields empty).
- Switching the repository in the dropdown re-fills the name with the new repo's name.
- Once the user edits the name field, it stops auto-filling and their value sticks. Implemented with a `nameTouched` flag + `$effect`, mirroring the existing `pullSecret`-reset effect on the same page.

## Notes

- The deployment name field has no client-side validation (the backend validates), so the generated default is a starting point the user can edit — same contract as before.
- No e2e test added; this is a UI default. `bun lint` and `bun check` both pass with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)