### PR TITLE
fix(github): reload repo list when project changes (#219)

### DIFF
--- a/src/routes/(auth)/(project)/github/+page.svelte
+++ b/src/routes/(auth)/(project)/github/+page.svelte
@@ -1,5 +1,4 @@
 <script>
-	import { untrack } from 'svelte'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
@@ -13,7 +12,10 @@
 	const error = $derived(data.error)
 	const serviceAccounts = $derived(data.serviceAccounts)
 
-	let links = $state(untrack(() => data.links))
+	// Derived from the loader so switching project (same /github route → this
+	// component is reused, only `data.links` changes) re-syncs the list. Writable
+	// so unlink/edit can update it in place until the next load (fixes #219).
+	let links = $derived(data.links)
 
 	/** @type {EditGithubLinkModal} */
 	let editModal = $state(/** @type {any} */ (undefined))

--- a/tests/github.spec.js
+++ b/tests/github.spec.js
@@ -73,6 +73,12 @@ const repos = [
 
 const savedInstallation = { installationId: 77, createdAt: '2026-01-01T00:00:00Z' }
 
+// Two projects so the project picker can switch between them (#219 test).
+const twoProjects = [
+	{ id: 'p1', project: 'project-a', name: 'Project A' },
+	{ id: 'p2', project: 'project-b', name: 'Project B' }
+]
+
 function mocks (overrides = {}) {
 	return setMocks({
 		'github.list': { ok: true, result: { items: [link] } },
@@ -105,6 +111,35 @@ test.describe('github repositories page', () => {
 
 		// The workflow generator does NOT live on this page anymore.
 		await expect(main.locator('.workflow-yaml')).toHaveCount(0)
+	})
+
+	test('switching project via the modal reloads the repo list (#219)', async ({ page }) => {
+		// Two projects so the picker can switch between them; project-a has one
+		// linked repo.
+		await mocks({
+			'project.list': { ok: true, result: { items: twoProjects } },
+			'github.list': { ok: true, result: { items: [link] } }
+		})
+		await page.goto('/github?project=project-a')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.locator('.repo-card', { hasText: 'acme/web' })).toBeVisible()
+
+		// The next project has a different linked repo.
+		const otherLink = { ...link, repositoryId: 900000001, repository: 'contoso/site' }
+		await setMocks({ 'github.list': { ok: true, result: { items: [otherLink] } } })
+
+		// Switch project through the sidebar modal — a same-route SPA navigation
+		// that reuses this page component (the #219 repro: the loader re-runs but
+		// the locally-held list must follow the new project).
+		await page.locator('.project-box').click()
+		const projectModal = page.locator('.modal.is-active')
+		await projectModal.getByRole('link', { name: 'Project B' }).click()
+
+		await expect(page).toHaveURL(/project=project-b/)
+		// The list must reflect the newly selected project, not the stale one.
+		await expect(main.locator('.repo-card', { hasText: 'contoso/site' })).toBeVisible()
+		await expect(main.locator('.repo-card', { hasText: 'acme/web' })).toHaveCount(0)
 	})
 
 	test('Workflow tab navigates to the standalone generator', async ({ page }) => {


### PR DESCRIPTION
Fixes #219.

## Problem

On `/github`, switching project via the search modal didn't reload the repo list — it kept showing the previous project's repositories.

## Cause

`setProject` does `goto('?project=…')`, a **same-route SPA navigation**, so the `/github` page component is reused. The loader re-runs and `data.links` updates, but the list was held in a capture-once binding:

```js
let links = $state(untrack(() => data.links))
```

which never re-syncs when `data.links` changes. (`project`/`error`/`serviceAccounts` are `$derived`, so they updated fine — only `links` was stale.)

## Fix

Make it a **writable `$derived`** — re-syncs on every loader re-run (project switch) while staying reassignable for in-place `unlink`/`edit` updates:

```js
let links = $derived(data.links)
```

One line; no visual/layout change. (ESLint's `svelte/prefer-writable-derived` recommends exactly this over `$state`+`$effect`.)

## Test

Added an e2e that switches project through the sidebar modal and asserts the repo list follows the new project. **Verified it fails on the old code and passes on the fix.** Full `github.spec` (34) + `bun lint` + `bun check` green.

## Before / after

Sidebar switched to **Project B** — before still shows `acme/web` (Project A, stale); after shows `contoso/site` (Project B).

| Before (stale) | After (fixed) |
|---|---|
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/219-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/219-after.png) |

<sub>Screenshots live on the image-only `screenshots` branch (not merged to main), referenced via raw URLs.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)