### PR TITLE
docs: use the screenshots branch for PR screenshots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,25 @@ make deploy  # build and deploy to deploys-app project
 
 `main` is protected — all changes must go through a pull request; never commit or push directly to `main`. Branch off the latest `main` (`git checkout main && git pull`), make changes, then open a PR. Merging a PR auto-deletes its branch, which can silently leave your local checkout on `main` — so verify the current branch before committing or pushing.
 
-**UI changes must include screenshots in the PR description.** Any PR that adds or changes user-visible UI (a page, component, modal, layout, or styling) must show the result visually in the PR body — not just describe it. Capture the affected screens with the mock + Playwright (`bun dev:mock`, then screenshot via `@playwright/test`), covering the relevant states (e.g. empty vs populated, a toggle on/off, light/dark when it matters); a before/after is ideal for changes to existing screens. Preferred attach mechanism: drag-and-drop the images into the GitHub PR editor — GitHub stores them under `user-attachments`, keeping binaries out of the repo. Don't commit screenshots into the source tree just to embed them.
+**UI changes must include screenshots in the PR description.** Any PR that adds or changes user-visible UI (a page, component, modal, layout, or styling) must show the result visually in the PR body — not just describe it. Capture the affected screens with the mock + Playwright (`bun dev:mock`, then screenshot via `@playwright/test`), covering the relevant states (e.g. empty vs populated, a toggle on/off, light/dark when it matters); a before/after is ideal for changes to existing screens. Attach mechanism: store the images on the dedicated **`screenshots`** branch — a long-lived branch that is **never merged into `main`**, so the binaries stay out of the source tree — and embed them in the PR body via raw URLs. Name each file by PR number (`<PR#>-before.png`, `<PR#>-after.png`, or `<PR#>-<label>.png`). Because the filename needs the PR number, open the PR first, then push the screenshots and edit the body to add the links. Reference them as `https://raw.githubusercontent.com/deploys-app/console/screenshots/<file>` — e.g. a side-by-side before/after:
+
+```md
+| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/<PR#>-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/<PR#>-after.png) |
+| --- | --- |
+```
+
+To publish the images (after PR `#<N>` exists):
+
+```bash
+git fetch origin screenshots
+git worktree add ../.worktrees/console-screenshots screenshots
+cp before.png ../.worktrees/console-screenshots/<N>-before.png
+cp after.png  ../.worktrees/console-screenshots/<N>-after.png
+cd ../.worktrees/console-screenshots && git add . && git commit -m "screenshots: console#<N> before/after" && git push origin screenshots
+git worktree remove ../.worktrees/console-screenshots
+```
+
+Never commit screenshots into the source tree on `main` just to embed them.
 
 ## Architecture
 


### PR DESCRIPTION
## What

Updates the **UI changes must include screenshots** guidance in `CLAUDE.md` to document the convention this repo already uses in practice (e.g. PR #220): store screenshots on the long-lived **`screenshots`** branch and embed them in the PR body via raw URLs, instead of drag-and-dropping into the GitHub editor.

## Why

- The `screenshots` branch is already the de-facto mechanism (`219-before.png` / `219-after.png` live there and PR #220 embeds them), but `CLAUDE.md` still told contributors to drag-and-drop.
- Raw-URL embeds from a dedicated branch keep binaries out of `main` *and* are reproducible — non-interactive tooling can attach them, which drag-and-drop can't.

## Details documented

- File naming by PR number: `<PR#>-before.png`, `<PR#>-after.png`, or `<PR#>-<label>.png`.
- Embed via `https://raw.githubusercontent.com/deploys-app/console/screenshots/<file>`, with a side-by-side before/after table example.
- The ordering gotcha (open the PR first to get its number, then push the images and edit the body) and a copy-paste publish snippet.
- Restated: never commit screenshots into the source tree on `main`.

Docs-only change — no code, so `bun lint`/`bun check` are not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)