### PR TITLE
env-group: Update vs Update and redeploy buttons

### DIFF
--- a/src/lib/components/GuardedButton.svelte
+++ b/src/lib/components/GuardedButton.svelte
@@ -4,7 +4,8 @@
 
 	/**
 	 * @typedef {Object} Props
-	 * @property {string} permission  required permission, e.g. 'deployment.deploy'
+	 * @property {string | string[]} permission  required permission(s), e.g. 'deployment.deploy'
+	 *   or ['envgroup.update', 'deployment.deploy']. When an array, ALL are required.
 	 * @property {string} [href]  when set AND allowed, renders an <a> instead of a <button>
 	 * @property {(e: MouseEvent) => void} [onclick]
 	 * @property {'button' | 'submit' | 'reset'} [type]  button type (ignored for <a>); default 'button'
@@ -32,7 +33,11 @@
 	/** @type {{ can: (p: string) => boolean }} */
 	const { can } = getContext('permission')
 
-	const allowed = $derived(can(permission))
+	const required = $derived(Array.isArray(permission) ? permission : [permission])
+	// First permission the caller is missing — drives the deny tooltip so the
+	// user sees exactly which grant is needed.
+	const missing = $derived(required.find((p) => !can(p)))
+	const allowed = $derived(missing === undefined)
 </script>
 
 {#if !allowed}
@@ -43,7 +48,7 @@
 		hover — a bare disabled button does not fire hover tooltips consistently
 		across browsers.
 	-->
-	<span class="inline-flex" title={denyTooltip(permission)}>
+	<span class="inline-flex" title={denyTooltip(missing)}>
 		<button class={klass} type="button" disabled aria-disabled="true" {...rest}>
 			{@render children?.()}
 		</button>

--- a/src/lib/permission.js
+++ b/src/lib/permission.js
@@ -26,9 +26,10 @@ export function hasPermission (permissions, admin, permission) {
 
 /**
  * Default tooltip shown on a denied action control.
- * @param {string} permission  the missing permission, e.g. 'deployment.deploy'
+ * @param {string | undefined} permission  the missing permission, e.g. 'deployment.deploy'
  * @returns {string}
  */
 export function denyTooltip (permission) {
+	if (!permission) return 'You don\'t have permission to do this.'
 	return `You don't have permission to do this (requires ${permission}).`
 }

--- a/src/routes/(auth)/(project)/env-group/create/+page.svelte
+++ b/src/routes/(auth)/(project)/env-group/create/+page.svelte
@@ -33,16 +33,17 @@
 	}
 
 	let saving = $state(false)
-
-	// The submit RPC depends on whether we're editing an existing env group
-	// (envGroup.update) or creating a new one (envGroup.create); gate on the one
-	// the save handler will actually call.
-	const savePermission = $derived(envGroup ? 'envgroup.update' : 'envgroup.create')
+	// Which save button is in flight, so only that one shows the spinner:
+	// 'redeploy' (Update and redeploy), 'update' (Update, no redeploy), or
+	// 'create'. Empty when idle.
+	let savingAction = $state('')
 
 	/**
 	 * @param {Event} e
+	 * @param {boolean} [redeploy]  on update, whether to redeploy the deployments
+	 *   that reference this group so they pick up the new values. Ignored on create.
 	 */
-	async function save (e) {
+	async function save (e, redeploy = true) {
 		e.preventDefault()
 
 		if (saving) {
@@ -50,6 +51,7 @@
 		}
 
 		saving = true
+		savingAction = envGroup ? (redeploy ? 'redeploy' : 'update') : 'create'
 		try {
 			const env = form.env.reduce((p, x) => {
 				if (x.k) p[x.k] = x.v
@@ -57,11 +59,11 @@
 			}, {})
 
 			const fn = envGroup ? 'envgroup.update' : 'envgroup.create'
-			const resp = await api.invoke(fn, {
-				project,
-				name: form.name,
-				env
-			}, fetch)
+			const args = { project, name: form.name, env }
+			if (envGroup) {
+				args.redeploy = redeploy
+			}
+			const resp = await api.invoke(fn, args, fetch)
 			if (!resp.ok) {
 				modal.error({ error: resp.error })
 				return
@@ -69,6 +71,7 @@
 			await goto(`/env-group?project=${project}`)
 		} finally {
 			saving = false
+			savingAction = ''
 		}
 	}
 
@@ -105,7 +108,7 @@
 </div>
 
 <div class="panel is-level-300 grid gap-4">
-	<form class="grid gap-4 w-full" onsubmit={save}>
+	<form class="grid gap-4 w-full" onsubmit={(e) => save(e, true)}>
 		<div class="field">
 			<label for="input-name">Name</label>
 			<div class="input">
@@ -178,10 +181,26 @@
 
 		<hr>
 
-		<div class="flex gap-4">
-			<GuardedButton permission={savePermission} type="submit" class="button" loading={saving}>
-				{#if envGroup}Update{:else}Create{/if}
-			</GuardedButton>
+		<div class="flex gap-4 items-center flex-wrap">
+			{#if envGroup}
+				<GuardedButton permission={['envgroup.update', 'deployment.deploy']} type="submit" class="button"
+					loading={saving && savingAction === 'redeploy'} disabled={saving}>
+					Update and redeploy
+				</GuardedButton>
+				<GuardedButton permission="envgroup.update" type="button" class="button is-variant-secondary"
+					loading={saving && savingAction === 'update'} disabled={saving}
+					onclick={(e) => save(e, false)}>
+					Update
+				</GuardedButton>
+				<p class="text-content/50 text-sm">
+					“Update and redeploy” rolls the new values out to deployments that use this group.
+					“Update” saves them without redeploying.
+				</p>
+			{:else}
+				<GuardedButton permission="envgroup.create" type="submit" class="button" loading={saving}>
+					Create
+				</GuardedButton>
+			{/if}
 		</div>
 	</form>
 </div>

--- a/tests/env-group.spec.js
+++ b/tests/env-group.spec.js
@@ -39,7 +39,8 @@ test.describe('env groups', () => {
 		await expect(main.getByRole('textbox', { name: 'Name', exact: true })).toHaveValue('shared-config')
 		await expect(main.locator('input[placeholder="Variable name"]').nth(0)).toHaveValue('LOG_LEVEL')
 		await expect(main.locator('input[placeholder="Value"]').nth(0)).toHaveValue('info')
-		await expect(main.getByRole('button', { name: 'Update' })).toBeVisible()
+		await expect(main.getByRole('button', { name: 'Update', exact: true })).toBeVisible()
+		await expect(main.getByRole('button', { name: 'Update and redeploy' })).toBeVisible()
 		// Deletion now lives on the env-group detail page, not the edit form.
 		await expect(main.getByRole('button', { name: 'Delete' })).toHaveCount(0)
 		await expect(main.getByRole('link', { name: 'shared-config' })).toHaveAttribute('href', /\/env-group\/detail\?/)


### PR DESCRIPTION
## What

Editing an env group now offers two save actions:

- **Update and redeploy** — `redeploy: true`; rolls the new values out to every deployment that uses the group.
- **Update** — `redeploy: false`; stores the values without redeploying.

Create still shows a single **Create** button (a new group has no referencing deployments).

## Permissions

**Update and redeploy** requires both `envgroup.update` and `deployment.deploy` (the redeploy is a deploy action, enforced server-side). To honor the "a button rendered enabled here is never rejected by the API" invariant, `GuardedButton` now accepts `permission: string | string[]` (ALL required), and its deny tooltip names the first missing grant. All existing single-string callers are unchanged.

A user with only `envgroup.update` sees **Update and redeploy** disabled (tooltip: requires `deployment.deploy`) while **Update** stays enabled.

## Screenshots

| Both permissions | Missing `deployment.deploy` |
| --- | --- |
| ![enabled](https://raw.githubusercontent.com/deploys-app/console/screenshots/237-enabled.png) | ![denied](https://raw.githubusercontent.com/deploys-app/console/screenshots/237-denied.png) |

## Depends on

apiserver behavior in deploys-app/apiserver#141 (api field deploys-app/api#77).

🤖 Generated with [Claude Code](https://claude.com/claude-code)