### PR TITLE
feat(auth): OAuth 2.1 PKCE + secretless local sign-in

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,9 @@
 API_ENDPOINT=https://api.deploys.app
+# `localhost` is a public OAuth client (PKCE, no secret) for local development —
+# leave OAUTH2_CLIENT_SECRET empty. Real sign-in logs you in as your own Google
+# account against auth.deploys.app. For pure UI work, `bun dev:mock` skips auth
+# entirely. See the README "Developing" section.
 OAUTH2_CLIENT_ID=localhost
-OAUTH2_CLIENT_SECRET=localhost
+OAUTH2_CLIENT_SECRET=
 PUBLIC_API_ENDPOINT=https://api.deploys.app
 PUBLIC_SENTRY_DSN=

--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@ bun dev
 bun dev --open
 ```
 
+### Auth for local development — no secret required
+
+You can run the console locally and sign in **without any client secret**:
+
+- **Pure UI work (no sign-in at all):** `bun dev:mock` runs against static
+  fixtures and skips authentication entirely — no login, no backend, no client.
+- **Real sign-in (your own account):** plain `bun dev` uses the `localhost`
+  OAuth client, which is a **public** client (PKCE, no secret). The default
+  `.env` ships `OAUTH2_CLIENT_ID=localhost` with an empty `OAUTH2_CLIENT_SECRET`;
+  sign-in goes through `auth.deploys.app` and logs you in as your own Google
+  account (you only see your own resources). The authorization code is bound to
+  your browser with PKCE, so no secret is needed.
+
+The production deployment configures a confidential client (its own
+`OAUTH2_CLIENT_SECRET`); when that variable is set the console sends it at the
+token exchange, otherwise it falls back to PKCE-only.
+
 ## Building
 
 To create a production build:

--- a/src/routes/auth/callback/+server.js
+++ b/src/routes/auth/callback/+server.js
@@ -25,15 +25,22 @@ export async function GET ({ cookies, url }) {
 	})
 
 	// exchange token
+	const body = new URLSearchParams({
+		grant_type: 'authorization_code',
+		code,
+		client_id: env.OAUTH2_CLIENT_ID,
+		code_verifier: codeVerifier
+	})
+	// Confidential clients (e.g. production) authenticate with a secret; public
+	// clients — local/contributor setups with no secret — rely on PKCE alone, so
+	// only send client_secret when one is configured.
+	if (env.OAUTH2_CLIENT_SECRET) {
+		body.set('client_secret', env.OAUTH2_CLIENT_SECRET)
+	}
+
 	const resp = await fetch(`${authEndpoint}/token`, {
 		method: 'POST',
-		body: new URLSearchParams({
-			grant_type: 'authorization_code',
-			code,
-			client_id: env.OAUTH2_CLIENT_ID,
-			client_secret: env.OAUTH2_CLIENT_SECRET,
-			code_verifier: codeVerifier
-		}),
+		body,
 		headers: {
 			'content-type': 'application/x-www-form-urlencoded'
 		}

--- a/src/routes/auth/callback/+server.js
+++ b/src/routes/auth/callback/+server.js
@@ -12,6 +12,18 @@ export async function GET ({ cookies, url }) {
 		return new Response('invalid state', { status: 400 })
 	}
 
+	// PKCE: replay the verifier minted at /auth/signin so auth can bind this code
+	// to the client that started the flow (it stays a confidential exchange — the
+	// client_secret is still sent). Clear it up front so it's dropped on every
+	// exit path — success, a non-2xx /token relay, or a throw — not just success.
+	const codeVerifier = cookies.get('code_verifier') ?? ''
+	cookies.delete('code_verifier', {
+		httpOnly: true,
+		sameSite: 'lax',
+		path: '/',
+		secure: import.meta.env.PROD
+	})
+
 	// exchange token
 	const resp = await fetch(`${authEndpoint}/token`, {
 		method: 'POST',
@@ -19,7 +31,8 @@ export async function GET ({ cookies, url }) {
 			grant_type: 'authorization_code',
 			code,
 			client_id: env.OAUTH2_CLIENT_ID,
-			client_secret: env.OAUTH2_CLIENT_SECRET
+			client_secret: env.OAUTH2_CLIENT_SECRET,
+			code_verifier: codeVerifier
 		}),
 		headers: {
 			'content-type': 'application/x-www-form-urlencoded'
@@ -29,7 +42,9 @@ export async function GET ({ cookies, url }) {
 		return resp
 	}
 	const respBody = await resp.json()
-	const token = respBody.refresh_token
+	// OAuth 2.1 returns the bearer as access_token; refresh_token is the legacy
+	// alias auth still sets, kept as a fallback during the rollout.
+	const token = respBody.access_token || respBody.refresh_token
 	if (!token) {
 		return new Response('unknown error', { status: 500 })
 	}

--- a/src/routes/auth/signin/+server.js
+++ b/src/routes/auth/signin/+server.js
@@ -15,9 +15,51 @@ function randomState () {
 	return Array.from(x, (d) => d.toString(16).padStart(2, '0')).join('')
 }
 
+/**
+ * base64url encodes bytes without padding (RFC 4648 §5) — the encoding PKCE uses.
+ * @param {Uint8Array} bytes
+ * @returns {string}
+ */
+function base64url (bytes) {
+	let s = ''
+	for (const b of bytes) {
+		s += String.fromCharCode(b)
+	}
+	return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/**
+ * randomCodeVerifier returns a high-entropy PKCE code_verifier (RFC 7636):
+ * base64url of 32 random bytes (43 chars, within the 43–128 range).
+ * @returns {string}
+ */
+function randomCodeVerifier () {
+	const x = new Uint8Array(32)
+	webcrypto.getRandomValues(x)
+	return base64url(x)
+}
+
+/**
+ * codeChallengeS256 derives the S256 PKCE code_challenge from a verifier:
+ * base64url(SHA-256(verifier)), no padding (RFC 7636 §4.2). auth verifies this
+ * at /token against the code_verifier we present in the callback.
+ * @param {string} verifier
+ * @returns {Promise<string>}
+ */
+async function codeChallengeS256 (verifier) {
+	const digest = await webcrypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier))
+	return base64url(new Uint8Array(digest))
+}
+
 /** @type {import('@sveltejs/kit').RequestHandler} */
 export async function GET ({ cookies, url }) {
 	const state = randomState()
+
+	// PKCE (OAuth 2.1): console stays a confidential client (it still sends its
+	// client_secret at /token), but we add a code_challenge so an intercepted
+	// authorization code can't be redeemed without the verifier held here.
+	const codeVerifier = randomCodeVerifier()
+	const codeChallenge = await codeChallengeS256(codeVerifier)
 
 	const callback = new URL(url.toString())
 	callback.pathname = '/auth/callback'
@@ -30,8 +72,20 @@ export async function GET ({ cookies, url }) {
 	q.set('client_id', env.OAUTH2_CLIENT_ID)
 	q.set('redirect_uri', callback.toString())
 	q.set('state', state)
+	q.set('code_challenge', codeChallenge)
+	q.set('code_challenge_method', 'S256')
 
 	cookies.set('state', state, {
+		httpOnly: true,
+		maxAge: 60 * 60,
+		sameSite: 'lax',
+		path: '/',
+		secure: import.meta.env.PROD
+	})
+
+	// The verifier never leaves us; it is replayed to /token in the callback to
+	// prove this is the same client that started the flow.
+	cookies.set('code_verifier', codeVerifier, {
 		httpOnly: true,
 		maxAge: 60 * 60,
 		sameSite: 'lax',


### PR DESCRIPTION
## What

Two related auth improvements for the console:

1. **Add PKCE** to console's OAuth flow against `auth.deploys.app` (OAuth 2.1).
2. **Make the client secret optional**, so open-source contributors can run the console locally and sign in **without any secret** — the `localhost` dev client becomes a public (PKCE-only) client.

Console **stays confidential in production** (it still sends `OAUTH2_CLIENT_SECRET` when set); PKCE is added on top as defense-in-depth, and is also what authenticates a secretless public client locally.

## Changes (console-only)

- **`/auth/signin`** — generate a PKCE `code_verifier` (32 random bytes → base64url), send `code_challenge=base64url(SHA-256(verifier))` + `code_challenge_method=S256`, stash the verifier in an httpOnly cookie.
- **`/auth/callback`** — replay `code_verifier` to `/token`; **only send `client_secret` when one is configured** (confidential in prod, PKCE-only locally); read `access_token` (fallback `refresh_token`); clear the verifier cookie up front (all exit paths).
- **`.env`** — ship the `localhost` client with an **empty** secret (it's a public client). Removes the committed `client_secret` from the open-source repo.
- **README** — document the two zero-secret local-dev paths: `bun dev:mock` (no auth at all, for UI work) and `bun dev` (real sign-in as your own Google account via the public `localhost` client).

## Why no auth-service code change

`auth.deploys.app` already (a) verifies PKCE whenever a code was issued with a challenge — for confidential clients too — and (b) authenticates public clients (`token_endpoint_auth_method='none'`) via PKCE with no secret. Its S256 matches console's exactly.

## ⚠️ Operator action required (auth data, not code)

For secretless local sign-in to work, the **`localhost` row in auth's `oauth2_clients`** must be a public client:
- `token_endpoint_auth_method = 'none'`
- `redirect_uris` including a loopback callback (e.g. `http://localhost/auth/callback`; auth already allows any loopback port per RFC 8252).

Production's own confidential client is unaffected.

## Rollout & verification

- Backward-compatible both directions (auth skips PKCE when no challenge was stored; a confidential client still works with its secret).
- Crypto APIs (`crypto.getRandomValues`, `crypto.subtle.digest`, `TextEncoder`, `btoa`) work on both the Cloudflare Workers and Node adapters — no `Buffer`.
- `bun lint` ✅, `bun check` ✅ (0 errors / 0 warnings, 714 files).
- Adversarial review of the PKCE change: **go** (its one hygiene nit — clear the verifier on the error path — is fixed here).

No user-visible UI change (server endpoints only), so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)