### PR TITLE
feat(github): add "Edit on GitHub" to the workflow generator

### DIFF
--- a/src/routes/(auth)/(project)/github/workflow/+page.svelte
+++ b/src/routes/(auth)/(project)/github/workflow/+page.svelte
@@ -339,8 +339,16 @@ jobs:
 ${withBlock()}
 `)
 
+	// Create opens a brand-new file pre-filled with the YAML; Edit opens the file
+	// already in the repo. Both target the default branch (where the workflow file
+	// lives), independent of the deploy trigger's branch. GitHub's /new flow errors
+	// if the path already exists, and /edit can't pre-fill content — so editing
+	// pairs with the Copy button (copy here, then paste over the existing file there).
 	const createOnGitHubURL = $derived(gen.repository
 		? `https://github.com/${gen.repository}/new/main?filename=.github/workflows/deploy.yaml&value=${encodeURIComponent(workflowYaml)}`
+		: '')
+	const editOnGitHubURL = $derived(gen.repository
+		? `https://github.com/${gen.repository}/edit/main/.github/workflows/deploy.yaml`
 		: '')
 
 	onMount(() => setupCopy('.copy-workflow'))
@@ -645,11 +653,15 @@ ${withBlock()}
 			</div>
 
 			<div class="wf-actions">
-				<a class="button is-icon-left wf-create" href={createOnGitHubURL} target="_blank" rel="noreferrer">
+				<a class="button is-icon-left wf-action" href={createOnGitHubURL} target="_blank" rel="noreferrer">
 					<i class="fa-brands fa-github"></i>
 					Create on GitHub
 				</a>
-				<span class="helper">Opens GitHub's file editor pre-filled with this workflow — review and commit it there.</span>
+				<a class="button is-variant-secondary is-icon-left wf-action" href={editOnGitHubURL} target="_blank" rel="noreferrer">
+					<i class="fa-brands fa-github"></i>
+					Edit on GitHub
+				</a>
+				<span class="helper">First time? <strong>Create on GitHub</strong> opens a new file pre-filled with this workflow. Updating an existing workflow? <strong>Copy</strong> it above, then <strong>Edit on GitHub</strong> opens the current file to paste over.</span>
 			</div>
 		</aside>
 	</div>
@@ -853,7 +865,7 @@ ${withBlock()}
 		font-size: 0.8125rem;
 	}
 
-	.wf-create { width: 100%; }
+	.wf-action { width: 100%; }
 
 	.env-group-chip {
 		display: inline-flex;

--- a/tests/github.spec.js
+++ b/tests/github.spec.js
@@ -320,6 +320,11 @@ test.describe('github workflow page', () => {
 		const href = await main.getByRole('link', { name: 'Create on GitHub' }).getAttribute('href')
 		expect(href).toContain('https://github.com/acme/web/new/main?filename=.github/workflows/deploy.yaml&value=')
 		expect(decodeURIComponent(href ?? '')).toContain('name: api')
+
+		// Edit-on-GitHub opens the existing file (no value pre-fill — pairs with Copy)
+		// so users can update a workflow that already exists in the repo.
+		const editHref = await main.getByRole('link', { name: 'Edit on GitHub' }).getAttribute('href')
+		expect(editHref).toBe('https://github.com/acme/web/edit/main/.github/workflows/deploy.yaml')
 	})
 
 	test('preselects the repository named in ?repo=', async ({ page }) => {


### PR DESCRIPTION
## Problem

On the GitHub **Workflow** page, the only output action was **Create on GitHub**, which deep-links to GitHub's *new file* flow (`/new/main?filename=…&value=…`). Once a repo already has `.github/workflows/deploy.yaml`, GitHub rejects that path ("already exists"), so **a user who wants to edit their current workflow has no way to do it** from the console.

## Change

Add an **Edit on GitHub** action next to Create:

- `Create on GitHub` → `/new/main/...` — first-time setup, pre-filled with the generated YAML (unchanged).
- `Edit on GitHub` → `/edit/main/.github/workflows/deploy.yaml` — opens the file that's already in the repo.

GitHub's `/edit` view can't be pre-filled with content, so editing pairs with the existing **Copy** button: copy the regenerated YAML, click Edit, paste over the file. The helper text now spells out both paths.

Both links target the **default branch** (where the workflow file actually lives, and where PR-preview workflows are read from), independent of the deploy trigger's branch.

This is the console-only first step; pre-filling the generator from a workflow's current settings is a separate, larger follow-up.

## Verification

- `bun lint` — 0 errors
- `bun check` — 0 errors
- `bun test tests/github.spec.js` — 34 passed (added an assertion for the Edit link)
- Rendered locally in mock mode; before/after below.

### Screenshots

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/224-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/224-after.png) |

Before: only "Create on GitHub" (a dead end once the file exists). After: "Edit on GitHub" added, with helper text covering first-time vs. updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
