### PR TITLE
fix(project-metrics): reload charts when active project changes

### DIFF
--- a/src/lib/components/ProjectMetrics.svelte
+++ b/src/lib/components/ProjectMetrics.svelte
@@ -1,6 +1,7 @@
 <script>
-	import { onMount, tick } from 'svelte'
+	import { tick, untrack } from 'svelte'
 	import { page } from '$app/stores'
+	import { replaceState } from '$app/navigation'
 	import api from '$lib/api'
 	import Chart from '$lib/components/Chart.svelte'
 	import Select from '$lib/components/Select.svelte'
@@ -35,8 +36,11 @@
 	let storage = $state([])
 
 	async function fetchMetrics (clear = false) {
+		// `range` is read untracked so the project-keyed effect below isn't also
+		// triggered by range changes — those refresh via the Select's onchange.
+		const range = untrack(() => filter.range)
 		/** @type {Api.Response<Api.ProjectMetricsResult>} */
-		const resp = await api.invoke('project.metrics', { project, timeRange: filter.range }, fetch)
+		const resp = await api.invoke('project.metrics', { project, timeRange: range }, fetch)
 		if (!resp.ok) {
 			return
 		}
@@ -59,8 +63,23 @@
 		storage = [{ prefix: 'Storage', lines: resp.result.staticStorage ?? [] }]
 	}
 
-	onMount(() => {
-		fetchMetrics()
+	// Persist the selected range in the URL so it survives reloads and is
+	// shareable, then refetch. Mirrors the cache/WAF metrics pages.
+	function selectRange () {
+		const u = new URL($page.url)
+		u.searchParams.set('range', filter.range)
+		replaceState(u, {})
+		fetchMetrics(true)
+	}
+
+	// Re-fetch whenever the active project changes. This component is reused
+	// across project switches — same route, new `?project=` — so `onMount`
+	// won't fire again. `fetchMetrics` reads `project` synchronously when
+	// building the request, so the effect tracks it and re-runs on a project
+	// switch; `range` is read untracked, so it doesn't double-fetch alongside
+	// the Select's onchange.
+	$effect(() => {
+		fetchMetrics(true)
 	})
 </script>
 
@@ -68,7 +87,7 @@
 	<Select
 		bind:value={filter.range}
 		options={rangeOptions}
-		onchange={() => fetchMetrics(true)} />
+		onchange={selectRange} />
 </div>
 
 <div class="grid gap-4 mt-4 lg:grid-cols-2">

--- a/src/lib/components/ProjectMetrics.svelte
+++ b/src/lib/components/ProjectMetrics.svelte
@@ -19,6 +19,7 @@
 	const { project } = $props()
 
 	const rangeOptions = [
+		{ value: '1d', label: '1 Day' },
 		{ value: '7d', label: '7 Days' },
 		{ value: '30d', label: '30 Days' },
 		{ value: '90d', label: '90 Days' }


### PR DESCRIPTION
## Problem

The project `/metrics` view (`ProjectMetrics.svelte`) did **not** reload its charts when you switched the active project — it kept showing the previous project's CPU/memory/egress/replica/disk/static-storage data.

This is the same class of bug as console#233 (which fixed the Dropbox/Registry `UsageMetrics` view), applied here to the project-level metrics page.

## Root cause

`ProjectMetrics` fetched only in `onMount`. Switching project from `/metrics` navigates to the **same route** with a new `?project=` — `ModalSelectProject.setProject` redirects to `$page.data.overrideRedirect`, and `metrics/+layout.js` sets `overrideRedirect: '/metrics'`. SvelteKit therefore **reuses the existing component instance**: `load()` re-runs and the `project` prop updates, but `onMount` never fires again, so `fetchMetrics()` is never re-invoked.

This is why console#233 left the deployment/cache/WAF/disk metrics pages untouched — their `overrideRedirect` points at a *list* page, so the metrics component unmounts on a project switch and `onMount` fires fresh. The project-level `/metrics` page redirects to itself, so it reuses the instance and reproduces the bug.

## Fix

Mirror console#233 — drive the fetch from a `$effect` instead of `onMount`:

- `fetchMetrics(true)` reads `project` synchronously when building the request, so the effect tracks it and re-runs on a project switch.
- `filter.range` is read via `untrack(...)`, so a range change doesn't also re-trigger the effect (still handled by the Select's `onchange` → `selectRange`, which also persists the range in the URL) — no double-fetch.
- `clear = true` blanks the charts before repopulating, avoiding a flash of the prior project's data.

## Also: "1 Day" range option

Adds a **1 Day** choice to the range selector (alongside 7/30/90 Days).

`project.metrics` validates `timeRange` server-side against `UsageMetricsTimeRange` ({7d,30d,90d}), so this option requires backend support to function. Cross-repo dependency:

- **deploys-app/api#72** — adds `1d` to `validUsageMetricsTimeRange` + `Days()==1`.
- **deploys-app/apiserver#135** — bumps the api dependency.

Until both land, selecting "1 Day" returns `timeRange invalid` and the charts stay blank. Note `project.metrics` is daily-aggregated, so a 1-day window is an intentionally small (~1-point) chart.

## Verification

- `bun lint` — clean
- `bun check` — 0 errors

## Screenshots

The reload fix is behavioral (charts visually identical; only the underlying per-project data differs across a switch) — as with console#233, a static before/after can't convey "stale vs. reloaded data", so none is attached. The "1 Day" change adds a single `<Select>` option and can't render meaningfully until the api/apiserver PRs land. Happy to capture a populated walkthrough once the backend is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)