### PR TITLE
Hide pause/resume/deploy actions for static deployments

### DIFF
--- a/src/routes/(auth)/(project)/deployment/_components/Header.svelte
+++ b/src/routes/(auth)/(project)/deployment/_components/Header.svelte
@@ -21,8 +21,14 @@
 	/** @type {{ can: (p: string) => boolean }} */
 	const { can } = getContext('permission')
 
-	const canPause = $derived(deployment.status === 'success' && deployment.action === 'deploy')
-	const canResume = $derived(deployment.status === 'success' && deployment.action === 'pause')
+	// Static deployments serve a release from the edge and have no container/pods.
+	// The console deploy form is container-image only (a static revision needs a
+	// site:// release reference from the publish/GitHub-action path), and the
+	// apiserver rejects pause/resume for static — so hide all three actions.
+	const isStatic = $derived(deployment.type === 'Static')
+
+	const canPause = $derived(!isStatic && deployment.status === 'success' && deployment.action === 'deploy')
+	const canResume = $derived(!isStatic && deployment.status === 'success' && deployment.action === 'pause')
 
 	const statusTone = $derived(
 		deployment.status === 'success' && deployment.action === 'pause'
@@ -325,17 +331,19 @@
 					</button>
 				</span>
 			{/if}
-			{#if can('deployment.deploy')}
-				<a class="mast-btn is-primary"
-					href={`/deployment/deploy?project=${project}&location=${deployment.location}&name=${deployment.name}`}>
-					<i class="fa-solid fa-rocket"></i> Deploy New Revision
-				</a>
-			{:else}
-				<span class="inline-flex" title={denyTooltip('deployment.deploy')}>
-					<button class="mast-btn is-primary" type="button" disabled aria-disabled="true">
+			{#if !isStatic}
+				{#if can('deployment.deploy')}
+					<a class="mast-btn is-primary"
+						href={`/deployment/deploy?project=${project}&location=${deployment.location}&name=${deployment.name}`}>
 						<i class="fa-solid fa-rocket"></i> Deploy New Revision
-					</button>
-				</span>
+					</a>
+				{:else}
+					<span class="inline-flex" title={denyTooltip('deployment.deploy')}>
+						<button class="mast-btn is-primary" type="button" disabled aria-disabled="true">
+							<i class="fa-solid fa-rocket"></i> Deploy New Revision
+						</button>
+					</span>
+				{/if}
 			{/if}
 		</div>
 	</div>


### PR DESCRIPTION
## What

For Static deployments, hide the **Pause**, **Resume**, and **Deploy New Revision** actions in the deployment masthead (`Header.svelte`).

## Why

Static deployments serve a release from the edge and have no container/pods:

- **Pause/Resume** are meaningless — nothing to scale down/up. The apiserver now rejects these for static (companion change in `apiserver`).
- **Deploy New Revision** links to the console deploy form, which is container-image only. A static revision requires a `site://` release reference produced by the publish / GitHub-action upload path, and the apiserver's `deployment.deploy` rejects an `image` for static — so the form can never produce a valid static revision.

**Rollback stays available** — it re-points the site to an already-published release (the deliberate static "change which revision is live" path).

## How

- Add `isStatic = deployment.type === 'Static'` (same idiom already used in the detail page/layout).
- `canPause` / `canResume` now also require `!isStatic`.
- Wrap the Deploy New Revision block in `{#if !isStatic}`.

Mirrors the existing pattern where the detail layout drops the Logs/Events tabs for static.

`bun lint` and `bun check` pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)