### PR TITLE
feat(deployment): mark the Access feature as Preview

### DIFF
--- a/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
@@ -958,7 +958,10 @@
 
 		{#if ['WebService', 'Static'].includes(form.type)}
 			<div class="form-section">
-				<h6 class="form-section-title">Access</h6>
+				<h6 class="form-section-title inline-flex items-center gap-2">
+					Access
+					<span class="preview-badge">Preview</span>
+				</h6>
 				<span class="form-section-hint">Restrict who can reach this deployment over the web.</span>
 			</div>
 			<div class="field">

--- a/src/routes/(auth)/Sidebar.svelte
+++ b/src/routes/(auth)/Sidebar.svelte
@@ -92,19 +92,6 @@
 		gap: 0.4rem;
 	}
 
-	/* Marks a feature that's still in preview. */
-	.preview-badge {
-		padding: 0.0625rem 0.375rem;
-		font-size: 0.625rem;
-		font-weight: 600;
-		letter-spacing: 0.04em;
-		text-transform: uppercase;
-		line-height: 1.4;
-		border-radius: 9999px;
-		color: hsl(var(--hsl-primary));
-		background-color: hsl(var(--hsl-primary) / 0.12);
-	}
-
 	.section-caption {
 		font-size: 0.6875rem;
 		letter-spacing: 0.12em;

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -406,6 +406,19 @@
 		color: hsl(var(--hsl-content) / 0.6);
 	}
 
+	/* Small pill that marks a feature still in preview (sidebar nav, section titles). */
+	.preview-badge {
+		padding: 0.0625rem 0.375rem;
+		font-size: 0.625rem;
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		line-height: 1.4;
+		border-radius: 9999px;
+		color: hsl(var(--hsl-primary));
+		background-color: hsl(var(--hsl-primary) / 0.12);
+	}
+
 	/* Centered empty state for panels (tables use the NoDataRow component). */
 	.empty-state {
 		display: flex;


### PR DESCRIPTION
Adds a **Preview** badge next to the **Access** section title on the deploy page, signalling that deployment access control is still in preview.

## Changes
- `deployment/deploy/+page.svelte` — render a `Preview` pill in the Access section title.
- `app.css` — promote `.preview-badge` to a shared `@layer components` class (token-based primary pill that auto-adapts to light/dark).
- `Sidebar.svelte` — drop the now-redundant scoped `.preview-badge` definition; the sidebar nav badges now use the shared class. One definition instead of two.

## Access section — before / after
| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/229-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/229-after.png) |

## Dark mode
![after dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/229-after-dark.png)

## Verification
- `bun run lint` → 0 errors; `bun run check` → 0 errors / 0 warnings.
- Rendered locally via `bun dev:mock` + Playwright; confirmed the sidebar nav PREVIEW badges are unchanged after the refactor (computed style identical: primary color, 9999px radius, uppercase, weight 600).