### PR TITLE
feat(dashboard): add Static Storage card to the billing widget

### DIFF
--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -1009,7 +1009,8 @@ const handlers = {
 		registryEgress: 268435456,
 		dropboxEgress: 134217728,
 		disk: 10737418240,
-		replica: 4
+		replica: 4,
+		staticStorage: 25769803776
 	}),
 	'project.metrics': () => ok({
 		cpuUsage: dailyMetricLine('cpu_usage', 1.5),

--- a/src/routes/(auth)/(project)/+page.svelte
+++ b/src/routes/(auth)/(project)/+page.svelte
@@ -54,6 +54,17 @@
 		const r = formatStorage(bytes, 's')
 		return `${r.full} ${r.unit}`
 	}
+	// static_storage is a daily byte gauge summed over the month (byte-days), so
+	// its average level divides by elapsed days — not seconds like the
+	// continuously-integrated memory/disk metrics. Floor at 1 day so the first of
+	// the month (one snapshot) reads as that snapshot, not an inflated number.
+	function billingElapsedDays () {
+		return Math.max(billingElapsedSeconds() / 86400, 1)
+	}
+	function rawStorageDayTooltip (bytes) {
+		const r = formatStorage(bytes, 'd')
+		return `${r.full} ${r.unit}`
+	}
 	const projectInfo = $derived(data.projectInfo)
 	const usage = $derived(data.usage)
 	const price = $derived(data.price)
@@ -78,6 +89,13 @@
 			label: 'Disk',
 			...formatStorage(usage.disk / billingElapsedSeconds(), ''),
 			tooltip: rawStorageTooltip(usage.disk)
+		},
+		{
+			key: 'staticStorage',
+			icon: 'fa-folder-tree',
+			label: 'Static Storage',
+			...formatStorage(usage.staticStorage / billingElapsedDays(), ''),
+			tooltip: rawStorageDayTooltip(usage.staticStorage)
 		},
 		{
 			key: 'egress',

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -66,6 +66,7 @@ declare namespace Api {
         dropboxEgress: number
         disk: number
         replica: number
+        staticStorage: number
     }
 
     export type BillingProject = {


### PR DESCRIPTION
## What

Adds a **Static Storage** card to the project dashboard's Billing widget, next to Disk.

It reads `project.usage.staticStorage` — the project-level static-web storage (the `project_usages` `static_storage` daily byte-gauge that backs the `static_storage` billing SKU) — and shows the **average GiB level** for the month. Because `static_storage` is a daily gauge *summed* over the month (byte-days), the average divides by elapsed **days**, not seconds like the continuously-integrated memory/disk metrics; the card tooltip shows the raw GiB-days total.

## Dependencies

The field is new on `project.usage`:
- deploys-app/api#75 — adds `ProjectUsageResult.StaticStorage` (merged)
- deploys-app/apiserver#139 — populates it from the monthly sum + dep bump

Until apiserver is deployed the card reads `?` (graceful — `formatStorage(NaN)` → `?`). The mock fixture is updated so dev/mock mode shows a real value.

## Screenshots

Dashboard Billing widget (mock data), before vs after:

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/236-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/236-after.png) |

(CPU/Memory/Disk read 0 here only because the mock stores raw bytes, not byte-seconds — pre-existing, unrelated to this change.)

## Verification

- `bun lint` — clean
- `bun check` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
