### PR TITLE
feat(github): pre-fill the workflow generator from saved config

### DIFF
--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -707,6 +707,26 @@ const githubLinks = [
 		productionBranch: 'main',
 		// 'all' (default): push to main + PR previews
 		trigger: 'all',
+		// Saved workflow-generator inputs so the generator pre-fills them offline.
+		workflowConfig: {
+			name: 'web',
+			location: '',
+			buildType: 'dockerfile',
+			port: 3000,
+			protocol: 'h2c',
+			framework: 'auto',
+			buildCommand: '',
+			outputDir: 'public',
+			spa: false,
+			notFound: '404.html',
+			workingDirectory: 'app',
+			env: 'NODE_ENV=production\nLOG_LEVEL=info',
+			envGroups: ['shared'],
+			pullSecret: '',
+			requireGoogleLogin: true,
+			allowedEmails: 'owner@acme.io',
+			allowedDomains: 'acme.io'
+		},
 		createdAt: CREATED_AT,
 		createdBy: USER_EMAIL
 	},
@@ -1319,6 +1339,12 @@ const handlers = {
 		l.serviceAccountEmail = sa?.email ?? l.serviceAccountEmail
 		l.trigger = args?.trigger ?? 'all'
 		l.productionBranch = l.trigger === 'pr' ? '' : (args?.productionBranch ?? '')
+		return ok({})
+	},
+	'github.setWorkflowConfig': (args) => {
+		const l = githubLinks.find((x) => x.repositoryId === args?.repositoryId)
+		if (!l) return err('api: github repository link not found')
+		l.workflowConfig = args?.workflowConfig ?? null
 		return ok({})
 	},
 	'serviceAccount.list': () => list(serviceAccounts),

--- a/src/routes/(auth)/(project)/github/workflow/+page.svelte
+++ b/src/routes/(auth)/(project)/github/workflow/+page.svelte
@@ -31,38 +31,74 @@
 			.replace(/^-+|-+$/g, '')
 	}
 
+	// Default generator state for a repository with no saved config.
+	/** @param {string | undefined} repository */
+	function defaultGen (repository) {
+		return {
+			repository,
+			location: data.locations[0]?.id ?? '',
+			name: repoToName(repository) || 'web',
+			buildType: 'dockerfile',
+			port: 8080,
+			framework: 'auto',
+			buildCommand: '',
+			outputDir: 'public',
+			spa: false,
+			notFound: '404.html',
+			workingDirectory: '',
+			env: '',
+			/** @type {string[]} */
+			envGroups: [],
+			pullSecret: '',
+			protocol: 'http',
+			requireGoogleLogin: false,
+			allowedEmails: '',
+			allowedDomains: ''
+		}
+	}
+
+	/** @param {string | undefined} repository */
+	function savedConfigFor (repository) {
+		return data.links.find((l) => l.repository === repository)?.workflowConfig
+	}
+
+	// Merge a link's saved workflow config (github.setWorkflowConfig) over the
+	// defaults so the generator pre-fills the user's last-saved inputs. Missing
+	// or empty fields fall back to defaults.
+	/**
+	 * @param {string | undefined} repository
+	 * @param {Api.GitHubWorkflowConfig | undefined} cfg
+	 */
+	function genFromConfig (repository, cfg) {
+		const d = defaultGen(repository)
+		if (!cfg) return d
+		return {
+			repository,
+			location: cfg.location || d.location,
+			name: cfg.name || d.name,
+			buildType: cfg.buildType || d.buildType,
+			port: cfg.port || d.port,
+			framework: cfg.framework || d.framework,
+			buildCommand: cfg.buildCommand ?? d.buildCommand,
+			outputDir: cfg.outputDir || d.outputDir,
+			spa: cfg.spa ?? d.spa,
+			notFound: cfg.notFound || d.notFound,
+			workingDirectory: cfg.workingDirectory ?? d.workingDirectory,
+			env: cfg.env ?? d.env,
+			envGroups: cfg.envGroups ? [...cfg.envGroups] : d.envGroups,
+			pullSecret: cfg.pullSecret ?? d.pullSecret,
+			protocol: cfg.protocol || d.protocol,
+			requireGoogleLogin: cfg.requireGoogleLogin ?? d.requireGoogleLogin,
+			allowedEmails: cfg.allowedEmails ?? d.allowedEmails,
+			allowedDomains: cfg.allowedDomains ?? d.allowedDomains
+		}
+	}
+
 	// workflow generator — seed the repository from ?repo= (validated in the
 	// loader against the linked set) so jumping in from a repository card lands
-	// on the right repo.
-	const gen = $state(untrack(() => ({
-		repository: data.initialRepo,
-		location: data.locations[0]?.id ?? '',
-		name: repoToName(data.initialRepo) || 'web',
-		// 'dockerfile' (default) emits today's container workflow; 'static' emits
-		// a bucket-native static-web workflow (mode: static).
-		buildType: 'dockerfile',
-		port: 8080,
-		// static fields — only used when buildType === 'static'
-		framework: 'auto',
-		buildCommand: '',
-		outputDir: 'public',
-		spa: false,
-		notFound: '404.html',
-		// shared config
-		workingDirectory: '',
-		env: '',
-		/** @type {string[]} */
-		envGroups: [],
-		// container-only
-		pullSecret: '',
-		// WebService protocol (dockerfile only): http (default) | https | h2c
-		protocol: 'http',
-		// access (deployment access) — applies to both container and static.
-		// Allow-lists are free text (one entry per line or comma-separated).
-		requireGoogleLogin: false,
-		allowedEmails: '',
-		allowedDomains: ''
-	})))
+	// on the right repo, and pre-fill the build settings from that repo's saved
+	// workflow config so users edit their current workflow instead of defaults.
+	const gen = $state(untrack(() => genFromConfig(data.initialRepo, savedConfigFor(data.initialRepo))))
 	const genRepoOptions = $derived(links.map((l) => ({ value: l.repository, label: l.repository })))
 	const genLink = $derived(links.find((l) => l.repository === gen.repository))
 	const genBranch = $derived(genLink?.productionBranch || 'main')
@@ -71,10 +107,25 @@
 
 	// Keep the deployment name defaulting to the selected repository's name until
 	// the user edits it — switching repos then re-fills with the new repo name.
-	let nameTouched = $state(false)
+	// A saved config carries an explicit name, so treat the name as already set —
+	// don't let the repo-name default overwrite it.
+	let nameTouched = $state(untrack(() => !!savedConfigFor(data.initialRepo)?.name))
 	$effect(() => {
 		const derivedName = repoToName(gen.repository)
 		if (!nameTouched && derivedName) gen.name = derivedName
+	})
+
+	// When the selected repository changes, pre-fill the generator from that
+	// repo's saved workflow config (or reset to defaults). The initial load is
+	// already seeded above, so this only fires on an actual switch.
+	let configLoadedRepo = untrack(() => data.initialRepo)
+	$effect(() => {
+		const repo = gen.repository
+		if (repo === configLoadedRepo) return
+		configLoadedRepo = repo
+		const cfg = savedConfigFor(repo)
+		Object.assign(gen, genFromConfig(repo, cfg))
+		nameTouched = !!cfg?.name
 	})
 
 	const buildTypeOptions = [
@@ -350,6 +401,37 @@ ${withBlock()}
 	const editOnGitHubURL = $derived(gen.repository
 		? `https://github.com/${gen.repository}/edit/main/.github/workflows/deploy.yaml`
 		: '')
+
+	// Persist the current generator inputs to the link so the next visit pre-fills
+	// them. Fired (fire-and-forget) when the user clicks Create/Edit on GitHub —
+	// it never blocks opening GitHub, and failures (e.g. no github.update
+	// permission) are ignored.
+	function saveWorkflowConfig () {
+		const link = genLink
+		if (!link) return
+		const workflowConfig = {
+			name: gen.name,
+			location: gen.location,
+			buildType: gen.buildType,
+			port: gen.port,
+			protocol: gen.protocol,
+			framework: gen.framework,
+			buildCommand: gen.buildCommand,
+			outputDir: gen.outputDir,
+			spa: gen.spa,
+			notFound: gen.notFound,
+			workingDirectory: gen.workingDirectory,
+			env: gen.env,
+			envGroups: [...gen.envGroups],
+			pullSecret: gen.pullSecret,
+			requireGoogleLogin: gen.requireGoogleLogin,
+			allowedEmails: gen.allowedEmails,
+			allowedDomains: gen.allowedDomains
+		}
+		Promise.resolve(api.invoke('github.setWorkflowConfig', {
+			project, repositoryId: link.repositoryId, workflowConfig
+		}, fetch)).catch(() => {})
+	}
 
 	onMount(() => setupCopy('.copy-workflow'))
 </script>
@@ -653,11 +735,11 @@ ${withBlock()}
 			</div>
 
 			<div class="wf-actions">
-				<a class="button is-icon-left wf-action" href={createOnGitHubURL} target="_blank" rel="noreferrer">
+				<a class="button is-icon-left wf-action" href={createOnGitHubURL} target="_blank" rel="noreferrer" onclick={saveWorkflowConfig}>
 					<i class="fa-brands fa-github"></i>
 					Create on GitHub
 				</a>
-				<a class="button is-variant-secondary is-icon-left wf-action" href={editOnGitHubURL} target="_blank" rel="noreferrer">
+				<a class="button is-variant-secondary is-icon-left wf-action" href={editOnGitHubURL} target="_blank" rel="noreferrer" onclick={saveWorkflowConfig}>
 					<i class="fa-brands fa-github"></i>
 					Edit on GitHub
 				</a>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -383,6 +383,32 @@ declare namespace Api {
         trigger?: 'all' | 'branch' | 'pr'
         createdAt: string
         createdBy: string
+        // saved workflow-generator inputs, so the generator can pre-fill them;
+        // absent until the user saves (on Create/Edit on GitHub).
+        workflowConfig?: GitHubWorkflowConfig
+    }
+
+    // GitHubWorkflowConfig is the console workflow-generator's saved inputs for a
+    // linked repository (api.GitHubWorkflowConfig). Persisted via
+    // github.setWorkflowConfig and returned on github.list for pre-fill.
+    export type GitHubWorkflowConfig = {
+        name?: string
+        location?: string
+        buildType?: 'dockerfile' | 'static'
+        port?: number
+        protocol?: 'http' | 'https' | 'h2c'
+        framework?: 'auto' | 'hugo' | 'node'
+        buildCommand?: string
+        outputDir?: string
+        spa?: boolean
+        notFound?: string
+        workingDirectory?: string
+        env?: string
+        envGroups?: string[]
+        pullSecret?: string
+        requireGoogleLogin?: boolean
+        allowedEmails?: string
+        allowedDomains?: string
     }
 
     export type GithubLookupRepoResult = {

--- a/tests/github.spec.js
+++ b/tests/github.spec.js
@@ -446,6 +446,65 @@ test.describe('github workflow page', () => {
 		await expect(main.getByText('Link a repository first')).toBeVisible()
 		await expect(main.locator('.workflow-yaml')).toHaveCount(0)
 	})
+
+	test('pre-fills the generator from the link\'s saved workflow config', async ({ page }) => {
+		const linkWithConfig = {
+			...link,
+			workflowConfig: {
+				name: 'web-prod',
+				location: 'gke',
+				buildType: 'static',
+				framework: 'hugo',
+				buildCommand: 'hugo --minify',
+				outputDir: 'dist',
+				spa: true,
+				notFound: 'not-found.html',
+				workingDirectory: 'site',
+				env: 'NODE_ENV=production',
+				envGroups: [],
+				requireGoogleLogin: true,
+				allowedEmails: 'owner@acme.io',
+				allowedDomains: 'acme.io'
+			}
+		}
+		await mocks({ 'github.list': { ok: true, result: { items: [linkWithConfig] } } })
+
+		await page.goto('/github/workflow?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		// The saved settings pre-fill instead of the defaults, so the user edits
+		// their current workflow rather than starting over.
+		await expect(main.locator('#gen-name')).toHaveValue('web-prod')
+		const yaml = main.locator('.workflow-yaml')
+		await expect(yaml).toContainText('mode: static')
+		await expect(yaml).toContainText('framework: hugo')
+		await expect(yaml).toContainText('outputDir: dist')
+	})
+
+	test('saves the workflow config when opening it on GitHub', async ({ page, context }) => {
+		await mocks({ 'github.setWorkflowConfig': { ok: true, result: {} } })
+		// The Create/Edit links open github.com in a new tab — block that so the
+		// test never hits the network, and close the popup it spawns.
+		await context.route('https://github.com/**', (r) => r.abort())
+		page.on('popup', (p) => { p.close().catch(() => {}) })
+
+		await page.goto('/github/workflow?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await main.locator('#gen-name').fill('api')
+
+		await main.getByRole('link', { name: 'Create on GitHub' }).click()
+
+		// Clicking persists the current generator inputs via github.setWorkflowConfig.
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/github.setWorkflowConfig')
+		}).toBe(true)
+
+		const req = (await getRequestLog()).find((r) => r.path === '/github.setWorkflowConfig')
+		const body = JSON.parse(req?.body ?? '{}')
+		expect(body.repositoryId).toBe(812345678)
+		expect(body.workflowConfig.name).toBe('api')
+	})
 })
 
 test.describe('github link page', () => {


### PR DESCRIPTION
## What

Phase **2c of 3** (final) of "let users edit their current GitHub workflow from the console". The workflow generator now **pre-fills** a user's last-saved build settings instead of always starting from defaults, and **saves** them when the user pushes the workflow to GitHub.

## Changes

- **Pre-fill**: on load (and when switching the selected repository), seed the generator from the link's `workflowConfig` (returned by `github.list`). Repos with no saved config keep today's defaults — a never-saved link reads back as absent, so nothing is clobbered.
- **Save**: clicking **Create on GitHub** / **Edit on GitHub** persists the current generator inputs via `github.setWorkflowConfig` (fire-and-forget — it never blocks opening GitHub, and ignores failures such as a missing `github.update` permission).
- `Api.GitHubWorkflowConfig` type + `GithubLink.workflowConfig`.
- Mock: `acme/web` carries a saved config so pre-fill is exercisable offline; added the `github.setWorkflowConfig` handler.

## Verification

- `bun lint` — 0 errors
- `bun check` — 0 errors
- `bun test tests/github.spec.js` — 36 passed (added: pre-fill from saved config; save-on-click posts `github.setWorkflowConfig`)
- Before/after below.

### Screenshots

| Before (defaults) | After (pre-filled from saved config) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/225-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/225-after.png) |

Before: the generator opens with defaults (port 8080, http, empty env, login off). After: it pre-fills the link's saved config — port 3000, h2c, root folder `app`, env vars, the `shared` env group, and Require Google login with allow-lists.

## Dependency

Needs **apiserver#131** (Phase 2b — `github.setWorkflowConfig` + the `workflow_config` column) deployed to function end-to-end. Degrades gracefully without it: the save call no-ops and there's no saved config to pre-fill. Pins to the merged api#67 contract. Merge after apiserver#131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
