### PR TITLE
Allow routing to Static deployments

### DIFF
--- a/src/routes/(auth)/(project)/route/create/+page.svelte
+++ b/src/routes/(auth)/(project)/route/create/+page.svelte
@@ -86,7 +86,7 @@
 		const list = resp.result.items ?? []
 		deployments = list
 			.filter((x) => x.location === form.location)
-			.filter((x) => x.type === 'WebService')
+			.filter((x) => x.type === 'WebService' || x.type === 'Static')
 			.filter((x) => x.ttl === 0)
 			.map((x) => ({ name: x.name, paused: x.action === 'pause' }))
 	}

--- a/src/routes/(auth)/(project)/route/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/route/edit/+page.svelte
@@ -124,7 +124,7 @@
 		const list = resp.result?.items ?? []
 		deployments = list
 			.filter((/** @type {Api.Deployment} */ x) => x.location === route.location)
-			.filter((/** @type {Api.Deployment} */ x) => x.type === 'WebService')
+			.filter((/** @type {Api.Deployment} */ x) => x.type === 'WebService' || x.type === 'Static')
 			.filter((/** @type {Api.Deployment} */ x) => x.ttl === 0)
 			.map((/** @type {Api.Deployment} */ x) => ({ name: x.name, paused: x.action === 'pause' }))
 	}


### PR DESCRIPTION
## What

Include `Static` deployments in the route create/edit deployment picker (previously filtered to `WebService` only).

## Why

The backend now supports a `deployment://` route that points at a Static deployment: apiserver validation accepts it (#111) and the deployer materializes it against the shared `static-gateway`. So the WebService-only filter that hid Static deployments from the picker is no longer needed — this was the reason users couldn't create a route for a static deployment.

## Dependency order

PR 4 of 4: api → apiserver → deployer → **console**. The console change is safe to ship only once the deployer side is deployed (otherwise such routes would 503).

🤖 Generated with [Claude Code](https://claude.com/claude-code)