### PR TITLE
fix(auth): send redirect_uri at the token exchange

### DIFF
--- a/src/routes/auth/callback/+server.js
+++ b/src/routes/auth/callback/+server.js
@@ -13,9 +13,9 @@ export async function GET ({ cookies, url }) {
 	}
 
 	// PKCE: replay the verifier minted at /auth/signin so auth can bind this code
-	// to the client that started the flow (it stays a confidential exchange — the
-	// client_secret is still sent). Clear it up front so it's dropped on every
-	// exit path — success, a non-2xx /token relay, or a throw — not just success.
+	// to the client that started the flow. Clear it up front so it's dropped on
+	// every exit path — success, a non-2xx /token relay, or a throw — not just
+	// success.
 	const codeVerifier = cookies.get('code_verifier') ?? ''
 	cookies.delete('code_verifier', {
 		httpOnly: true,
@@ -24,11 +24,20 @@ export async function GET ({ cookies, url }) {
 		secure: import.meta.env.PROD
 	})
 
+	// Rebuild the exact redirect_uri sent at /auth/signin (same origin, /auth/
+	// callback, no query). RFC 6749 §4.1.3 requires it to be present and identical
+	// at the token exchange, and auth enforces the match for public (secretless)
+	// clients — omitting it fails with invalid_grant "redirect_uri mismatch".
+	const callback = new URL(url.toString())
+	callback.pathname = '/auth/callback'
+	callback.search = ''
+
 	// exchange token
 	const body = new URLSearchParams({
 		grant_type: 'authorization_code',
 		code,
 		client_id: env.OAUTH2_CLIENT_ID,
+		redirect_uri: callback.toString(),
 		code_verifier: codeVerifier
 	})
 	// Confidential clients (e.g. production) authenticate with a secret; public


### PR DESCRIPTION
## Bug

A public (secretless) console — local dev with the `localhost` public client, or a **PR-preview deploy** — failed sign-in at the callback with:

```json
{"error":"invalid_grant","error_description":"redirect_uri mismatch"}
```

## Root cause

`/auth/callback` posts to auth's `/token` with `grant_type`, `code`, `client_id`, `code_verifier` (and `client_secret` only when set) — but **never `redirect_uri`**. auth's `TokenHandler` requires `redirect_uri` at the token step to equal the one bound to the code at authorize, **for public clients** (RFC 6749 §4.1.3):

```go
if oauth2Client.IsPublic() && oauth2Code.RedirectURI != "" {
    if r.PostFormValue("redirect_uri") != oauth2Code.RedirectURI { // "" != stored
        oauthError(w, 400, "invalid_grant", "redirect_uri mismatch")
    }
}
```

So `""` (console sent nothing) `!=` the stored value → mismatch. Confidential clients (production, with a secret) are unaffected — auth skips the check for them — which is exactly why this only showed up on the public path.

## Fix

Rebuild the same `redirect_uri` the signin step sent (`<origin>/auth/callback`, no query — the identical `new URL(url.toString())` + `pathname`/`search` reconstruction signin uses) and include it in the `/token` body. Harmless for confidential clients (auth ignores it there) and standard OAuth regardless.

`bun lint` ✅, `bun check` ✅ (0/0). Server-only change, no UI → no screenshots.