### PR TITLE
Redesign GitHub page; move workflow generator to its own page

### DIFF
--- a/src/routes/(auth)/(project)/github/+page.js
+++ b/src/routes/(auth)/(project)/github/+page.js
@@ -1,40 +1,12 @@
 import api from '$lib/api'
-import { hasPermission } from '$lib/permission'
 
 export async function load ({ parent, fetch }) {
-	const { project, permissions, permissionsAdmin } = await parent()
+	const { project } = await parent()
 
-	const [links, locations, envGroups, pullSecrets, githubPullRole] = await Promise.all([
-		api.invoke('github.list', { project }, fetch),
-		api.invoke('location.list', { project }, fetch),
-		api.invoke('envGroup.list', { project }, fetch),
-		// No location => every location's pull secrets; the generator filters by
-		// the selected location client-side.
-		api.invoke('pullSecret.list', { project }, fetch),
-		// Decides whether provisioning the dedicated pull service account still
-		// needs role.create (vs. the shared github-pull role already existing).
-		api.invoke('role.get', { project, role: 'github-pull' }, fetch)
-	])
-
-	const githubPullRoleExists = githubPullRole.ok && !!githubPullRole.result
-	// The "create dedicated pull secret" flow needs to: make a pull-only service
-	// account, mint a key, bind the registry.pull role, and create the pull
-	// secret. Gate the affordance on that whole set (lowercase canonical names,
-	// matching the server's effective grants), plus role.create only when the
-	// shared github-pull role doesn't exist yet.
-	const canProvisionPullSecret =
-		hasPermission(permissions, permissionsAdmin, 'serviceaccount.create') &&
-		hasPermission(permissions, permissionsAdmin, 'serviceaccount.key.create') &&
-		hasPermission(permissions, permissionsAdmin, 'pullsecret.create') &&
-		hasPermission(permissions, permissionsAdmin, 'role.bind') &&
-		(githubPullRoleExists || hasPermission(permissions, permissionsAdmin, 'role.create'))
+	const links = await api.invoke('github.list', { project }, fetch)
 
 	return {
 		links: links.result?.items ?? [],
-		locations: locations.result?.items ?? [],
-		envGroups: envGroups.result?.items ?? [],
-		pullSecrets: pullSecrets.result?.items ?? [],
-		canProvisionPullSecret,
 		error: links.error
 	}
 }

--- a/src/routes/(auth)/(project)/github/+page.svelte
+++ b/src/routes/(auth)/(project)/github/+page.svelte
@@ -1,28 +1,17 @@
 <script>
-	import { onMount, untrack } from 'svelte'
+	import { untrack } from 'svelte'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
-	import Select from '$lib/components/Select.svelte'
-	import NoDataRow from '$lib/components/NoDataRow.svelte'
-	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
-	import { denyTooltip } from '$lib/permission'
 	import * as format from '$lib/format'
-	import { setupCopy } from '$lib/clipboard'
+	import GitHubNav from './_components/GitHubNav.svelte'
 
 	const { data } = $props()
 
 	const project = $derived(data.project)
-	const locations = $derived(data.locations)
-	const envGroups = $derived(data.envGroups)
-	const canProvisionPullSecret = $derived(data.canProvisionPullSecret)
 	const error = $derived(data.error)
 
 	let links = $state(untrack(() => data.links))
-	// Mutable so a freshly-provisioned pull secret is selectable without a reload.
-	let pullSecrets = $state(untrack(() => data.pullSecrets))
-
-	const locationOptions = $derived(locations.map((l) => ({ value: l.id, label: l.id })))
 
 	async function reloadLinks () {
 		const resp = await api.invoke('github.list', { project }, fetch)
@@ -48,287 +37,10 @@
 		})
 	}
 
-	// Derive a sensible deployment name from a `owner/name` repository: the repo
-	// name, lowercased with anything outside [a-z0-9-] folded to a hyphen.
-	/** @param {string | undefined} repository */
-	function repoToName (repository) {
-		const short = (repository ?? '').split('/').pop() ?? ''
-		return short
-			.toLowerCase()
-			.replace(/[^a-z0-9-]+/g, '-')
-			.replace(/^-+|-+$/g, '')
+	/** @param {string} repository */
+	function workflowHref (repository) {
+		return `/github/workflow?project=${project}&repo=${encodeURIComponent(repository)}`
 	}
-
-	// workflow generator
-	const gen = $state(untrack(() => ({
-		repository: data.links[0]?.repository ?? '',
-		location: data.locations[0]?.id ?? '',
-		name: repoToName(data.links[0]?.repository) || 'web',
-		// 'dockerfile' (default) emits today's container workflow; 'static' emits
-		// a bucket-native static-web workflow (mode: static).
-		buildType: 'dockerfile',
-		port: 8080,
-		// static fields — only used when buildType === 'static'
-		framework: 'auto',
-		buildCommand: '',
-		outputDir: 'public',
-		spa: false,
-		notFound: '404.html',
-		// shared config
-		workingDirectory: '',
-		env: '',
-		/** @type {string[]} */
-		envGroups: [],
-		// container-only
-		pullSecret: ''
-	})))
-	const genRepoOptions = $derived(links.map((l) => ({ value: l.repository, label: l.repository })))
-	const genBranch = $derived(links.find((l) => l.repository === gen.repository)?.productionBranch || 'main')
-
-	// Keep the deployment name defaulting to the selected repository's name until
-	// the user edits it — switching repos then re-fills with the new repo name.
-	let nameTouched = $state(false)
-	$effect(() => {
-		const derivedName = repoToName(gen.repository)
-		if (!nameTouched && derivedName) gen.name = derivedName
-	})
-
-	const buildTypeOptions = [
-		{ value: 'dockerfile', label: 'Dockerfile' },
-		{ value: 'static', label: 'Static' }
-	]
-	const frameworkOptions = [
-		{ value: 'auto', label: 'Auto-detect' },
-		{ value: 'hugo', label: 'Hugo' },
-		{ value: 'node', label: 'Node' }
-	]
-
-	// --- env groups (multi-select) ---
-	const envGroupOptions = $derived(
-		envGroups
-			.filter((g) => !gen.envGroups.includes(g.name))
-			.map((g) => ({ value: g.name, label: g.name }))
-	)
-
-	/** @param {string} name */
-	function addEnvGroup (name) {
-		const n = name.trim()
-		if (!n || gen.envGroups.includes(n)) return
-		gen.envGroups = [...gen.envGroups, n]
-	}
-
-	/** @param {string} name */
-	function removeEnvGroup (name) {
-		gen.envGroups = gen.envGroups.filter((g) => g !== name)
-	}
-
-	// --- pull secret (container deploys only) ---
-	const locationPullSecrets = $derived(pullSecrets.filter((p) => p.location === gen.location))
-	const pullSecretOptions = $derived([
-		{ value: '', label: 'No pull secret' },
-		...locationPullSecrets.map((p) => ({ value: p.name, label: p.name }))
-	])
-
-	// Drop a selection that doesn't exist in the chosen location (e.g. after
-	// switching location). Setting it to '' once is stable — the guard then fails.
-	$effect(() => {
-		if (gen.pullSecret && !locationPullSecrets.some((p) => p.name === gen.pullSecret)) {
-			gen.pullSecret = ''
-		}
-	})
-
-	const PULL_SA_SID = 'github-pull'
-	const PULL_SA_NAME = 'GitHub Pull'
-	const PULL_ROLE = 'github-pull'
-	const PULL_SECRET_NAME = 'github-pull'
-	const REGISTRY_SERVER = 'https://registry.deploys.app'
-
-	let creatingPullSecret = $state(false)
-	let pullSecretError = $state('')
-
-	// Provision a dedicated pull-only service account (registry.pull), mint a
-	// key, and create a pull secret for it in the selected location — then select
-	// it in the generator. Idempotent: reuses an existing github-pull secret,
-	// service account, role, or key rather than duplicating them.
-	async function createPullSecret () {
-		if (creatingPullSecret) return
-		const location = gen.location
-		if (!location) {
-			pullSecretError = 'Select a location first.'
-			return
-		}
-
-		creatingPullSecret = true
-		pullSecretError = ''
-		try {
-			// Already provisioned in this location? Just select it.
-			const existing = pullSecrets.find((p) => p.name === PULL_SECRET_NAME && p.location === location)
-			if (existing) {
-				gen.pullSecret = existing.name
-				return
-			}
-
-			// 1. Dedicated pull-only service account (tolerate an existing one).
-			const saResp = await api.invoke('serviceAccount.create', { project, sid: PULL_SA_SID, name: PULL_SA_NAME }, fetch)
-			if (!saResp.ok && !/already exist/i.test(saResp.error?.message ?? '')) {
-				pullSecretError = saResp.error?.message ?? 'Failed to create the pull service account.'
-				return
-			}
-
-			// 2. Resolve the SA email + existing keys.
-			let getResp = await api.invoke('serviceAccount.get', { project, id: PULL_SA_SID }, fetch)
-			if (!getResp.ok) {
-				pullSecretError = getResp.error?.message ?? 'Failed to read the pull service account.'
-				return
-			}
-			const email = getResp.result?.email
-			if (!email) {
-				pullSecretError = 'The pull service account has no email.'
-				return
-			}
-
-			// 3. Ensure the github-pull role (registry.pull) exists, then bind it.
-			const roleResp = await api.invoke('role.get', { project, role: PULL_ROLE }, fetch)
-			if (!roleResp.ok && roleResp.error?.notFound) {
-				const roleCreate = await api.invoke('role.create', {
-					project,
-					role: PULL_ROLE,
-					name: PULL_SA_NAME,
-					permissions: ['registry.pull']
-				}, fetch)
-				if (!roleCreate.ok && !/already exist/i.test(roleCreate.error?.message ?? '')) {
-					pullSecretError = roleCreate.error?.message ?? 'Failed to create the github-pull role.'
-					return
-				}
-			}
-			const bindResp = await api.invoke('role.bind', { project, email, roles: [PULL_ROLE] }, fetch)
-			if (!bindResp.ok) {
-				pullSecretError = bindResp.error?.message ?? 'Failed to bind the github-pull role.'
-				return
-			}
-
-			// 4. Reuse a key if the SA already has one; otherwise mint one and
-			//    re-read (createKey returns no secret).
-			let keys = getResp.result?.keys ?? []
-			if (keys.length === 0) {
-				const keyResp = await api.invoke('serviceAccount.createKey', { project, id: PULL_SA_SID }, fetch)
-				if (!keyResp.ok) {
-					pullSecretError = keyResp.error?.message ?? 'Failed to create a service account key.'
-					return
-				}
-				getResp = await api.invoke('serviceAccount.get', { project, id: PULL_SA_SID }, fetch)
-				if (!getResp.ok) {
-					pullSecretError = getResp.error?.message ?? 'Failed to read the new key.'
-					return
-				}
-				keys = getResp.result?.keys ?? []
-			}
-			// Newest key by createdAt.
-			const newest = keys.reduce((a, b) => (new Date(b.createdAt) > new Date(a.createdAt) ? b : a), keys[0])
-			const secret = newest?.secret
-			if (!secret) {
-				pullSecretError = 'Could not read the service account key secret.'
-				return
-			}
-
-			// 5. Create the pull secret in the selected location.
-			const psResp = await api.invoke('pullSecret.create', {
-				project,
-				location,
-				name: PULL_SECRET_NAME,
-				spec: { server: REGISTRY_SERVER, username: email, password: secret }
-			}, fetch)
-			if (!psResp.ok && !/already exist/i.test(psResp.error?.message ?? '')) {
-				pullSecretError = psResp.error?.message ?? 'Failed to create the pull secret.'
-				return
-			}
-
-			// 6. Reflect it locally + select it.
-			if (!pullSecrets.some((p) => p.name === PULL_SECRET_NAME && p.location === location)) {
-				pullSecrets = [...pullSecrets, { name: PULL_SECRET_NAME, location }]
-			}
-			gen.pullSecret = PULL_SECRET_NAME
-		} catch (e) {
-			pullSecretError = e instanceof Error ? e.message : 'Failed to create the pull secret.'
-		} finally {
-			creatingPullSecret = false
-		}
-	}
-
-	// --- workflow YAML ---
-	const permissionsBlock = $derived(gen.buildType === 'static'
-		? `permissions:
-  id-token: write   # required — this is the credential
-  contents: read
-  pull-requests: write   # sticky PR preview comment`
-		: `permissions:
-  id-token: write   # required — this is the credential
-  contents: read`)
-
-	// Build the action's `with:` block, emitting only the keys the user set so
-	// the generated workflow stays minimal.
-	function withBlock () {
-		const out = []
-		out.push(`        project: ${project}`)
-		out.push(`        location: ${gen.location}`)
-		out.push(`        name: ${gen.name || 'web'}`)
-
-		if (gen.buildType === 'static') {
-			out.push('        mode: static')
-			out.push(`        framework: ${gen.framework || 'auto'}`)
-			if (gen.buildCommand.trim()) out.push(`        buildCommand: ${gen.buildCommand.trim()}`)
-			out.push(`        outputDir: ${gen.outputDir || 'public'}`)
-			out.push(`        spa: ${gen.spa ? 'true' : 'false'}`)
-			out.push(`        notFound: ${gen.notFound || '404.html'}`)
-		} else {
-			out.push(`        port: ${Number(gen.port) || 8080}`)
-		}
-
-		const wd = gen.workingDirectory.trim()
-		if (wd && wd !== '.') out.push(`        workingDirectory: ${wd}`)
-
-		// env / envGroups are container-only — static has no pod.
-		if (gen.buildType === 'dockerfile') {
-			const envLines = gen.env.split('\n').map((l) => l.trim()).filter(Boolean)
-			if (envLines.length) {
-				out.push('        env: |')
-				for (const l of envLines) out.push(`          ${l}`)
-			}
-
-			if (gen.envGroups.length) out.push(`        envGroups: ${gen.envGroups.join(',')}`)
-		}
-
-		// Pull secret only applies to container deploys — static has no pod.
-		if (gen.buildType === 'dockerfile' && gen.pullSecret) {
-			out.push(`        pullSecret: ${gen.pullSecret}`)
-		}
-
-		return out.join('\n')
-	}
-
-	const workflowYaml = $derived(`name: Deploy
-on:
-  push:
-    branches: [${genBranch}]
-  pull_request:
-
-${permissionsBlock}
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: deploys-app/build-deploy-action@v1
-      with:
-${withBlock()}
-`)
-
-	const createOnGitHubURL = $derived(gen.repository
-		? `https://github.com/${gen.repository}/new/main?filename=.github/workflows/deploy.yaml&value=${encodeURIComponent(workflowYaml)}`
-		: '')
-
-	onMount(() => setupCopy('.copy-workflow'))
 </script>
 
 <div class="page-head">
@@ -337,264 +49,213 @@ ${withBlock()}
 		<p class="page-sub">Build and deploy linked repositories with GitHub Actions — keyless, with pull request previews</p>
 	</div>
 	<div>
-		<GuardedButton permission="github.link" href={`/github/link?project=${project}`}>
-			<i class="fa-solid fa-link mr-2"></i>
+		<GuardedButton permission="github.link" class="button is-icon-left" href={`/github/link?project=${project}`}>
+			<i class="fa-solid fa-link"></i>
 			Link repository
 		</GuardedButton>
 	</div>
 </div>
 
-<div class="panel is-level-300 grid gap-6">
-	<div>
-		<h6><strong>Linked repositories</strong></h6>
-		<p class="text-content/50 text-sm mt-1">
-			Workflows in a linked repository can deploy to this project as the
-			linked service account — authenticated by GitHub OIDC, no stored secrets.
-		</p>
-	</div>
-
-	<div class="table-container">
-		<table class="table is-variant-compact">
-			<thead>
-			<tr>
-				<th>Repository</th>
-				<th>Service Account</th>
-				<th>Branch</th>
-				<th>Linked</th>
-				<th class="is-collapse is-align-right"></th>
-			</tr>
-			</thead>
-			<tbody>
-				{#each links as it (it.repositoryId)}
-					<tr>
-						<td>
-							<a class="link cell-name" href={`https://github.com/${it.repository}`} target="_blank" rel="noreferrer">
-								<i class="fa-brands fa-github mr-1"></i>{it.repository}
-							</a>
-						</td>
-						<td><span class="cell-muted font-mono text-sm">{it.serviceAccountEmail}</span></td>
-						<td>
-							{#if it.productionBranch}
-								<span class="cell-muted font-mono text-sm">{it.productionBranch}</span>
-							{:else}
-								<span class="cell-muted" title="Any branch can deploy">—</span>
-							{/if}
-						</td>
-						<td>
-							<span class="cell-time" title={format.datetime(it.createdAt)}>{format.fromNow(it.createdAt) || '—'}</span>
-						</td>
-						<td>
-							<GuardedButton permission="github.unlink" class="icon-button" type="button" aria-label="Unlink repository" onclick={() => unlink(it)}>
-								<i class="fa-solid fa-link-slash"></i>
-							</GuardedButton>
-						</td>
-					</tr>
-				{/each}
-				<NoDataRow span={5} list={links} />
-				<ErrorRow span={5} {error} />
-			</tbody>
-		</table>
-	</div>
-</div>
+<GitHubNav {project} />
 
 {#if links.length > 0}
-	<br>
-	<div class="panel is-level-300 grid gap-6">
-		<div>
-			<h6><strong>Workflow</strong></h6>
-			<p class="text-content/50 text-sm mt-1">
-				Add this file as <span class="font-mono">.github/workflows/deploy.yaml</span>
-				to deploy on push and get pull request previews.
-			</p>
+	<div class="repo-grid">
+		{#each links as it (it.repositoryId)}
+			<article class="repo-card">
+				<header class="repo-card-head">
+					<span class="repo-mark"><i class="fa-brands fa-github"></i></span>
+					<a class="repo-name link" href={`https://github.com/${it.repository}`} target="_blank" rel="noreferrer">
+						{it.repository}
+					</a>
+					<GuardedButton permission="github.unlink" class="icon-button repo-unlink" type="button"
+						aria-label={`Unlink ${it.repository}`} onclick={() => unlink(it)}>
+						<i class="fa-solid fa-link-slash"></i>
+					</GuardedButton>
+				</header>
+
+				<dl class="repo-meta">
+					<div>
+						<dt>Service account</dt>
+						<dd class="font-mono" title={it.serviceAccountEmail}>{it.serviceAccountEmail}</dd>
+					</div>
+					<div>
+						<dt>Production branch</dt>
+						<dd>
+							{#if it.productionBranch}
+								<span class="branch-pill font-mono"><i class="fa-solid fa-code-branch"></i>{it.productionBranch}</span>
+							{:else}
+								<span class="text-content/45" title="Any branch can deploy">Any branch</span>
+							{/if}
+						</dd>
+					</div>
+					<div>
+						<dt>Linked</dt>
+						<dd title={format.datetime(it.createdAt)}>{format.fromNow(it.createdAt) || '—'}</dd>
+					</div>
+				</dl>
+
+				<footer class="repo-card-foot">
+					<a class="button is-variant-secondary is-icon-left repo-workflow-btn" href={workflowHref(it.repository)}>
+						<i class="fa-solid fa-diagram-project"></i>
+						Set up workflow
+					</a>
+				</footer>
+			</article>
+		{/each}
+	</div>
+{:else if error}
+	<div class="panel is-level-300">
+		<div class="empty-state">
+			<i class="fa-solid fa-triangle-exclamation empty-icon"></i>
+			<span class="empty-title">Couldn't load repositories</span>
+			<span class="empty-sub">{error.forbidden ? "You don't have permission to view linked repositories." : (error.message || 'Try again later.')}</span>
 		</div>
-
-		<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-			<div class="field">
-				<label for="gen-repository">Repository</label>
-				<Select id="gen-repository" bind:value={gen.repository} options={genRepoOptions} />
-			</div>
-			<div class="field">
-				<label for="gen-location">Location</label>
-				<Select id="gen-location" bind:value={gen.location} options={locationOptions} />
-			</div>
-			<div class="field">
-				<label for="gen-name">Deployment name</label>
-				<div class="input">
-					<input id="gen-name" class="font-mono" bind:value={gen.name} oninput={() => nameTouched = true} placeholder="web">
-				</div>
-			</div>
-			<div class="field">
-				<label for="gen-build-type">Build type</label>
-				<Select id="gen-build-type" bind:value={gen.buildType} options={buildTypeOptions} />
-			</div>
-			{#if gen.buildType === 'dockerfile'}
-				<div class="field">
-					<label for="gen-port">Port</label>
-					<div class="input">
-						<input id="gen-port" type="number" min="1" bind:value={gen.port} placeholder="8080">
-					</div>
-				</div>
-			{:else}
-				<div class="field">
-					<label for="gen-framework">Framework</label>
-					<Select id="gen-framework" bind:value={gen.framework} options={frameworkOptions} />
-				</div>
-				<div class="field">
-					<label for="gen-build-command">Build command</label>
-					<div class="input">
-						<input id="gen-build-command" class="font-mono" bind:value={gen.buildCommand} placeholder="preset (e.g. hugo --minify)">
-					</div>
-				</div>
-				<div class="field">
-					<label for="gen-output-dir">Output directory</label>
-					<div class="input">
-						<input id="gen-output-dir" class="font-mono" bind:value={gen.outputDir} placeholder="public">
-					</div>
-				</div>
-				<div class="field">
-					<label for="gen-not-found">404 document</label>
-					<div class="input">
-						<input id="gen-not-found" class="font-mono" bind:value={gen.notFound} placeholder="404.html">
-					</div>
-				</div>
-				<div class="field self-end">
-					<div class="checkbox">
-						<input id="gen-spa" type="checkbox" bind:checked={gen.spa}>
-						<label for="gen-spa">SPA fallback to index.html</label>
-					</div>
-				</div>
-			{/if}
-			<div class="field">
-				<label for="gen-working-directory">Root folder</label>
-				<div class="input">
-					<input id="gen-working-directory" class="font-mono" bind:value={gen.workingDirectory} placeholder=". (monorepo: apps/web)">
-				</div>
-			</div>
-		</div>
-
-		<!-- env, env groups, and pull secret are container-only; static has no
-		     pod, so the whole block is hidden and omitted from the workflow. -->
-		{#if gen.buildType === 'dockerfile'}
-		<div class="grid gap-4 lg:grid-cols-2">
-			<div class="field">
-				<label for="gen-env">Environment variables</label>
-				<div class="textarea">
-					<textarea id="gen-env" class="font-mono" rows="4" bind:value={gen.env} placeholder="KEY=value&#10;ANOTHER=thing"></textarea>
-				</div>
-				<p class="text-content/50 text-sm mt-1">One <span class="font-mono">KEY=VALUE</span> per line.</p>
-			</div>
-
-			<div class="field">
-				<label for="gen-env-group">Env groups</label>
-				{#key gen.envGroups}
-					<Select
-						id="gen-env-group"
-						placeholder="Add an env group"
-						resetOnSelect
-						disabled={envGroupOptions.length === 0}
-						onchange={(v) => addEnvGroup(String(v))}
-						options={envGroupOptions} />
-				{/key}
-				{#if gen.envGroups.length > 0}
-					<div class="flex flex-wrap gap-2 mt-2">
-						{#each gen.envGroups as name (name)}
-							<span class="env-group-chip font-mono text-sm">
-								{name}
-								<button type="button" class="chip-remove" aria-label={`Remove ${name}`} onclick={() => removeEnvGroup(name)}>
-									<i class="fa-solid fa-xmark"></i>
-								</button>
-							</span>
-						{/each}
-					</div>
-				{/if}
-				<p class="text-content/50 text-sm mt-1">Each group must already exist in this project.</p>
-			</div>
-
-			<div class="field">
-				<label for="gen-pull-secret">Pull secret</label>
-				<div class="flex items-center gap-2">
-					<div class="flex-1">
-						<Select id="gen-pull-secret" bind:value={gen.pullSecret} options={pullSecretOptions} />
-					</div>
-					{#if canProvisionPullSecret}
-						<button
-							class="button is-variant-secondary"
-							class:is-loading={creatingPullSecret}
-							disabled={creatingPullSecret || !gen.location}
-							onclick={createPullSecret}
-							title="Create a dedicated pull-only service account and pull secret in this location"
-							type="button">
-							<i class="fa-solid fa-plus mr-2"></i>
-							New
-						</button>
-					{:else}
-						<span class="inline-flex" title={denyTooltip('pullsecret.create')}>
-							<button class="button is-variant-secondary" type="button" disabled aria-disabled="true">
-								<i class="fa-solid fa-plus mr-2"></i>
-								New
-							</button>
-						</span>
-					{/if}
-				</div>
-				{#if pullSecretError}
-					<p class="text-negative text-sm mt-1">{pullSecretError}</p>
-				{:else}
-					<p class="text-content/50 text-sm mt-1">
-						For a private image registry. <strong>New</strong> provisions a dedicated
-						pull-only service account and secret for <span class="font-mono">registry.deploys.app</span>.
-					</p>
-				{/if}
-			</div>
-		</div>
-		{/if}
-
-		<pre class="workflow-yaml font-mono text-sm">{workflowYaml}</pre>
-
-		<div class="flex items-center gap-3">
-			<button type="button" class="button is-variant-secondary copy-workflow" data-clipboard-text={workflowYaml}>
-				<i class="fa-solid fa-copy mr-2"></i>
-				<span>Copy</span>
-			</button>
-			<a class="button" href={createOnGitHubURL} target="_blank" rel="noreferrer">
-				<i class="fa-brands fa-github mr-2"></i>
-				<span>Create on GitHub</span>
-			</a>
-			<p class="text-content/50 text-sm">
-				Opens GitHub's file editor pre-filled — commit it there.
-			</p>
+	</div>
+{:else}
+	<div class="panel is-level-300">
+		<div class="empty-state">
+			<i class="fa-brands fa-github empty-icon"></i>
+			<span class="empty-title">No repositories linked yet</span>
+			<span class="empty-sub">
+				Link a GitHub repository so its Actions workflows can deploy here —
+				authenticated by GitHub OIDC, with no stored secrets.
+			</span>
+			<GuardedButton permission="github.link" class="button is-icon-left mt-3" href={`/github/link?project=${project}`}>
+				<i class="fa-solid fa-link"></i>
+				Link repository
+			</GuardedButton>
 		</div>
 	</div>
 {/if}
 
 <style>
-	.workflow-yaml {
-		padding: 1rem;
-		border-radius: var(--radius-md);
+	.repo-grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 1rem;
+	}
+
+	@media (min-width: 640px) {
+		.repo-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+	}
+
+	@media (min-width: 1280px) {
+		.repo-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+	}
+
+	.repo-card {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		padding: 1.25rem;
+		background-color: hsl(var(--hsl-base-300));
 		border: 1px solid hsl(var(--hsl-line));
-		background-color: hsl(var(--hsl-base-400) / 0.12);
-		overflow-x: auto;
+		border-radius: var(--radius-lg);
+		box-shadow: var(--raised-z1);
+		transition: border-color var(--timing-faster) ease, box-shadow var(--timing-faster) ease, transform var(--timing-faster) ease;
 	}
 
-	:root:not(.dark) .workflow-yaml {
-		background-color: hsl(var(--hsl-base-100) / 0.6);
+	.repo-card:hover {
+		border-color: hsl(var(--hsl-primary) / 0.35);
+		box-shadow: var(--raised-z3);
+		transform: translateY(-2px);
 	}
 
-	.env-group-chip {
+	.repo-card-head {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		min-width: 0;
+	}
+
+	.repo-mark {
 		display: inline-flex;
 		align-items: center;
-		gap: 0.375rem;
-		padding: 0.125rem 0.5rem;
+		justify-content: center;
+		flex-shrink: 0;
+		width: 2rem;
+		height: 2rem;
 		border-radius: var(--radius-md);
-		border: 1px solid hsl(var(--hsl-line));
-		background-color: hsl(var(--hsl-base-400) / 0.12);
+		font-size: 1rem;
+		color: hsl(var(--hsl-content) / 0.8);
+		background-color: hsl(var(--hsl-content) / 0.06);
 	}
 
-	.chip-remove {
-		display: inline-flex;
+	.repo-name {
+		flex: 1;
+		min-width: 0;
+		font-weight: 600;
+		font-size: 0.95rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	/* The unlink control is rendered by GuardedButton (a child component), so it
+	 * doesn't carry this component's scope hash — reach it via :global, anchored
+	 * under .repo-card so it can't leak. */
+	.repo-card :global(.repo-unlink) {
+		flex-shrink: 0;
 		color: hsl(var(--hsl-content) / 0.5);
 	}
 
-	.chip-remove:hover {
+	.repo-card :global(.repo-unlink):hover {
 		color: hsl(var(--hsl-negative));
+	}
+
+	.repo-meta {
+		display: grid;
+		gap: 0.625rem;
+		padding-top: 1rem;
+		border-top: 1px solid hsl(var(--hsl-line) / 0.7);
+	}
+
+	.repo-meta > div {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 0.75rem;
+		min-width: 0;
+	}
+
+	.repo-meta dt {
+		flex-shrink: 0;
+		font-size: 0.75rem;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: hsl(var(--hsl-content) / 0.45);
+	}
+
+	.repo-meta dd {
+		min-width: 0;
+		font-size: 0.82rem;
+		color: hsl(var(--hsl-content) / 0.8);
+		text-align: right;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.branch-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		padding: 0.05rem 0.45rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-primary));
+		background-color: hsl(var(--hsl-primary) / 0.1);
+	}
+
+	.branch-pill > i { font-size: 0.62rem; opacity: 0.85; }
+
+	.repo-card-foot {
+		margin-top: auto;
+	}
+
+	.repo-workflow-btn {
+		width: 100%;
 	}
 </style>

--- a/src/routes/(auth)/(project)/github/_components/GitHubNav.svelte
+++ b/src/routes/(auth)/(project)/github/_components/GitHubNav.svelte
@@ -1,0 +1,45 @@
+<script>
+	import { page } from '$app/stores'
+
+	/**
+	 * Shared sub-navigation for the GitHub feature. Repositories is the
+	 * overview/management view; Workflow is the standalone generator.
+	 *
+	 * @typedef {Object} Props
+	 * @property {string | null} project
+	 */
+
+	/** @type {Props} */
+	const { project } = $props()
+
+	const onWorkflow = $derived($page.url.pathname.startsWith('/github/workflow'))
+	const q = $derived(project ? `?project=${project}` : '')
+</script>
+
+<nav class="tabs is-variant-underline github-nav" aria-label="GitHub sections">
+	<a class="tab-button" class:is-active={!onWorkflow} href={`/github${q}`} aria-current={!onWorkflow ? 'page' : undefined}>
+		<i class="fa-solid fa-book-bookmark mr-2"></i>Repositories
+	</a>
+	<a class="tab-button" class:is-active={onWorkflow} href={`/github/workflow${q}`} aria-current={onWorkflow ? 'page' : undefined}>
+		<i class="fa-solid fa-diagram-project mr-2"></i>Workflow
+	</a>
+</nav>
+
+<style>
+	/* A full-width hairline baseline turns the per-tab underlines into a proper
+	 * tab bar. The active tab's primary 2px rule overlays this 1px line. */
+	.github-nav {
+		position: relative;
+		margin-bottom: 1.5rem;
+	}
+
+	.github-nav::after {
+		content: '';
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		height: 1px;
+		background: hsl(var(--hsl-line));
+	}
+</style>

--- a/src/routes/(auth)/(project)/github/workflow/+page.js
+++ b/src/routes/(auth)/(project)/github/workflow/+page.js
@@ -1,0 +1,49 @@
+import api from '$lib/api'
+import { hasPermission } from '$lib/permission'
+
+export async function load ({ parent, url, fetch }) {
+	const { project, permissions, permissionsAdmin } = await parent()
+
+	const [links, locations, envGroups, pullSecrets, githubPullRole] = await Promise.all([
+		api.invoke('github.list', { project }, fetch),
+		api.invoke('location.list', { project }, fetch),
+		api.invoke('envGroup.list', { project }, fetch),
+		// No location => every location's pull secrets; the generator filters by
+		// the selected location client-side.
+		api.invoke('pullSecret.list', { project }, fetch),
+		// Decides whether provisioning the dedicated pull service account still
+		// needs role.create (vs. the shared github-pull role already existing).
+		api.invoke('role.get', { project, role: 'github-pull' }, fetch)
+	])
+
+	const items = links.result?.items ?? []
+
+	// Preselect the repo named in ?repo= when it's actually linked (the
+	// repositories page links here with the card's repo); otherwise fall back to
+	// the first linked repo.
+	const repoParam = url.searchParams.get('repo')
+	const initialRepo = items.find((l) => l.repository === repoParam)?.repository ?? items[0]?.repository ?? ''
+
+	const githubPullRoleExists = githubPullRole.ok && !!githubPullRole.result
+	// The "create dedicated pull secret" flow needs to: make a pull-only service
+	// account, mint a key, bind the registry.pull role, and create the pull
+	// secret. Gate the affordance on that whole set (lowercase canonical names,
+	// matching the server's effective grants), plus role.create only when the
+	// shared github-pull role doesn't exist yet.
+	const canProvisionPullSecret =
+		hasPermission(permissions, permissionsAdmin, 'serviceaccount.create') &&
+		hasPermission(permissions, permissionsAdmin, 'serviceaccount.key.create') &&
+		hasPermission(permissions, permissionsAdmin, 'pullsecret.create') &&
+		hasPermission(permissions, permissionsAdmin, 'role.bind') &&
+		(githubPullRoleExists || hasPermission(permissions, permissionsAdmin, 'role.create'))
+
+	return {
+		links: items,
+		initialRepo,
+		locations: locations.result?.items ?? [],
+		envGroups: envGroups.result?.items ?? [],
+		pullSecrets: pullSecrets.result?.items ?? [],
+		canProvisionPullSecret,
+		error: links.error
+	}
+}

--- a/src/routes/(auth)/(project)/github/workflow/+page.svelte
+++ b/src/routes/(auth)/(project)/github/workflow/+page.svelte
@@ -1,0 +1,784 @@
+<script>
+	import { onMount, untrack } from 'svelte'
+	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import { denyTooltip } from '$lib/permission'
+	import { setupCopy } from '$lib/clipboard'
+	import GitHubNav from '../_components/GitHubNav.svelte'
+
+	const { data } = $props()
+
+	const project = $derived(data.project)
+	const locations = $derived(data.locations)
+	const envGroups = $derived(data.envGroups)
+	const canProvisionPullSecret = $derived(data.canProvisionPullSecret)
+
+	const links = $derived(data.links)
+	// Mutable so a freshly-provisioned pull secret is selectable without a reload.
+	let pullSecrets = $state(untrack(() => data.pullSecrets))
+
+	const locationOptions = $derived(locations.map((l) => ({ value: l.id, label: l.id })))
+
+	// Derive a sensible deployment name from a `owner/name` repository: the repo
+	// name, lowercased with anything outside [a-z0-9-] folded to a hyphen.
+	/** @param {string | undefined} repository */
+	function repoToName (repository) {
+		const short = (repository ?? '').split('/').pop() ?? ''
+		return short
+			.toLowerCase()
+			.replace(/[^a-z0-9-]+/g, '-')
+			.replace(/^-+|-+$/g, '')
+	}
+
+	// workflow generator — seed the repository from ?repo= (validated in the
+	// loader against the linked set) so jumping in from a repository card lands
+	// on the right repo.
+	const gen = $state(untrack(() => ({
+		repository: data.initialRepo,
+		location: data.locations[0]?.id ?? '',
+		name: repoToName(data.initialRepo) || 'web',
+		// 'dockerfile' (default) emits today's container workflow; 'static' emits
+		// a bucket-native static-web workflow (mode: static).
+		buildType: 'dockerfile',
+		port: 8080,
+		// static fields — only used when buildType === 'static'
+		framework: 'auto',
+		buildCommand: '',
+		outputDir: 'public',
+		spa: false,
+		notFound: '404.html',
+		// shared config
+		workingDirectory: '',
+		env: '',
+		/** @type {string[]} */
+		envGroups: [],
+		// container-only
+		pullSecret: ''
+	})))
+	const genRepoOptions = $derived(links.map((l) => ({ value: l.repository, label: l.repository })))
+	const genBranch = $derived(links.find((l) => l.repository === gen.repository)?.productionBranch || 'main')
+
+	// Keep the deployment name defaulting to the selected repository's name until
+	// the user edits it — switching repos then re-fills with the new repo name.
+	let nameTouched = $state(false)
+	$effect(() => {
+		const derivedName = repoToName(gen.repository)
+		if (!nameTouched && derivedName) gen.name = derivedName
+	})
+
+	const buildTypeOptions = [
+		{ value: 'dockerfile', label: 'Dockerfile', icon: 'fa-brands fa-docker', hint: 'Container image built from your Dockerfile' },
+		{ value: 'static', label: 'Static', icon: 'fa-solid fa-bolt', hint: 'Prebuilt static site served from the CDN' }
+	]
+	const frameworkOptions = [
+		{ value: 'auto', label: 'Auto-detect' },
+		{ value: 'hugo', label: 'Hugo' },
+		{ value: 'node', label: 'Node' }
+	]
+
+	// --- env groups (multi-select) ---
+	const envGroupOptions = $derived(
+		envGroups
+			.filter((g) => !gen.envGroups.includes(g.name))
+			.map((g) => ({ value: g.name, label: g.name }))
+	)
+
+	/** @param {string} name */
+	function addEnvGroup (name) {
+		const n = name.trim()
+		if (!n || gen.envGroups.includes(n)) return
+		gen.envGroups = [...gen.envGroups, n]
+	}
+
+	/** @param {string} name */
+	function removeEnvGroup (name) {
+		gen.envGroups = gen.envGroups.filter((g) => g !== name)
+	}
+
+	// --- pull secret (container deploys only) ---
+	const locationPullSecrets = $derived(pullSecrets.filter((p) => p.location === gen.location))
+	const pullSecretOptions = $derived([
+		{ value: '', label: 'No pull secret' },
+		...locationPullSecrets.map((p) => ({ value: p.name, label: p.name }))
+	])
+
+	// Drop a selection that doesn't exist in the chosen location (e.g. after
+	// switching location). Setting it to '' once is stable — the guard then fails.
+	$effect(() => {
+		if (gen.pullSecret && !locationPullSecrets.some((p) => p.name === gen.pullSecret)) {
+			gen.pullSecret = ''
+		}
+	})
+
+	const PULL_SA_SID = 'github-pull'
+	const PULL_SA_NAME = 'GitHub Pull'
+	const PULL_ROLE = 'github-pull'
+	const PULL_SECRET_NAME = 'github-pull'
+	const REGISTRY_SERVER = 'https://registry.deploys.app'
+
+	let creatingPullSecret = $state(false)
+	let pullSecretError = $state('')
+
+	// Provision a dedicated pull-only service account (registry.pull), mint a
+	// key, and create a pull secret for it in the selected location — then select
+	// it in the generator. Idempotent: reuses an existing github-pull secret,
+	// service account, role, or key rather than duplicating them.
+	async function createPullSecret () {
+		if (creatingPullSecret) return
+		const location = gen.location
+		if (!location) {
+			pullSecretError = 'Select a location first.'
+			return
+		}
+
+		creatingPullSecret = true
+		pullSecretError = ''
+		try {
+			// Already provisioned in this location? Just select it.
+			const existing = pullSecrets.find((p) => p.name === PULL_SECRET_NAME && p.location === location)
+			if (existing) {
+				gen.pullSecret = existing.name
+				return
+			}
+
+			// 1. Dedicated pull-only service account (tolerate an existing one).
+			const saResp = await api.invoke('serviceAccount.create', { project, sid: PULL_SA_SID, name: PULL_SA_NAME }, fetch)
+			if (!saResp.ok && !/already exist/i.test(saResp.error?.message ?? '')) {
+				pullSecretError = saResp.error?.message ?? 'Failed to create the pull service account.'
+				return
+			}
+
+			// 2. Resolve the SA email + existing keys.
+			let getResp = await api.invoke('serviceAccount.get', { project, id: PULL_SA_SID }, fetch)
+			if (!getResp.ok) {
+				pullSecretError = getResp.error?.message ?? 'Failed to read the pull service account.'
+				return
+			}
+			const email = getResp.result?.email
+			if (!email) {
+				pullSecretError = 'The pull service account has no email.'
+				return
+			}
+
+			// 3. Ensure the github-pull role (registry.pull) exists, then bind it.
+			const roleResp = await api.invoke('role.get', { project, role: PULL_ROLE }, fetch)
+			if (!roleResp.ok && roleResp.error?.notFound) {
+				const roleCreate = await api.invoke('role.create', {
+					project,
+					role: PULL_ROLE,
+					name: PULL_SA_NAME,
+					permissions: ['registry.pull']
+				}, fetch)
+				if (!roleCreate.ok && !/already exist/i.test(roleCreate.error?.message ?? '')) {
+					pullSecretError = roleCreate.error?.message ?? 'Failed to create the github-pull role.'
+					return
+				}
+			}
+			const bindResp = await api.invoke('role.bind', { project, email, roles: [PULL_ROLE] }, fetch)
+			if (!bindResp.ok) {
+				pullSecretError = bindResp.error?.message ?? 'Failed to bind the github-pull role.'
+				return
+			}
+
+			// 4. Reuse a key if the SA already has one; otherwise mint one and
+			//    re-read (createKey returns no secret).
+			let keys = getResp.result?.keys ?? []
+			if (keys.length === 0) {
+				const keyResp = await api.invoke('serviceAccount.createKey', { project, id: PULL_SA_SID }, fetch)
+				if (!keyResp.ok) {
+					pullSecretError = keyResp.error?.message ?? 'Failed to create a service account key.'
+					return
+				}
+				getResp = await api.invoke('serviceAccount.get', { project, id: PULL_SA_SID }, fetch)
+				if (!getResp.ok) {
+					pullSecretError = getResp.error?.message ?? 'Failed to read the new key.'
+					return
+				}
+				keys = getResp.result?.keys ?? []
+			}
+			// Newest key by createdAt.
+			const newest = keys.reduce((a, b) => (new Date(b.createdAt) > new Date(a.createdAt) ? b : a), keys[0])
+			const secret = newest?.secret
+			if (!secret) {
+				pullSecretError = 'Could not read the service account key secret.'
+				return
+			}
+
+			// 5. Create the pull secret in the selected location.
+			const psResp = await api.invoke('pullSecret.create', {
+				project,
+				location,
+				name: PULL_SECRET_NAME,
+				spec: { server: REGISTRY_SERVER, username: email, password: secret }
+			}, fetch)
+			if (!psResp.ok && !/already exist/i.test(psResp.error?.message ?? '')) {
+				pullSecretError = psResp.error?.message ?? 'Failed to create the pull secret.'
+				return
+			}
+
+			// 6. Reflect it locally + select it.
+			if (!pullSecrets.some((p) => p.name === PULL_SECRET_NAME && p.location === location)) {
+				pullSecrets = [...pullSecrets, { name: PULL_SECRET_NAME, location }]
+			}
+			gen.pullSecret = PULL_SECRET_NAME
+		} catch (e) {
+			pullSecretError = e instanceof Error ? e.message : 'Failed to create the pull secret.'
+		} finally {
+			creatingPullSecret = false
+		}
+	}
+
+	// --- workflow YAML ---
+	const permissionsBlock = $derived(gen.buildType === 'static'
+		? `permissions:
+  id-token: write   # required — this is the credential
+  contents: read
+  pull-requests: write   # sticky PR preview comment`
+		: `permissions:
+  id-token: write   # required — this is the credential
+  contents: read`)
+
+	// Build the action's `with:` block, emitting only the keys the user set so
+	// the generated workflow stays minimal.
+	function withBlock () {
+		const out = []
+		out.push(`        project: ${project}`)
+		out.push(`        location: ${gen.location}`)
+		out.push(`        name: ${gen.name || 'web'}`)
+
+		if (gen.buildType === 'static') {
+			out.push('        mode: static')
+			out.push(`        framework: ${gen.framework || 'auto'}`)
+			if (gen.buildCommand.trim()) out.push(`        buildCommand: ${gen.buildCommand.trim()}`)
+			out.push(`        outputDir: ${gen.outputDir || 'public'}`)
+			out.push(`        spa: ${gen.spa ? 'true' : 'false'}`)
+			out.push(`        notFound: ${gen.notFound || '404.html'}`)
+		} else {
+			out.push(`        port: ${Number(gen.port) || 8080}`)
+		}
+
+		const wd = gen.workingDirectory.trim()
+		if (wd && wd !== '.') out.push(`        workingDirectory: ${wd}`)
+
+		// env / envGroups are container-only — static has no pod.
+		if (gen.buildType === 'dockerfile') {
+			const envLines = gen.env.split('\n').map((l) => l.trim()).filter(Boolean)
+			if (envLines.length) {
+				out.push('        env: |')
+				for (const l of envLines) out.push(`          ${l}`)
+			}
+
+			if (gen.envGroups.length) out.push(`        envGroups: ${gen.envGroups.join(',')}`)
+		}
+
+		// Pull secret only applies to container deploys — static has no pod.
+		if (gen.buildType === 'dockerfile' && gen.pullSecret) {
+			out.push(`        pullSecret: ${gen.pullSecret}`)
+		}
+
+		return out.join('\n')
+	}
+
+	const workflowYaml = $derived(`name: Deploy
+on:
+  push:
+    branches: [${genBranch}]
+  pull_request:
+
+${permissionsBlock}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: deploys-app/build-deploy-action@v1
+      with:
+${withBlock()}
+`)
+
+	const createOnGitHubURL = $derived(gen.repository
+		? `https://github.com/${gen.repository}/new/main?filename=.github/workflows/deploy.yaml&value=${encodeURIComponent(workflowYaml)}`
+		: '')
+
+	onMount(() => setupCopy('.copy-workflow'))
+</script>
+
+<div class="page-head">
+	<div>
+		<h4><strong>GitHub</strong></h4>
+		<p class="page-sub">Build and deploy linked repositories with GitHub Actions — keyless, with pull request previews</p>
+	</div>
+	<div>
+		<GuardedButton permission="github.link" class="button is-variant-secondary is-icon-left" href={`/github/link?project=${project}`}>
+			<i class="fa-solid fa-link"></i>
+			Link repository
+		</GuardedButton>
+	</div>
+</div>
+
+<GitHubNav {project} />
+
+{#if links.length === 0}
+	<div class="panel is-level-300">
+		<div class="empty-state">
+			<i class="fa-solid fa-diagram-project empty-icon"></i>
+			<span class="empty-title">Link a repository first</span>
+			<span class="empty-sub">
+				The workflow generator builds a GitHub Actions file for a linked repository.
+				Link one to get started.
+			</span>
+			<GuardedButton permission="github.link" class="button is-icon-left mt-3" href={`/github/link?project=${project}`}>
+				<i class="fa-solid fa-link"></i>
+				Link repository
+			</GuardedButton>
+		</div>
+	</div>
+{:else}
+	<div class="wf-layout">
+		<div class="panel is-level-300 grid gap-6 wf-config">
+			<div>
+				<h6><strong>Generate workflow</strong></h6>
+				<p class="text-content/50 text-sm mt-1">
+					Configure the deploy action, then drop the file into your repository.
+					It deploys on push to the production branch and posts a preview on every pull request.
+				</p>
+			</div>
+
+			<div class="grid gap-4 w-full">
+				<div class="form-section is-first">
+					<h6 class="form-section-title">Repository &amp; target</h6>
+					<span class="form-section-hint">Which linked repository this workflow belongs to, and where it deploys.</span>
+				</div>
+
+				<div class="grid gap-4 sm:grid-cols-2">
+					<div class="field">
+						<label for="gen-repository">Repository</label>
+						<Select id="gen-repository" bind:value={gen.repository} options={genRepoOptions} />
+					</div>
+					<div class="field">
+						<label for="gen-location">Location</label>
+						<Select id="gen-location" bind:value={gen.location} options={locationOptions} />
+					</div>
+					<div class="field sm:col-span-2">
+						<label for="gen-name">Deployment name</label>
+						<div class="input">
+							<input id="gen-name" class="font-mono" bind:value={gen.name} oninput={() => nameTouched = true} placeholder="web">
+						</div>
+						<span class="helper">The deployment created in this project. Defaults to the repository name.</span>
+					</div>
+				</div>
+
+				<div class="form-section">
+					<h6 class="form-section-title">Build</h6>
+					<span class="form-section-hint">How your app is built and served.</span>
+				</div>
+
+				<div>
+					<span class="label">Build type</span>
+					<div class="seg" role="group" aria-label="Build type">
+						{#each buildTypeOptions as opt (opt.value)}
+							<button
+								type="button"
+								class="seg-btn"
+								class:is-active={gen.buildType === opt.value}
+								aria-label={opt.label}
+								aria-pressed={gen.buildType === opt.value}
+								onclick={() => (gen.buildType = opt.value)}>
+								<i class="{opt.icon} seg-icon"></i>
+								<span class="seg-text">
+									<span class="seg-title">{opt.label}</span>
+									<span class="seg-hint">{opt.hint}</span>
+								</span>
+								{#if gen.buildType === opt.value}
+									<i class="fa-solid fa-circle-check seg-check"></i>
+								{/if}
+							</button>
+						{/each}
+					</div>
+				</div>
+
+				{#if gen.buildType === 'dockerfile'}
+					<div class="grid gap-4 sm:grid-cols-2">
+						<div class="field">
+							<label for="gen-port">Port</label>
+							<div class="input">
+								<input id="gen-port" type="number" min="1" bind:value={gen.port} placeholder="8080">
+							</div>
+							<span class="helper">The port your container listens on.</span>
+						</div>
+						<div class="field">
+							<label for="gen-working-directory">Root folder</label>
+							<div class="input">
+								<input id="gen-working-directory" class="font-mono" bind:value={gen.workingDirectory} placeholder=". (monorepo: apps/web)">
+							</div>
+							<span class="helper">Build context, relative to the repo root.</span>
+						</div>
+					</div>
+				{:else}
+					<div class="grid gap-4 sm:grid-cols-2">
+						<div class="field">
+							<label for="gen-framework">Framework</label>
+							<Select id="gen-framework" bind:value={gen.framework} options={frameworkOptions} />
+						</div>
+						<div class="field">
+							<label for="gen-build-command">Build command</label>
+							<div class="input">
+								<input id="gen-build-command" class="font-mono" bind:value={gen.buildCommand} placeholder="preset (e.g. hugo --minify)">
+							</div>
+						</div>
+						<div class="field">
+							<label for="gen-output-dir">Output directory</label>
+							<div class="input">
+								<input id="gen-output-dir" class="font-mono" bind:value={gen.outputDir} placeholder="public">
+							</div>
+						</div>
+						<div class="field">
+							<label for="gen-not-found">404 document</label>
+							<div class="input">
+								<input id="gen-not-found" class="font-mono" bind:value={gen.notFound} placeholder="404.html">
+							</div>
+						</div>
+						<div class="field">
+							<label for="gen-working-directory">Root folder</label>
+							<div class="input">
+								<input id="gen-working-directory" class="font-mono" bind:value={gen.workingDirectory} placeholder=". (monorepo: apps/web)">
+							</div>
+						</div>
+						<div class="field self-end">
+							<div class="checkbox">
+								<input id="gen-spa" type="checkbox" bind:checked={gen.spa}>
+								<label for="gen-spa">SPA fallback to index.html</label>
+							</div>
+						</div>
+					</div>
+				{/if}
+
+				<!-- env, env groups, and pull secret are container-only; static has no
+				     pod, so the whole block is hidden and omitted from the workflow. -->
+				{#if gen.buildType === 'dockerfile'}
+					<div class="form-section">
+						<h6 class="form-section-title">Environment</h6>
+						<span class="form-section-hint">Optional configuration passed to the running container.</span>
+					</div>
+
+					<div class="field">
+						<label for="gen-env">Environment variables</label>
+						<div class="textarea">
+							<textarea id="gen-env" class="font-mono" rows="4" bind:value={gen.env} placeholder="KEY=value&#10;ANOTHER=thing"></textarea>
+						</div>
+						<span class="helper">One <span class="font-mono">KEY=VALUE</span> per line.</span>
+					</div>
+
+					<div class="field">
+						<label for="gen-env-group">Env groups</label>
+						{#key gen.envGroups}
+							<Select
+								id="gen-env-group"
+								placeholder="Add an env group"
+								resetOnSelect
+								disabled={envGroupOptions.length === 0}
+								onchange={(v) => addEnvGroup(String(v))}
+								options={envGroupOptions} />
+						{/key}
+						{#if gen.envGroups.length > 0}
+							<div class="flex flex-wrap gap-2 mt-2">
+								{#each gen.envGroups as name (name)}
+									<span class="env-group-chip font-mono text-sm">
+										{name}
+										<button type="button" class="chip-remove" aria-label={`Remove ${name}`} onclick={() => removeEnvGroup(name)}>
+											<i class="fa-solid fa-xmark"></i>
+										</button>
+									</span>
+								{/each}
+							</div>
+						{/if}
+						<span class="helper">Each group must already exist in this project.</span>
+					</div>
+
+					<div class="field">
+						<label for="gen-pull-secret">Pull secret</label>
+						<div class="flex items-center gap-2">
+							<div class="flex-1">
+								<Select id="gen-pull-secret" bind:value={gen.pullSecret} options={pullSecretOptions} />
+							</div>
+							{#if canProvisionPullSecret}
+								<button
+									class="button is-variant-secondary"
+									class:is-loading={creatingPullSecret}
+									disabled={creatingPullSecret || !gen.location}
+									onclick={createPullSecret}
+									title="Create a dedicated pull-only service account and pull secret in this location"
+									type="button">
+									<i class="fa-solid fa-plus mr-2"></i>
+									New
+								</button>
+							{:else}
+								<span class="inline-flex" title={denyTooltip('pullsecret.create')}>
+									<button class="button is-variant-secondary" type="button" disabled aria-disabled="true">
+										<i class="fa-solid fa-plus mr-2"></i>
+										New
+									</button>
+								</span>
+							{/if}
+						</div>
+						{#if pullSecretError}
+							<p class="text-negative text-sm mt-1">{pullSecretError}</p>
+						{:else}
+							<span class="helper">
+								For a private image registry. <strong>New</strong> provisions a dedicated
+								pull-only service account and secret for <span class="font-mono">registry.deploys.app</span>.
+							</span>
+						{/if}
+					</div>
+				{/if}
+			</div>
+		</div>
+
+		<aside class="wf-preview">
+			<div class="yaml-card">
+				<div class="yaml-card-head">
+					<span class="yaml-file font-mono">
+						<i class="fa-regular fa-file-code"></i>
+						.github/workflows/deploy.yaml
+					</span>
+					<button type="button" class="yaml-copy copy-workflow" data-clipboard-text={workflowYaml}>
+						<i class="fa-regular fa-copy"></i>
+						<span class="yaml-copy-label">Copy</span>
+						<span class="yaml-copy-done"><i class="fa-solid fa-check mr-1"></i>Copied</span>
+					</button>
+				</div>
+				<pre class="workflow-yaml font-mono">{workflowYaml}</pre>
+			</div>
+
+			<div class="wf-actions">
+				<a class="button is-icon-left wf-create" href={createOnGitHubURL} target="_blank" rel="noreferrer">
+					<i class="fa-brands fa-github"></i>
+					Create on GitHub
+				</a>
+				<span class="helper">Opens GitHub's file editor pre-filled with this workflow — review and commit it there.</span>
+			</div>
+		</aside>
+	</div>
+{/if}
+
+<style>
+	.wf-layout {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 1.5rem;
+		align-items: start;
+	}
+
+	@media (min-width: 1280px) {
+		.wf-layout {
+			grid-template-columns: minmax(0, 1fr) 30rem;
+		}
+
+		.wf-preview {
+			position: sticky;
+			/* Clear the fixed navbar (4rem) plus a little breathing room. */
+			top: 5rem;
+		}
+	}
+
+	.wf-config .helper {
+		color: hsl(var(--hsl-content) / 0.55);
+		font-size: 0.8125rem;
+	}
+
+	/* Segmented build-type control — two side-by-side option cards. */
+	.seg {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 0.625rem;
+	}
+
+	@media (min-width: 480px) {
+		.seg { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+	}
+
+	.seg-btn {
+		position: relative;
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.75rem 0.875rem;
+		text-align: left;
+		cursor: pointer;
+		background-color: hsl(var(--hsl-base-400) / 0.18);
+		border: 1px solid hsl(var(--hsl-base-400) / 0.3);
+		border-radius: var(--radius-md);
+		color: inherit;
+		transition: border-color var(--timing-faster) ease, background-color var(--timing-faster) ease;
+	}
+
+	:root:not(.dark) .seg-btn {
+		border-color: hsl(var(--hsl-line));
+		background-color: hsl(var(--hsl-base-100));
+	}
+
+	.seg-btn:hover {
+		border-color: hsl(var(--hsl-primary) / 0.45);
+	}
+
+	.seg-btn.is-active {
+		border-color: hsl(var(--hsl-primary));
+		background-color: hsl(var(--hsl-primary) / 0.08);
+	}
+
+	.seg-icon {
+		flex-shrink: 0;
+		width: 1.75rem;
+		font-size: 1.25rem;
+		text-align: center;
+		color: hsl(var(--hsl-content) / 0.6);
+	}
+
+	.seg-btn.is-active .seg-icon {
+		color: hsl(var(--hsl-primary));
+	}
+
+	.seg-text {
+		display: flex;
+		flex-direction: column;
+		gap: 0.1rem;
+		min-width: 0;
+	}
+
+	.seg-title {
+		font-weight: 600;
+		font-size: 0.9rem;
+	}
+
+	.seg-hint {
+		font-size: 0.75rem;
+		line-height: 1.35;
+		color: hsl(var(--hsl-content) / 0.55);
+	}
+
+	.seg-check {
+		position: absolute;
+		top: 0.5rem;
+		right: 0.5rem;
+		font-size: 0.8rem;
+		color: hsl(var(--hsl-primary));
+	}
+
+	/* The YAML "file" — a header bar with the filename + copy, then the body. */
+	.yaml-card {
+		border: 1px solid hsl(var(--hsl-line));
+		border-radius: var(--radius-lg);
+		overflow: hidden;
+		background-color: hsl(var(--hsl-base-400) / 0.12);
+		box-shadow: var(--raised-z1);
+	}
+
+	:root:not(.dark) .yaml-card {
+		background-color: hsl(var(--hsl-base-100));
+	}
+
+	.yaml-card-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		padding: 0.5rem 0.5rem 0.5rem 0.875rem;
+		border-bottom: 1px solid hsl(var(--hsl-line));
+		background-color: hsl(var(--hsl-content) / 0.03);
+	}
+
+	.yaml-file {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		min-width: 0;
+		font-size: 0.78rem;
+		color: hsl(var(--hsl-content) / 0.7);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.yaml-file > i { color: hsl(var(--hsl-primary)); }
+
+	.yaml-copy {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		flex-shrink: 0;
+		padding: 0.35rem 0.7rem;
+		border-radius: var(--radius-sm);
+		font-size: 0.78rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.75);
+		background-color: transparent;
+		border: 1px solid hsl(var(--hsl-content) / 0.15);
+		cursor: pointer;
+		transition: background-color var(--timing-faster) ease, color var(--timing-faster) ease, border-color var(--timing-faster) ease;
+	}
+
+	.yaml-copy:hover {
+		background-color: hsl(var(--hsl-content) / 0.06);
+		color: hsl(var(--hsl-content));
+	}
+
+	/* Swap the label for a confirmation when clipboard.js stamps data-copied at
+	 * runtime. The attribute isn't in the template, so :global keeps Svelte from
+	 * pruning these as "unused". */
+	.yaml-copy-done { display: none; }
+	.yaml-copy:global([data-copied]) { color: hsl(var(--hsl-positive)); border-color: hsl(var(--hsl-positive) / 0.4); }
+	.yaml-copy:global([data-copied]) .yaml-copy-label { display: none; }
+	.yaml-copy:global([data-copied]) .yaml-copy-done { display: inline-flex; align-items: center; }
+
+	/* Reset the global <pre> chrome — the card supplies the frame. */
+	.workflow-yaml {
+		margin: 0;
+		padding: 1rem;
+		border: 0;
+		border-radius: 0;
+		background-color: transparent;
+		font-size: 0.78rem;
+		line-height: 1.55;
+		max-height: 28rem;
+		overflow: auto;
+	}
+
+	@media (min-width: 1280px) {
+		.workflow-yaml { max-height: calc(100vh - 14rem); }
+	}
+
+	.wf-actions {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		margin-top: 1rem;
+	}
+
+	.wf-actions .helper {
+		color: hsl(var(--hsl-content) / 0.55);
+		font-size: 0.8125rem;
+	}
+
+	.wf-create { width: 100%; }
+
+	.env-group-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		padding: 0.125rem 0.5rem;
+		border-radius: var(--radius-md);
+		border: 1px solid hsl(var(--hsl-line));
+		background-color: hsl(var(--hsl-base-400) / 0.12);
+	}
+
+	.chip-remove {
+		display: inline-flex;
+		color: hsl(var(--hsl-content) / 0.5);
+	}
+
+	.chip-remove:hover {
+		color: hsl(var(--hsl-negative));
+	}
+</style>

--- a/tests/github.spec.js
+++ b/tests/github.spec.js
@@ -57,16 +57,98 @@ function mocks (overrides = {}) {
 	})
 }
 
-test.describe('github', () => {
-	test('lists linked repositories and renders the workflow generator', async ({ page }) => {
+test.describe('github repositories page', () => {
+	test('lists linked repositories as cards with a workflow link', async ({ page }) => {
 		await mocks()
 
 		await page.goto('/github?project=test-project')
 
 		const main = page.locator('.content-wrapper')
 		await expect(main.getByRole('heading', { name: 'GitHub' })).toBeVisible()
-		await expect(main.getByRole('link', { name: /acme\/web/ })).toBeVisible()
-		await expect(main.getByText(link.serviceAccountEmail)).toBeVisible()
+
+		const card = main.locator('.repo-card', { hasText: 'acme/web' })
+		await expect(card.getByRole('link', { name: /acme\/web/ })).toBeVisible()
+		await expect(card.getByText(link.serviceAccountEmail)).toBeVisible()
+
+		// Each card links to the standalone workflow page, preselecting its repo.
+		const wfHref = await card.getByRole('link', { name: /Set up workflow/ }).getAttribute('href')
+		expect(wfHref).toBe('/github/workflow?project=test-project&repo=acme%2Fweb')
+
+		// The workflow generator does NOT live on this page anymore.
+		await expect(main.locator('.workflow-yaml')).toHaveCount(0)
+	})
+
+	test('Workflow tab navigates to the standalone generator', async ({ page }) => {
+		await mocks()
+
+		await page.goto('/github?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		// Scope to the sub-nav so we don't also match the per-card "Set up workflow" links.
+		const wfTab = main.locator('.github-nav').getByRole('link', { name: 'Workflow' })
+		await expect(wfTab).toHaveAttribute('href', '/github/workflow?project=test-project')
+		await wfTab.click()
+
+		await expect(page).toHaveURL(/\/github\/workflow\?project=test-project/)
+		await expect(main.locator('.workflow-yaml')).toBeVisible()
+	})
+
+	test('empty state shows a link CTA and no cards', async ({ page }) => {
+		await mocks({ 'github.list': { ok: true, result: { items: [] } } })
+
+		await page.goto('/github?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('No repositories linked yet')).toBeVisible()
+		await expect(main.locator('.repo-card')).toHaveCount(0)
+	})
+
+	test('shows a "Link repository" button pointing at /github/link', async ({ page }) => {
+		await mocks()
+
+		await page.goto('/github?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		const linkBtn = main.getByRole('link', { name: /Link repository/ })
+		await expect(linkBtn.first()).toBeVisible()
+		const href = await linkBtn.first().getAttribute('href')
+		expect(href).toBe('/github/link?project=test-project')
+	})
+
+	test('renders the production branch per card, "Any branch" when unset', async ({ page }) => {
+		await mocks({ 'github.list': { ok: true, result: { items: [link, linkAnyBranch] } } })
+
+		await page.goto('/github?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		await expect(main.locator('.repo-card', { hasText: 'acme/web' })).toContainText('release')
+		await expect(main.locator('.repo-card', { hasText: 'acme/mobile' })).toContainText('Any branch')
+	})
+
+	test('unlinks after confirmation', async ({ page }) => {
+		await mocks({ 'github.unlink': { ok: true, result: {} } })
+
+		await page.goto('/github?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		await main.getByRole('button', { name: /Unlink/ }).click()
+		await page.getByRole('button', { name: 'Unlink', exact: true }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/github.unlink')
+		}).toBe(true)
+
+		const req = JSON.parse((await getRequestLog()).find((r) => r.path === '/github.unlink')?.body ?? '{}')
+		expect(req.repositoryId).toBe(link.repositoryId)
+	})
+})
+
+test.describe('github workflow page', () => {
+	test('renders the generator carrying project/location and reacts to edits', async ({ page }) => {
+		await mocks()
+
+		await page.goto('/github/workflow?project=test-project')
+		const main = page.locator('.content-wrapper')
 
 		// The generated workflow carries the project and the action pin.
 		const yaml = main.locator('.workflow-yaml')
@@ -84,42 +166,21 @@ test.describe('github', () => {
 		expect(decodeURIComponent(href ?? '')).toContain('name: api')
 	})
 
-	test('empty state hides the workflow generator', async ({ page }) => {
-		await mocks({ 'github.list': { ok: true, result: { items: [] } } })
-
-		await page.goto('/github?project=test-project')
-		const main = page.locator('.content-wrapper')
-		await expect(main.getByText('Nothing here yet')).toBeVisible()
-		await expect(main.locator('.workflow-yaml')).toHaveCount(0)
-	})
-
-	test('shows a "Link repository" button pointing at /github/link', async ({ page }) => {
-		await mocks()
-
-		await page.goto('/github?project=test-project')
-		const main = page.locator('.content-wrapper')
-
-		const linkBtn = main.getByRole('link', { name: /Link repository/ })
-		await expect(linkBtn).toBeVisible()
-		const href = await linkBtn.getAttribute('href')
-		expect(href).toBe('/github/link?project=test-project')
-	})
-
-	test('renders the production branch per row, with "—" when unset', async ({ page }) => {
+	test('preselects the repository named in ?repo=', async ({ page }) => {
 		await mocks({ 'github.list': { ok: true, result: { items: [link, linkAnyBranch] } } })
 
-		await page.goto('/github?project=test-project')
+		await page.goto('/github/workflow?project=test-project&repo=acme/mobile')
 		const main = page.locator('.content-wrapper')
 
-		await expect(main.getByRole('columnheader', { name: 'Branch' })).toBeVisible()
-		await expect(main.locator('tr', { hasText: 'acme/web' })).toContainText('release')
-		await expect(main.locator('tr', { hasText: 'acme/mobile' })).toContainText('—')
+		// acme/mobile is selected, and it has no production branch → falls back to main.
+		await expect(main.locator('#gen-repository')).toContainText('acme/mobile')
+		await expect(main.locator('.workflow-yaml')).toContainText('branches: [main]')
 	})
 
-	test('workflow generator uses the link production branch, falling back to main', async ({ page }) => {
+	test('uses the link production branch, falling back to main', async ({ page }) => {
 		await mocks({ 'github.list': { ok: true, result: { items: [link, linkAnyBranch] } } })
 
-		await page.goto('/github?project=test-project')
+		await page.goto('/github/workflow?project=test-project')
 		const main = page.locator('.content-wrapper')
 
 		// Default selection is acme/web, which restricts production to "release".
@@ -135,7 +196,7 @@ test.describe('github', () => {
 	test('Static build type emits a mode: static workflow with framework/outputDir and no dockerfile/port', async ({ page }) => {
 		await mocks()
 
-		await page.goto('/github?project=test-project')
+		await page.goto('/github/workflow?project=test-project')
 		const main = page.locator('.content-wrapper')
 		const yaml = main.locator('.workflow-yaml')
 
@@ -143,9 +204,8 @@ test.describe('github', () => {
 		await expect(yaml).toContainText('port:')
 		await expect(yaml).not.toContainText('mode: static')
 
-		// Switch the build type to Static.
-		await main.locator('#gen-build-type').click()
-		await page.getByRole('option', { name: 'Static' }).click()
+		// Switch the build type to Static via the segmented control.
+		await main.getByRole('button', { name: 'Static' }).click()
 
 		// The static workflow carries mode: static + framework/outputDir/spa/notFound,
 		// and the production branch filter is preserved.
@@ -181,22 +241,14 @@ test.describe('github', () => {
 		expect(decodeURIComponent(href ?? '')).toContain('framework: hugo')
 	})
 
-	test('unlinks after confirmation', async ({ page }) => {
-		await mocks({ 'github.unlink': { ok: true, result: {} } })
+	test('with no linked repositories prompts to link one first', async ({ page }) => {
+		await mocks({ 'github.list': { ok: true, result: { items: [] } } })
 
-		await page.goto('/github?project=test-project')
+		await page.goto('/github/workflow?project=test-project')
 		const main = page.locator('.content-wrapper')
 
-		await main.getByRole('button', { name: 'Unlink repository' }).click()
-		await page.getByRole('button', { name: 'Unlink', exact: true }).click()
-
-		await expect.poll(async () => {
-			const log = await getRequestLog()
-			return log.some((r) => r.path === '/github.unlink')
-		}).toBe(true)
-
-		const req = JSON.parse((await getRequestLog()).find((r) => r.path === '/github.unlink')?.body ?? '{}')
-		expect(req.repositoryId).toBe(link.repositoryId)
+		await expect(main.getByText('Link a repository first')).toBeVisible()
+		await expect(main.locator('.workflow-yaml')).toHaveCount(0)
 	})
 })
 


### PR DESCRIPTION
## What & why

The GitHub page mixed two jobs on one screen — the linked-repository list and a long, flat workflow-generator form. This splits them into two focused views joined by a sub-nav, and makes the generator much easier to drive.

### Repositories (`/github`)
- A **card gallery** of linked repositories instead of a dense table. Each card shows the service account, production branch (as a pill, or *Any branch*), and link time.
- Every card has a **"Set up workflow"** action that jumps straight to the generator with that repo preselected — the main "easier to use" win.
- Friendly empty and error states (replacing the table's no-data/error rows).

### Workflow (`/github/workflow`) — new, standalone page
- **Guided, sectioned form**: *Repository & target → Build → Environment*.
- Build type is now a **segmented Dockerfile / Static control** (was a dropdown) with icons and one-line descriptions; the container-only Environment section is hidden for Static.
- **Sticky live YAML "file" preview** styled like an editor (`.github/workflows/deploy.yaml`), with Copy and Create-on-GitHub.
- Reads `?repo=` to preselect (validated against the linked set; falls back to the first repo).

### Plumbing
- `/github` loader now fetches only the linked repos. The generator's data (locations, env groups, pull secrets, the pull-secret provisioning gate) moves to the workflow loader.
- **All YAML emission and pull-secret provisioning logic is carried over unchanged** — only its location and presentation changed.
- Shared `GitHubNav` sub-nav component (Repositories | Workflow).

## Testing
- `bun lint` clean · `bun check` clean (0 errors / 0 warnings)
- `bun run test` — **209 passed** (full suite, production build). `tests/github.spec.js` rewritten for the two-page layout: repository cards, sub-nav navigation, `?repo=` preselect, segmented build-type, branch fallback, empty states, unlink.

## Screenshots
Provided separately (repositories gallery, workflow generator in Dockerfile + Static modes, light mode, empty state) — drop them here inline if desired.