### PR TITLE
github: edit a linked repository in place

### DIFF
--- a/src/lib/components/EditGithubLinkModal.svelte
+++ b/src/lib/components/EditGithubLinkModal.svelte
@@ -1,0 +1,222 @@
+<script>
+	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
+
+	/**
+	 * Edit an existing GitHub link in place: change the linked service account,
+	 * deploy trigger, and production branch. The repository and installation id
+	 * are immutable, so only the mutable fields are editable here. Calls
+	 * github.update.
+	 *
+	 * @typedef {Object} Props
+	 * @property {string} project
+	 * @property {{ sid: string, name: string }[]} serviceAccounts  selectable service accounts in the project
+	 * @property {() => void} onsaved  called after a successful update so the parent can reload the link list
+	 */
+
+	/** @type {Props} */
+	const { project, serviceAccounts, onsaved } = $props()
+
+	let isActive = $state(false)
+	// Identifies the link being edited; repository is display-only.
+	let repositoryId = $state(0)
+	let repository = $state('')
+	let serviceAccount = $state('')
+	let productionBranch = $state('')
+	let trigger = $state('all')
+	// Initial values, to detect whether the workflow file needs recreating.
+	let initialBranch = $state('')
+	let initialTrigger = $state('all')
+	let submitting = $state(false)
+	let errorMessage = $state('')
+	// After a save that changed the trigger or branch, swap the body for a note
+	// nudging the user to recreate deploy.yaml (its on: block tracks both).
+	let savedWorkflowChanged = $state(false)
+
+	const triggerOptions = [
+		{ value: 'all', label: 'Branch + PR previews' },
+		{ value: 'branch', label: 'Branch only (no previews)' },
+		{ value: 'pr', label: 'PR previews only (no branch deploys)' }
+	]
+
+	const serviceAccountOptions = $derived(
+		serviceAccounts.map((sa) => ({ value: sa.sid, label: `${sa.sid} — ${sa.name}` }))
+	)
+
+	const workflowHref = $derived(
+		`/github/workflow?project=${project}&repo=${encodeURIComponent(repository)}`
+	)
+
+	const canSubmit = $derived(serviceAccount !== '' && !submitting)
+
+	/** @param {Api.GithubLink} link */
+	export function open (link) {
+		repositoryId = link.repositoryId
+		repository = link.repository
+		serviceAccount = link.serviceAccount
+		productionBranch = link.productionBranch ?? ''
+		trigger = link.trigger ?? 'all'
+		initialBranch = productionBranch
+		initialTrigger = trigger
+		submitting = false
+		errorMessage = ''
+		savedWorkflowChanged = false
+		isActive = true
+	}
+
+	function close () {
+		isActive = false
+	}
+
+	/** @param {MouseEvent} e */
+	function onBackdrop (e) {
+		if (e.target === e.currentTarget) close()
+	}
+
+	async function save () {
+		if (!canSubmit) return
+
+		submitting = true
+		errorMessage = ''
+		// pr links never deploy a branch, so the branch is dropped for them.
+		const branch = trigger === 'pr' ? '' : productionBranch.trim()
+
+		try {
+			const resp = await api.invoke('github.update', {
+				project,
+				repositoryId,
+				serviceAccount,
+				productionBranch: branch,
+				trigger
+			}, fetch)
+			if (!resp.ok) {
+				errorMessage = resp.error?.message ?? 'Failed to update the link.'
+				return
+			}
+
+			// Reload the parent's link list so the card reflects the new fields
+			// (and the workflow generator picks up the change).
+			onsaved()
+
+			const initialEffectiveBranch = initialTrigger === 'pr' ? '' : initialBranch.trim()
+			if (trigger !== initialTrigger || branch !== initialEffectiveBranch) {
+				// The trigger or branch changed — the committed deploy.yaml's `on:`
+				// block is now stale. Keep the modal open with a nudge to recreate
+				// it on GitHub rather than closing silently.
+				savedWorkflowChanged = true
+			} else {
+				close()
+			}
+		} finally {
+			submitting = false
+		}
+	}
+</script>
+
+<div class="modal" onclick={onBackdrop} class:is-active={isActive} aria-hidden={!isActive}>
+	<div class="modal-panel">
+		<div class="modal-close" onclick={close} onkeypress={close} tabindex="0" role="button">✕</div>
+
+		{#if savedWorkflowChanged}
+			<h4><strong>Link updated</strong></h4>
+			<p class="text-content/50 text-sm mt-1">
+				The deploy trigger or production branch changed. The workflow file already
+				in <span class="font-mono">{repository}</span> still has the old
+				<span class="font-mono">on:</span> block — recreate
+				<span class="font-mono">.github/workflows/deploy.yaml</span> and commit it
+				so it runs for the right events.
+			</p>
+
+			<div class="flex items-center gap-3 mt-6">
+				<a class="button is-icon-left" href={workflowHref}>
+					<i class="fa-solid fa-diagram-project"></i>
+					Recreate workflow
+				</a>
+				<button class="button is-variant-secondary" onclick={close} type="button">
+					Close
+				</button>
+			</div>
+		{:else}
+			<h4><strong>Edit link</strong></h4>
+			<p class="text-content/50 text-sm mt-1">
+				Change the deploy identity, trigger, and production branch for
+				<span class="font-mono">{repository}</span>. The repository and installation
+				can't be changed — unlink and relink to move to a different repository.
+			</p>
+
+			<div class="grid gap-4 mt-4">
+				<div class="field">
+					<label for="edit-link-service-account">Service account</label>
+					<Select
+						id="edit-link-service-account"
+						bind:value={serviceAccount}
+						options={serviceAccountOptions}
+						placeholder="Select a service account" />
+					<p class="text-content/50 text-sm mt-1">
+						Workflows deploy as this identity.
+					</p>
+				</div>
+
+				<div class="field">
+					<label for="edit-link-trigger">Deploy trigger</label>
+					<Select
+						id="edit-link-trigger"
+						bind:value={trigger}
+						options={triggerOptions} />
+					<p class="text-content/50 text-sm mt-1">
+						{#if trigger === 'pr'}
+							Only pull requests deploy (each a preview). Pushes to any branch are rejected — no production deploys.
+						{:else if trigger === 'branch'}
+							Pushes to the production branch deploy; pull requests get no preview.
+						{:else}
+							Pushes to the production branch deploy, and every pull request gets a preview.
+						{/if}
+					</p>
+				</div>
+
+				<div class="field">
+					<label for="edit-link-production-branch">Production branch</label>
+					<div class="input">
+						<input id="edit-link-production-branch" class="font-mono" bind:value={productionBranch} placeholder="main" disabled={trigger === 'pr'}>
+					</div>
+					<p class="text-content/50 text-sm mt-1">
+						{#if trigger === 'pr'}
+							Not used — previews-only links never deploy a branch.
+						{:else}
+							Deploys are only accepted from this branch. Leave empty to allow any branch.
+						{/if}
+					</p>
+				</div>
+
+				{#if errorMessage}
+					<p class="text-negative text-sm">{errorMessage}</p>
+				{/if}
+			</div>
+
+			<div class="flex items-center gap-3 mt-6">
+				<button
+					class="button"
+					class:is-loading={submitting}
+					disabled={!canSubmit}
+					onclick={save}
+					type="button">
+					Save
+				</button>
+				<button
+					class="button is-variant-secondary"
+					disabled={submitting}
+					onclick={close}
+					type="button">
+					Cancel
+				</button>
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.modal-panel {
+		width: 100%;
+		max-width: 32rem;
+	}
+</style>

--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -1302,6 +1302,16 @@ const handlers = {
 		githubLinks.splice(i, 1)
 		return ok({})
 	},
+	'github.update': (args) => {
+		const l = githubLinks.find((x) => x.repositoryId === args?.repositoryId)
+		if (!l) return err('api: github repository link not found')
+		const sa = serviceAccounts.find((s) => s.sid === args?.serviceAccount)
+		l.serviceAccount = args?.serviceAccount ?? l.serviceAccount
+		l.serviceAccountEmail = sa?.email ?? l.serviceAccountEmail
+		l.trigger = args?.trigger ?? 'all'
+		l.productionBranch = l.trigger === 'pr' ? '' : (args?.productionBranch ?? '')
+		return ok({})
+	},
 	'serviceAccount.list': () => list(serviceAccounts),
 	'serviceAccount.get': (args) => ok({
 		...serviceAccounts[0],

--- a/src/routes/(auth)/(project)/github/+page.js
+++ b/src/routes/(auth)/(project)/github/+page.js
@@ -3,10 +3,15 @@ import api from '$lib/api'
 export async function load ({ parent, fetch }) {
 	const { project } = await parent()
 
-	const links = await api.invoke('github.list', { project }, fetch)
+	const [links, serviceAccounts] = await Promise.all([
+		api.invoke('github.list', { project }, fetch),
+		// Service accounts feed the edit modal's picker.
+		api.invoke('serviceAccount.list', { project }, fetch)
+	])
 
 	return {
 		links: links.result?.items ?? [],
+		serviceAccounts: serviceAccounts.result?.items ?? [],
 		error: links.error
 	}
 }

--- a/src/routes/(auth)/(project)/github/+page.svelte
+++ b/src/routes/(auth)/(project)/github/+page.svelte
@@ -3,6 +3,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import EditGithubLinkModal from '$lib/components/EditGithubLinkModal.svelte'
 	import * as format from '$lib/format'
 	import GitHubNav from './_components/GitHubNav.svelte'
 
@@ -10,12 +11,21 @@
 
 	const project = $derived(data.project)
 	const error = $derived(data.error)
+	const serviceAccounts = $derived(data.serviceAccounts)
 
 	let links = $state(untrack(() => data.links))
+
+	/** @type {EditGithubLinkModal} */
+	let editModal = $state(/** @type {any} */ (undefined))
 
 	async function reloadLinks () {
 		const resp = await api.invoke('github.list', { project }, fetch)
 		if (resp.ok) links = resp.result?.items ?? []
+	}
+
+	/** @param {Api.GithubLink} it */
+	function edit (it) {
+		editModal.open(it)
 	}
 
 	/** @param {Api.GithubLink} it */
@@ -74,6 +84,10 @@
 					<a class="repo-name link" href={`https://github.com/${it.repository}`} target="_blank" rel="noreferrer">
 						{it.repository}
 					</a>
+					<GuardedButton permission="github.update" class="icon-button repo-edit" type="button"
+						aria-label={`Edit ${it.repository}`} onclick={() => edit(it)}>
+						<i class="fa-solid fa-pen"></i>
+					</GuardedButton>
 					<GuardedButton permission="github.unlink" class="icon-button repo-unlink" type="button"
 						aria-label={`Unlink ${it.repository}`} onclick={() => unlink(it)}>
 						<i class="fa-solid fa-link-slash"></i>
@@ -143,6 +157,8 @@
 	</div>
 {/if}
 
+<EditGithubLinkModal bind:this={editModal} {project} {serviceAccounts} onsaved={reloadLinks} />
+
 <style>
 	.repo-grid {
 		display: grid;
@@ -206,12 +222,17 @@
 		white-space: nowrap;
 	}
 
-	/* The unlink control is rendered by GuardedButton (a child component), so it
-	 * doesn't carry this component's scope hash — reach it via :global, anchored
-	 * under .repo-card so it can't leak. */
+	/* The edit/unlink controls are rendered by GuardedButton (a child component),
+	 * so they don't carry this component's scope hash — reach them via :global,
+	 * anchored under .repo-card so they can't leak. */
+	.repo-card :global(.repo-edit),
 	.repo-card :global(.repo-unlink) {
 		flex-shrink: 0;
 		color: hsl(var(--hsl-content) / 0.5);
+	}
+
+	.repo-card :global(.repo-edit):hover {
+		color: hsl(var(--hsl-primary));
 	}
 
 	.repo-card :global(.repo-unlink):hover {

--- a/tests/github.spec.js
+++ b/tests/github.spec.js
@@ -170,6 +170,81 @@ test.describe('github repositories page', () => {
 		await expect(svcCard).toContainText('main')
 	})
 
+	test('edits a link: changes branch via the modal and nudges to recreate the workflow', async ({ page }) => {
+		await mocks({ 'github.update': { ok: true, result: {} } })
+
+		await page.goto('/github?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		const card = main.locator('.repo-card', { hasText: 'acme/web' })
+		await card.getByRole('button', { name: 'Edit acme/web' }).click()
+
+		const modal = page.locator('.modal.is-active')
+		await expect(modal.getByRole('heading', { name: 'Edit link' })).toBeVisible()
+
+		// Branch is prefilled with the link's current production branch.
+		const branchInput = modal.locator('#edit-link-production-branch')
+		await expect(branchInput).toHaveValue('release')
+		await branchInput.fill('  develop  ')
+
+		await modal.getByRole('button', { name: 'Save', exact: true }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/github.update')
+		}).toBe(true)
+
+		const req = JSON.parse((await getRequestLog()).find((r) => r.path === '/github.update')?.body ?? '{}')
+		expect(req.repositoryId).toBe(link.repositoryId)
+		expect(req.serviceAccount).toBe('ci')
+		expect(req.productionBranch).toBe('develop')
+		expect(req.trigger).toBe('all')
+
+		// Because the branch changed, the modal stays open with a nudge to recreate
+		// deploy.yaml via the workflow generator (the redirect path), preselecting the repo.
+		await expect(modal.getByRole('heading', { name: 'Link updated' })).toBeVisible()
+		const recreate = modal.getByRole('link', { name: /Recreate workflow/ })
+		await expect(recreate).toHaveAttribute('href', '/github/workflow?project=test-project&repo=acme%2Fweb')
+	})
+
+	test('editing to the pr trigger disables and clears the production branch', async ({ page }) => {
+		await mocks({ 'github.update': { ok: true, result: {} } })
+
+		await page.goto('/github?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		await main.locator('.repo-card', { hasText: 'acme/web' }).getByRole('button', { name: 'Edit acme/web' }).click()
+		const modal = page.locator('.modal.is-active')
+
+		// Switch the trigger to "PR previews only" — the branch input disables.
+		await modal.locator('#edit-link-trigger').click()
+		await page.getByRole('option', { name: 'PR previews only (no branch deploys)' }).click()
+		await expect(modal.locator('#edit-link-production-branch')).toBeDisabled()
+
+		await modal.getByRole('button', { name: 'Save', exact: true }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/github.update')
+		}).toBe(true)
+
+		const req = JSON.parse((await getRequestLog()).find((r) => r.path === '/github.update')?.body ?? '{}')
+		expect(req.trigger).toBe('pr')
+		expect(req.productionBranch).toBe('')
+	})
+
+	test('Edit is disabled without the github.update permission', async ({ page }) => {
+		await mocks({
+			'me.permissions': { ok: true, result: { permissions: ['github.list'], admin: false } }
+		})
+
+		await page.goto('/github?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		const card = main.locator('.repo-card', { hasText: 'acme/web' })
+		await expect(card.getByRole('button', { name: 'Edit acme/web' })).toBeDisabled()
+	})
+
 	test('unlinks after confirmation', async ({ page }) => {
 		await mocks({ 'github.unlink': { ok: true, result: {} } })
 


### PR DESCRIPTION
## What

Adds an **Edit** action to each repository card on the GitHub page: change a link's **service account**, **deploy trigger**, and **production branch** without unlink + relink. Backed by `github.update` (deploys-app/api#65, deploys-app/apiserver#130).

The repository and installation id stay immutable (the modal says so — unlink + relink to move to a different repo).

## Recreate `deploy.yaml` — via the existing redirect

When the trigger or production branch changes, the modal stays open with a **"Recreate workflow"** nudge that links to the workflow generator (preselecting the repo). The generator's `on:` block already tracks the link's trigger + branch, so the regenerated YAML matches — and the user commits it themselves via the existing **Create on GitHub** deep-link. **No GitHub App write access is involved.**

## Changes

- New `src/lib/components/EditGithubLinkModal.svelte` (mirrors `CreateServiceAccountModal.svelte` + the link form's trigger control): read-only repo name, service-account `Select`, **Deploy trigger** `Select` (`pr` disables + clears the production branch), production-branch input, then a post-save "Link updated" nudge when the trigger or branch changed.
- `github/+page.svelte`: per-card Edit `GuardedButton permission="github.update"` (pencil, beside Unlink) + modal instance, reloads links on save.
- `github/+page.js`: also loads `serviceAccount.list` for the modal's picker.
- `mock.js`: `github.update` handler (mirrors the `pr`-clears-branch rule).
- `tests/github.spec.js`: edit-flow e2e (asserts the `github.update` payload incl. `trigger` + the recreate nudge href), a pr-trigger-disables-branch test, and a gating test (Edit disabled without `github.update`).

## Verification

Rebased onto the merged deploy-trigger control (#216). `bun lint` ✓ · `bun check` ✓ (0 errors) · `bun run test tests/github.spec.js` → **33 passed**. Screenshot of the edit modal (service account / deploy trigger / production branch) captured locally and on-design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)