### PR TITLE
Use deploy.yaml filename for GitHub workflow

### DIFF
--- a/src/routes/(auth)/(project)/github/+page.svelte
+++ b/src/routes/(auth)/(project)/github/+page.svelte
@@ -322,7 +322,7 @@ ${withBlock()}
 `)
 
 	const createOnGitHubURL = $derived(gen.repository
-		? `https://github.com/${gen.repository}/new/main?filename=.github/workflows/deploy.yml&value=${encodeURIComponent(workflowYaml)}`
+		? `https://github.com/${gen.repository}/new/main?filename=.github/workflows/deploy.yaml&value=${encodeURIComponent(workflowYaml)}`
 		: '')
 
 	onMount(() => setupCopy('.copy-workflow'))
@@ -400,7 +400,7 @@ ${withBlock()}
 		<div>
 			<h6><strong>Workflow</strong></h6>
 			<p class="text-content/50 text-sm mt-1">
-				Add this file as <span class="font-mono">.github/workflows/deploy.yml</span>
+				Add this file as <span class="font-mono">.github/workflows/deploy.yaml</span>
 				to deploy on push and get pull request previews.
 			</p>
 		</div>

--- a/tests/github.spec.js
+++ b/tests/github.spec.js
@@ -80,7 +80,7 @@ test.describe('github', () => {
 
 		// Create-on-GitHub deep-link targets the linked repo's file editor.
 		const href = await main.getByRole('link', { name: 'Create on GitHub' }).getAttribute('href')
-		expect(href).toContain('https://github.com/acme/web/new/main?filename=.github/workflows/deploy.yml&value=')
+		expect(href).toContain('https://github.com/acme/web/new/main?filename=.github/workflows/deploy.yaml&value=')
 		expect(decodeURIComponent(href ?? '')).toContain('name: api')
 	})
 


### PR DESCRIPTION
When creating the GitHub Actions workflow from the console, the suggested file is now `.github/workflows/deploy.yaml` instead of `deploy.yml`.

Updates both the "Create on GitHub" new-file URL and the on-page instruction text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)