### PR TITLE
deployment: add Restart action to the detail header

### DIFF
--- a/src/lib/server/mock.js
+++ b/src/lib/server/mock.js
@@ -1119,6 +1119,7 @@ const handlers = {
 	'deployment.delete': () => ok({}),
 	'deployment.pause': () => ok({}),
 	'deployment.resume': () => ok({}),
+	'deployment.restart': () => ok({}),
 	'deployment.rollback': () => ok({}),
 	'deployment.revisions': (args) => {
 		// Static deployment: per-revision release-shas, no image.

--- a/src/routes/(auth)/(project)/deployment/_components/Header.svelte
+++ b/src/routes/(auth)/(project)/deployment/_components/Header.svelte
@@ -29,6 +29,10 @@
 
 	const canPause = $derived(!isStatic && deployment.status === 'success' && deployment.action === 'deploy')
 	const canResume = $derived(!isStatic && deployment.status === 'success' && deployment.action === 'pause')
+	// Restart re-rolls the current revision (recreating the pods). Only meaningful
+	// for a live deployment — same state as pause; the apiserver rejects static,
+	// paused, and mid-deploy.
+	const canRestart = $derived(canPause)
 
 	const statusTone = $derived(
 		deployment.status === 'success' && deployment.action === 'pause'
@@ -63,6 +67,25 @@
 			yes: 'Pause',
 			callback: async () => {
 				const resp = await api.invoke('deployment.pause', {
+					project: deployment.project,
+					location: deployment.location,
+					name: deployment.name
+				}, fetch)
+				if (!resp.ok) {
+					modal.error({ error: resp.error })
+					return
+				}
+				invalidate?.()
+			}
+		})
+	}
+
+	function restart () {
+		modal.confirm({
+			title: `Restart ${deployment.name} in ${deployment.location}? This recreates the pods.`,
+			yes: 'Restart',
+			callback: async () => {
+				const resp = await api.invoke('deployment.restart', {
 					project: deployment.project,
 					location: deployment.location,
 					name: deployment.name
@@ -317,6 +340,13 @@
 			</div>
 		</div>
 		<div class="masthead__actions">
+			{#if canRestart}
+				<span class="inline-flex" title={can('deployment.deploy') ? null : denyTooltip('deployment.deploy')}>
+					<button class="mast-btn" type="button" disabled={!can('deployment.deploy')} aria-disabled={!can('deployment.deploy')} onclick={restart}>
+						<i class="fa-solid fa-rotate-right"></i> Restart
+					</button>
+				</span>
+			{/if}
 			{#if canPause}
 				<span class="inline-flex" title={can('deployment.deploy') ? null : denyTooltip('deployment.deploy')}>
 					<button class="mast-btn" type="button" disabled={!can('deployment.deploy')} aria-disabled={!can('deployment.deploy')} onclick={pause}>

--- a/src/routes/(auth)/(project)/deployment/_components/Header.svelte
+++ b/src/routes/(auth)/(project)/deployment/_components/Header.svelte
@@ -30,9 +30,10 @@
 	const canPause = $derived(!isStatic && deployment.status === 'success' && deployment.action === 'deploy')
 	const canResume = $derived(!isStatic && deployment.status === 'success' && deployment.action === 'pause')
 	// Restart re-rolls the current revision (recreating the pods). Only meaningful
-	// for a live deployment — same state as pause; the apiserver rejects static,
-	// paused, and mid-deploy.
-	const canRestart = $derived(canPause)
+	// for a live deployment that keeps standing pods — so, unlike pause, it also
+	// excludes CronJob (no standing pods; it spawns Jobs on a schedule). The
+	// apiserver rejects static, cronjob, paused, and mid-deploy.
+	const canRestart = $derived(canPause && deployment.type !== 'CronJob')
 
 	const statusTone = $derived(
 		deployment.status === 'success' && deployment.action === 'pause'

--- a/tests/deployment.spec.js
+++ b/tests/deployment.spec.js
@@ -447,6 +447,9 @@ test.describe('deployment detail — non-static keeps pod surface', () => {
 		await expect(main.locator('.spec').filter({ hasText: 'Pull Secret' })).toBeVisible()
 		await expect(main.locator('.spec').filter({ hasText: 'Workload Identity' })).toBeVisible()
 		await expect(main.locator('.spec').filter({ hasText: 'Allocated Price' })).toBeVisible()
+		// A live (success + deploy) non-static deployment offers Restart and Pause.
+		await expect(page.getByRole('button', { name: 'Restart' })).toBeVisible()
+		await expect(page.getByRole('button', { name: 'Pause' })).toBeVisible()
 	})
 })
 


### PR DESCRIPTION
## What

Add a **Restart** button to the deployment masthead (next to Pause), gated on `deployment.deploy`, calling the new `deployment.restart` API to recreate the pods on the current revision.

- Shown only for **live, non-static** deployments (same state condition as Pause: `status=success`, `action=deploy`).
- Confirm dialog notes it recreates the pods.
- Without `deployment.deploy` the button is disabled with a `requires deployment.deploy` tooltip.

## Screenshot

![restart](https://raw.githubusercontent.com/deploys-app/console/screenshots/238-restart.png)

## Depends on

deploys-app/apiserver#143 (api deploys-app/api#78).

🤖 Generated with [Claude Code](https://claude.com/claude-code)