### PR TITLE
Hide Live range filter on Static deployment metrics

### DIFF
--- a/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
@@ -26,6 +26,10 @@
 
 	const deployment = $derived(data.deployment)
 
+	// Static deployments have no live metrics pipeline — the live and aggregate
+	// windows resolve to the same data, so the Live row is redundant noise.
+	const isStatic = $derived(deployment.type === 'Static')
+
 	const RELOAD_INTERVAL_MS = 60_000
 
 	const validRanges = new Set(RANGES.map((o) => o.value))
@@ -283,17 +287,19 @@
 	</div>
 
 	<div class="metric-rail__ranges" role="group" aria-label="time range">
-		<span class="range-group">
-			<span class="range-group__label">Live</span>
-			{#each RANGES.filter((r) => r.group === 'live') as r (r.value)}
-				<button type="button" class="range-pill"
-					data-active={filter.range === r.value}
-					data-group="live"
-					onclick={() => setRange(r.value)}>
-					{r.label}
-				</button>
-			{/each}
-		</span>
+		{#if !isStatic}
+			<span class="range-group">
+				<span class="range-group__label">Live</span>
+				{#each RANGES.filter((r) => r.group === 'live') as r (r.value)}
+					<button type="button" class="range-pill"
+						data-active={filter.range === r.value}
+						data-group="live"
+						onclick={() => setRange(r.value)}>
+						{r.label}
+					</button>
+				{/each}
+			</span>
+		{/if}
 		<span class="range-group">
 			<span class="range-group__label">Agg</span>
 			{#each RANGES.filter((r) => r.group === 'agg') as r (r.value)}


### PR DESCRIPTION
## Summary
On the deployment metrics page, Static deployments have no live metrics pipeline — the **Live** and **Agg** time windows resolve to the same underlying data, so the Live pill row is redundant noise.

This hides the Live range row for Static deployments (`#if !isStatic`), leaving only the Agg windows. The default range stays `1hagg`, so Static pages still land on a valid window. WebService deployments are unchanged.

## Screenshots

**Static deployment — Live row hidden (Agg only):**

![Static metrics rail](https://raw.githubusercontent.com/deploys-app/console/assets/static-metrics-screenshots-214/static-rail.png)

**WebService deployment — unchanged (Live + Agg):**

![WebService metrics rail](https://raw.githubusercontent.com/deploys-app/console/assets/static-metrics-screenshots-214/web-rail.png)

**Full Static metrics page:**

![Static metrics page](https://raw.githubusercontent.com/deploys-app/console/assets/static-metrics-screenshots-214/static-full.png)

## Testing
- `bun lint` — clean
- `bun check` — 0 errors, 0 warnings
- Captured via Playwright in mock mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)