### PR TITLE
fix(deployment): hide resources for Static deployments in the list

### DIFF
--- a/src/routes/(auth)/(project)/deployment/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/+page.svelte
@@ -52,6 +52,8 @@
 		color: hsl(var(--hsl-content) / 0.75);
 	}
 	.resources .sep { color: hsl(var(--hsl-content) / 0.3); }
+	/* Static deployments have no configurable resources — show a muted placeholder. */
+	.resources-none { color: hsl(var(--hsl-content) / 0.35); }
 
 	/* CronJob schedule on the meta line. */
 	.schedule {
@@ -123,11 +125,15 @@
 							</div>
 						</td>
 						<td>
-							<span class="resources">
-								{format.cpuLimited(it.resources.limits.cpu)}
-								<span class="sep">·</span>
-								{format.memory(it.resources.requests.memory)}
-							</span>
+							{#if it.type === 'Static'}
+								<span class="resources-none" title="Static sites have no configurable resources">—</span>
+							{:else}
+								<span class="resources">
+									{format.cpuLimited(it.resources.limits.cpu)}
+									<span class="sep">·</span>
+									{format.memory(it.resources.requests.memory)}
+								</span>
+							{/if}
 						</td>
 						<td>
 							{#if it.minReplicas > 0}


### PR DESCRIPTION
## Problem

On the **Deployments** list page, every row showed a CPU · Memory value in the **Resources** column — including **Static** deployments. Static sites have no configurable resources (you can't set CPU/memory for them), so that value is meaningless and confusing.

## Change

For `Static` rows, render a muted `—` placeholder in the Resources column instead of CPU · Memory. This mirrors the deployment **detail** page, which already omits the Resources section for Static (`{#if !isStatic}`), and matches the Replicas column, which already shows `—` for Static.

Other deployment types (WebService, CronJob, Worker) run a container and keep their resources unchanged. As a side benefit, the change no longer reads `it.resources.limits.cpu` for Static rows.

## Verification

- `bun lint` — 0 errors
- `bun check` — 0 errors
- `bun test tests/deployment.spec.js` — 20 passed
- Rendered locally in mock mode; before/after below.

### Screenshots

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/222-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/222-after.png) |

Before: the Static `website` row shows `500m vCPU · 128 MiB`. After: it shows a muted `—`, while WebService / CronJob / Worker rows keep their resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
