### PR TITLE
deployment list: show DELETING pill and auto-reload pending rows

### DIFF
--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -259,6 +259,12 @@ const deployments = [
 		address: '',
 		status: 'pending',
 		allocatedPrice: 60
+	},
+	{
+		...deployment('acme'),
+		name: 'web-old',
+		status: 'pending',
+		action: 'delete'
 	}
 ]
 

--- a/src/routes/(auth)/(project)/deployment/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/+page.svelte
@@ -4,12 +4,33 @@
 	import * as format from '$lib/format'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import api from '$lib/api'
+	import { onMount } from 'svelte'
 
 	const { data } = $props()
 
 	const project = $derived(data.project)
 	const deployments = $derived(data.deployments)
 	const error = $derived(data.error)
+
+	// A deploy/delete/pause that's still settling reports `status: 'pending'`, so
+	// the list snapshot goes stale the moment one is in flight (e.g. a row stuck
+	// on "Deleting" until a manual refresh). Poll while any row has pending work
+	// so the table converges on its own; once everything's resolved we stop
+	// re-fetching, with a 2-minute floor as a catch-all for slower drift.
+	const hasPendingAction = $derived(
+		deployments.some((it) => it.status === 'pending' || it.action === 'delete')
+	)
+
+	let lastReload = Date.now()
+
+	onMount(() => api.intervalInvalidate(async () => {
+		if (!hasPendingAction && Date.now() - lastReload < 120000) {
+			return
+		}
+		await api.invalidate('deployment.list')
+		lastReload = Date.now()
+	}, 4000))
 
 	// Per-type glyph + label for the chip on each row's meta line.
 	const typeMeta = {
@@ -23,12 +44,19 @@
 	/**
 	 * Static status label for the pill next to the name. A healthy running
 	 * deployment returns null so its row stays clean — only noteworthy states
-	 * (paused / deploying / failed / cancelled) get a labelled pill, mirroring
-	 * the live icon to its left.
+	 * (deleting / paused / deploying / failed / cancelled) get a labelled pill,
+	 * mirroring the live icon to its left.
+	 *
+	 * A pending delete reuses the same `status: 'pending'` as a fresh deploy, so
+	 * the action has to be checked first — otherwise a deployment being torn down
+	 * would mislabel as "Deploying".
 	 * @param {Api.Deployment} it
 	 * @returns {{ label: string, tone: string } | null}
 	 */
 	function statusPill (it) {
+		if (it.action === 'delete') {
+			return { label: 'Deleting', tone: 'negative' }
+		}
 		if (it.action === 'pause') {
 			return { label: 'Paused', tone: 'warning' }
 		}


### PR DESCRIPTION
## Problem

Two bugs in the **Deployments** list table:

1. **A deployment being deleted showed the `DEPLOYING` pill instead of `DELETING`.** A pending delete reports `action: 'delete'` with `status: 'pending'` — the same status a fresh deploy uses — so `statusPill()` fell through to the `pending → "Deploying"` branch and mislabeled it.
2. **The list never auto-refreshed while an action was in flight.** A delete/deploy stayed stale until a manual page reload.

## Fix

- `statusPill()` now checks `action === 'delete'` first and returns a negative-tone **Deleting** pill, mirroring how the `pause` action is already special-cased ahead of the status switch.
- Added the same interval-invalidate polling the deployment **detail** layout already uses: re-fetch `deployment.list` every 4s while any row has pending work (`status === 'pending'` or `action === 'delete'`), then quiesce once everything settles, with a 2-minute keepalive floor for out-of-band changes. Timer is cleared on navigate-away via the `onMount` disposer.
- Added a `delete`-action sample (`web-old`) to the dev mock so the new state is visible in `bun dev:mock`. This only touches `src/lib/server/mock.js` (dev mock); the Playwright e2e suite uses its own `tests/fixtures/mocks.js`, so test counts are unaffected.

## Verification

- `bun lint` and `bun check` both pass with zero errors.
- Rendered the list in `bun dev:mock`: `web-old` shows a red **DELETING** pill while `worker` still shows **DEPLOYING** (`pending` deploy).

| Light | Dark |
| --- | --- |
| ![light](https://raw.githubusercontent.com/deploys-app/console/screenshots/232-light.png) | ![dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/232-dark.png) |