### PR TITLE
revert(project-metrics): remove 1 Day range option

### DIFF
--- a/src/lib/components/ProjectMetrics.svelte
+++ b/src/lib/components/ProjectMetrics.svelte
@@ -19,7 +19,6 @@
 	const { project } = $props()
 
 	const rangeOptions = [
-		{ value: '1d', label: '1 Day' },
 		{ value: '7d', label: '7 Days' },
 		{ value: '30d', label: '30 Days' },
 		{ value: '90d', label: '90 Days' }


### PR DESCRIPTION
## What

Removes the **1 Day** choice from the project `/metrics` range selector (added in #234), restoring the 7 / 30 / 90 Days options.

## Why

`project.metrics` is daily-aggregated (one point per day), so a 1-day window rendered an unhelpful ~1-point chart.

## Scope

- Surgical removal of the single `rangeOptions` entry — the project-reload `$effect` fix from #234 is untouched.
- The backend still accepts `"1d"` as a `UsageMetricsTimeRange` (deploys-app/api#72, deploys-app/apiserver#135), but nothing sends it now. Left in place as harmless, unused capability rather than churning two more repos; can be reverted on request.

## Verification

- `bun lint` — clean
- `bun check` — 0 errors

## Screenshots

Removes one `<Select>` option; no other visual or layout change. The chart panels are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)