### PR TITLE
Add the GitHub deploy-trigger control

### DIFF
--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -696,6 +696,8 @@ const githubLinks = [
 		serviceAccount: 'sa_mock_ci',
 		serviceAccountEmail: 'ci@acme.serviceaccount.deploys.app',
 		productionBranch: 'main',
+		// 'all' (default): push to main + PR previews
+		trigger: 'all',
 		createdAt: CREATED_AT,
 		createdBy: USER_EMAIL
 	},
@@ -705,8 +707,21 @@ const githubLinks = [
 		installationId: 77,
 		serviceAccount: 'sa_mock_ci',
 		serviceAccountEmail: 'ci@acme.serviceaccount.deploys.app',
-		// no productionBranch — any branch can deploy; exercises the "—" / fallback path
+		productionBranch: 'main',
+		// 'branch': push to main only, no PR previews
+		trigger: 'branch',
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL
+	},
+	{
+		repositoryId: 812345683,
+		repository: 'fabrikam/docs',
+		installationId: 77,
+		serviceAccount: 'sa_mock_ci',
+		serviceAccountEmail: 'ci@acme.serviceaccount.deploys.app',
 		productionBranch: '',
+		// 'pr': previews only — exercises the "PR previews only" card + push-less workflow
+		trigger: 'pr',
 		createdAt: CREATED_AT,
 		createdBy: USER_EMAIL
 	}
@@ -1275,6 +1290,7 @@ const handlers = {
 			serviceAccount: args?.serviceAccount,
 			serviceAccountEmail: sa?.email ?? `${args?.serviceAccount}@acme.serviceaccount.deploys.app`,
 			productionBranch: args?.productionBranch ?? '',
+			trigger: args?.trigger ?? 'all',
 			createdAt: CREATED_AT,
 			createdBy: USER_EMAIL
 		})

--- a/src/routes/(auth)/(project)/github/+page.svelte
+++ b/src/routes/(auth)/(project)/github/+page.svelte
@@ -41,6 +41,13 @@
 	function workflowHref (repository) {
 		return `/github/workflow?project=${project}&repo=${encodeURIComponent(repository)}`
 	}
+
+	/** @param {Api.GithubLink['trigger']} trigger */
+	function triggerLabel (trigger) {
+		if (trigger === 'pr') return 'PR previews only'
+		if (trigger === 'branch') return 'Branch only'
+		return 'Branch + PR previews'
+	}
 </script>
 
 <div class="page-head">
@@ -79,9 +86,17 @@
 						<dd class="font-mono" title={it.serviceAccountEmail}>{it.serviceAccountEmail}</dd>
 					</div>
 					<div>
+						<dt>Deploy trigger</dt>
+						<dd>
+							<span class="branch-pill font-mono"><i class="fa-solid fa-bolt"></i>{triggerLabel(it.trigger)}</span>
+						</dd>
+					</div>
+					<div>
 						<dt>Production branch</dt>
 						<dd>
-							{#if it.productionBranch}
+							{#if it.trigger === 'pr'}
+								<span class="text-content/45" title="Previews-only links never deploy a branch">—</span>
+							{:else if it.productionBranch}
 								<span class="branch-pill font-mono"><i class="fa-solid fa-code-branch"></i>{it.productionBranch}</span>
 							{:else}
 								<span class="text-content/45" title="Any branch can deploy">Any branch</span>

--- a/src/routes/(auth)/(project)/github/link/+page.svelte
+++ b/src/routes/(auth)/(project)/github/link/+page.svelte
@@ -101,7 +101,16 @@
 	let selectedRepoName = $state('')
 	let selectedServiceAccount = $state('')
 	let productionBranch = $state('main')
+	// Which workflow runs deploy. 'pr' has no production branch, so the branch
+	// input is cleared + disabled for it.
+	let trigger = $state('all')
 	let linking = $state(false)
+
+	const triggerOptions = [
+		{ value: 'all', label: 'Branch + PR previews' },
+		{ value: 'branch', label: 'Branch only (no previews)' },
+		{ value: 'pr', label: 'PR previews only (no branch deploys)' }
+	]
 
 	const selectedRepo = $derived(
 		selectedRepoName !== '' ? repos.find((r) => r.repository === selectedRepoName) : undefined
@@ -123,7 +132,8 @@
 				repository: selectedRepo.repository,
 				installationId: selectedRepo.installationId,
 				serviceAccount: selectedServiceAccount,
-				productionBranch: productionBranch.trim()
+				productionBranch: trigger === 'pr' ? '' : productionBranch.trim(),
+				trigger
 			}, fetch)
 			if (!resp.ok) {
 				modal.error({ error: resp.error })
@@ -253,14 +263,33 @@
 				</button>
 			</div>
 		</div>
-		<div class="field sm:col-span-2">
+		<div class="field">
+			<label for="link-trigger">Deploy trigger</label>
+			<Select
+				id="link-trigger"
+				bind:value={trigger}
+				options={triggerOptions} />
+			<p class="text-content/50 text-sm mt-1">
+				{#if trigger === 'pr'}
+					Only pull requests deploy (each a preview). Pushes to any branch are rejected — no production deploys.
+				{:else if trigger === 'branch'}
+					Pushes to the production branch deploy; pull requests get no preview.
+				{:else}
+					Pushes to the production branch deploy, and every pull request gets a preview.
+				{/if}
+			</p>
+		</div>
+		<div class="field">
 			<label for="link-production-branch">Production branch</label>
 			<div class="input">
-				<input id="link-production-branch" class="font-mono" bind:value={productionBranch} placeholder="main">
+				<input id="link-production-branch" class="font-mono" bind:value={productionBranch} placeholder="main" disabled={trigger === 'pr'}>
 			</div>
 			<p class="text-content/50 text-sm mt-1">
-				Production deploys are only accepted from this branch; pull-request previews are always allowed.
-				Leave empty to allow any branch.
+				{#if trigger === 'pr'}
+					Not used — previews-only links never deploy a branch.
+				{:else}
+					Deploys are only accepted from this branch. Leave empty to allow any branch.
+				{/if}
 			</p>
 		</div>
 	</div>

--- a/src/routes/(auth)/(project)/github/workflow/+page.svelte
+++ b/src/routes/(auth)/(project)/github/workflow/+page.svelte
@@ -57,7 +57,10 @@
 		pullSecret: ''
 	})))
 	const genRepoOptions = $derived(links.map((l) => ({ value: l.repository, label: l.repository })))
-	const genBranch = $derived(links.find((l) => l.repository === gen.repository)?.productionBranch || 'main')
+	const genLink = $derived(links.find((l) => l.repository === gen.repository))
+	const genBranch = $derived(genLink?.productionBranch || 'main')
+	// Which workflow runs deploy — drives the generated `on:` triggers.
+	const genTrigger = $derived(genLink?.trigger ?? 'all')
 
 	// Keep the deployment name defaulting to the selected repository's name until
 	// the user edits it — switching repos then re-fills with the new repo name.
@@ -280,11 +283,18 @@
 		return out.join('\n')
 	}
 
+	// The on: block matches the link's trigger: all = push + pull_request,
+	// branch = push only, pr = pull_request only.
+	const onBlock = $derived(
+		'on:\n' +
+		[
+			genTrigger !== 'pr' ? `  push:\n    branches: [${genBranch}]` : null,
+			genTrigger !== 'branch' ? '  pull_request:' : null
+		].filter(Boolean).join('\n')
+	)
+
 	const workflowYaml = $derived(`name: Deploy
-on:
-  push:
-    branches: [${genBranch}]
-  pull_request:
+${onBlock}
 
 ${permissionsBlock}
 
@@ -342,7 +352,13 @@ ${withBlock()}
 				<h6><strong>Generate workflow</strong></h6>
 				<p class="text-content/50 text-sm mt-1">
 					Configure the deploy action, then drop the file into your repository.
-					It deploys on push to the production branch and posts a preview on every pull request.
+					{#if genTrigger === 'pr'}
+						This repository is pull-request only — it posts a preview on every pull request and never deploys a branch.
+					{:else if genTrigger === 'branch'}
+						It deploys on push to the production branch. Pull requests get no preview.
+					{:else}
+						It deploys on push to the production branch and posts a preview on every pull request.
+					{/if}
 				</p>
 			</div>
 

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -364,9 +364,12 @@ declare namespace Api {
         // service account sid
         serviceAccount: string
         serviceAccountEmail: string
-        // production deploys (push events) are only accepted from this branch;
-        // empty = any branch. pull-request previews are always allowed.
+        // which branch deploys to production (for the 'all'/'branch' triggers);
+        // empty = any branch.
         productionBranch?: string
+        // which workflow runs deploy: 'all' (push + PR previews, default),
+        // 'branch' (push only, no previews), 'pr' (previews only, no branch).
+        trigger?: 'all' | 'branch' | 'pr'
         createdAt: string
         createdBy: string
     }

--- a/tests/github.spec.js
+++ b/tests/github.spec.js
@@ -1,5 +1,6 @@
 import { test, expect, setMocks, getRequestLog } from './helpers.js'
 
+// 'all' trigger (push to release + PR previews)
 const link = {
 	repositoryId: 812345678,
 	repository: 'acme/web',
@@ -7,11 +8,12 @@ const link = {
 	serviceAccount: 'ci',
 	serviceAccountEmail: 'ci@test-project.serviceaccount.deploys.app',
 	productionBranch: 'release',
+	trigger: 'all',
 	createdAt: '2026-01-01T00:00:00Z',
 	createdBy: 'dev@deploys.app'
 }
 
-// linked repo without a production branch — any branch may deploy
+// 'all' trigger without a production branch — any branch may deploy
 const linkAnyBranch = {
 	repositoryId: 812345681,
 	repository: 'acme/mobile',
@@ -19,6 +21,33 @@ const linkAnyBranch = {
 	serviceAccount: 'ci',
 	serviceAccountEmail: 'ci@test-project.serviceaccount.deploys.app',
 	productionBranch: '',
+	trigger: 'all',
+	createdAt: '2026-01-01T00:00:00Z',
+	createdBy: 'dev@deploys.app'
+}
+
+// 'pr' trigger — no branch ever deploys, only PR previews
+const linkPR = {
+	repositoryId: 812345682,
+	repository: 'acme/docs',
+	installationId: 77,
+	serviceAccount: 'ci',
+	serviceAccountEmail: 'ci@test-project.serviceaccount.deploys.app',
+	productionBranch: '',
+	trigger: 'pr',
+	createdAt: '2026-01-01T00:00:00Z',
+	createdBy: 'dev@deploys.app'
+}
+
+// 'branch' trigger — push to main only, no PR previews
+const linkBranchOnly = {
+	repositoryId: 812345684,
+	repository: 'acme/svc',
+	installationId: 77,
+	serviceAccount: 'ci',
+	serviceAccountEmail: 'ci@test-project.serviceaccount.deploys.app',
+	productionBranch: 'main',
+	trigger: 'branch',
 	createdAt: '2026-01-01T00:00:00Z',
 	createdBy: 'dev@deploys.app'
 }
@@ -114,14 +143,31 @@ test.describe('github repositories page', () => {
 		expect(href).toBe('/github/link?project=test-project')
 	})
 
-	test('renders the production branch per card, "Any branch" when unset', async ({ page }) => {
-		await mocks({ 'github.list': { ok: true, result: { items: [link, linkAnyBranch] } } })
+	test('renders each card\'s trigger and production branch', async ({ page }) => {
+		await mocks({ 'github.list': { ok: true, result: { items: [link, linkAnyBranch, linkPR, linkBranchOnly] } } })
 
 		await page.goto('/github?project=test-project')
 		const main = page.locator('.content-wrapper')
 
-		await expect(main.locator('.repo-card', { hasText: 'acme/web' })).toContainText('release')
-		await expect(main.locator('.repo-card', { hasText: 'acme/mobile' })).toContainText('Any branch')
+		// all + pinned branch
+		const webCard = main.locator('.repo-card', { hasText: 'acme/web' })
+		await expect(webCard).toContainText('Branch + PR previews')
+		await expect(webCard).toContainText('release')
+
+		// all + any branch
+		const mobileCard = main.locator('.repo-card', { hasText: 'acme/mobile' })
+		await expect(mobileCard).toContainText('Branch + PR previews')
+		await expect(mobileCard).toContainText('Any branch')
+
+		// pr → no production branch
+		const docsCard = main.locator('.repo-card', { hasText: 'acme/docs' })
+		await expect(docsCard).toContainText('PR previews only')
+		await expect(docsCard).not.toContainText('Any branch')
+
+		// branch only
+		const svcCard = main.locator('.repo-card', { hasText: 'acme/svc' })
+		await expect(svcCard).toContainText('Branch only')
+		await expect(svcCard).toContainText('main')
 	})
 
 	test('unlinks after confirmation', async ({ page }) => {
@@ -191,6 +237,41 @@ test.describe('github workflow page', () => {
 		await main.locator('#gen-repository').click()
 		await page.getByRole('option', { name: 'acme/mobile' }).click()
 		await expect(yaml).toContainText('branches: [main]')
+	})
+
+	test('a pr trigger drops the push trigger from the generated workflow', async ({ page }) => {
+		await mocks({ 'github.list': { ok: true, result: { items: [linkPR, link] } } })
+
+		await page.goto('/github/workflow?project=test-project&repo=acme/docs')
+		const main = page.locator('.content-wrapper')
+
+		// acme/docs has the pr trigger: the workflow triggers on pull_request alone.
+		const yaml = main.locator('.workflow-yaml')
+		await expect(main.locator('#gen-repository')).toContainText('acme/docs')
+		await expect(yaml).toContainText('pull_request:')
+		await expect(yaml).not.toContainText('push:')
+		await expect(yaml).not.toContainText('branches:')
+
+		// Switching to an all-trigger link brings the push trigger back.
+		await main.locator('#gen-repository').click()
+		await page.getByRole('option', { name: 'acme/web' }).click()
+		await expect(yaml).toContainText('branches: [release]')
+		await expect(yaml).toContainText('push:')
+		await expect(yaml).toContainText('pull_request:')
+	})
+
+	test('a branch trigger drops the pull_request trigger from the generated workflow', async ({ page }) => {
+		await mocks({ 'github.list': { ok: true, result: { items: [linkBranchOnly, link] } } })
+
+		await page.goto('/github/workflow?project=test-project&repo=acme/svc')
+		const main = page.locator('.content-wrapper')
+
+		// acme/svc is branch-only: push to main, no pull_request previews.
+		const yaml = main.locator('.workflow-yaml')
+		await expect(main.locator('#gen-repository')).toContainText('acme/svc')
+		await expect(yaml).toContainText('push:')
+		await expect(yaml).toContainText('branches: [main]')
+		await expect(yaml).not.toContainText('pull_request:')
 	})
 
 	test('Static build type emits a mode: static workflow with framework/outputDir and no dockerfile/port', async ({ page }) => {
@@ -308,6 +389,43 @@ test.describe('github link page', () => {
 		expect(linkReq.serviceAccount).toBe('ci')
 		expect(linkReq.repository).toBe('acme/api')
 		expect(linkReq.productionBranch).toBe('release')
+	})
+
+	test('selecting the PR trigger disables the branch input and links with trigger=pr and an empty branch', async ({ page }) => {
+		await mocks({ 'github.link': { ok: true, result: {} } })
+
+		await page.goto('/github/link?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		// Pick a repo (acme/web is already linked, so hidden) + service account.
+		const repoSelect = main.locator('#link-repository')
+		await repoSelect.click()
+		await repoSelect.fill('acme/api')
+		await page.getByRole('option', { name: 'acme/api' }).click()
+		await main.locator('#link-service-account').click()
+		await page.getByRole('option', { name: /ci — CI Deployer/ }).click()
+
+		// Default trigger is 'all', so the production branch input is enabled.
+		const branchInput = main.locator('#link-production-branch')
+		await expect(branchInput).toBeEnabled()
+
+		// Switch the trigger to PR previews only — the production branch input disables.
+		await main.locator('#link-trigger').click()
+		await page.getByRole('option', { name: /PR previews only/ }).click()
+		await expect(branchInput).toBeDisabled()
+
+		await main.getByRole('button', { name: 'Link', exact: true }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/github.link')
+		}).toBe(true)
+
+		const log = await getRequestLog()
+		const linkReq = JSON.parse(log.find((r) => r.path === '/github.link')?.body ?? '{}')
+		expect(linkReq.trigger).toBe('pr')
+		// The pr trigger has no production branch — it is cleared on submit.
+		expect(linkReq.productionBranch).toBe('')
 	})
 
 	test('link page with ?installation_id=99 calls github.listRepos with installationId 99', async ({ page }) => {


### PR DESCRIPTION
## What

Console UI for the GitHub **deploy-trigger** model (deploys-app/api#66, deploys-app/apiserver#129), replacing the PR-only toggle.

## Changes

- **Link form** — a **Deploy trigger** selector: *Branch + PR previews* (`all`), *Branch only* (`branch`), *PR previews only* (`pr`). Choosing `pr` clears + disables the **Production branch** input. Submits `trigger` + `productionBranch`.
- **Repo card** — a trigger pill plus the production branch (`—` for `pr`).
- **Workflow generator** — emits the matching `on:` block: `push` + `pull_request` for `all`, `push` only for `branch`, `pull_request` only for `pr`.
- Types (`trigger: 'all' | 'branch' | 'pr'`), mock fixtures + handler, and e2e tests (30 pass).

`bun lint` + `bun check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)