### PR TITLE
chore: migrate lib + server layer to TypeScript (batch 2)

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,7 +1,7 @@
+import type { Handle } from '@sveltejs/kit'
 import { sequence } from '@sveltejs/kit/hooks'
 
-/** @type {import('@sveltejs/kit').Handle} */
-async function theme ({ event, resolve }) {
+const theme: Handle = async ({ event, resolve }) => {
 	// Only force a class for an explicit choice. With no cookie the default is
 	// the OS preference, which is unknown server-side — the inline script in
 	// app.html applies it before first paint.
@@ -11,8 +11,7 @@ async function theme ({ event, resolve }) {
 	})
 }
 
-/** @type {import('@sveltejs/kit').Handle} */
-async function handleCookie ({ event, resolve }) {
+const handleCookie: Handle = async ({ event, resolve }) => {
 	const { cookies, locals } = event
 
 	locals.token = cookies.get('token') || ''
@@ -21,8 +20,7 @@ async function handleCookie ({ event, resolve }) {
 	return resolve(event)
 }
 
-/** @type {import('@sveltejs/kit').Handle} */
-function storeProject ({ event, resolve }) {
+const storeProject: Handle = ({ event, resolve }) => {
 	const { url, locals } = event
 
 	if (url.pathname.startsWith('/api/')) {

--- a/src/lib/cache/overrides.ts
+++ b/src/lib/cache/overrides.ts
@@ -4,38 +4,34 @@
 // Order = match order, with `priority` derived from index on every whole-zone
 // write — first match wins, lower priority first.
 
-/**
- * @typedef {Object} OverrideForm
- * @property {string} id
- * @property {string} description
- * @property {'cache' | 'bypass'} action
- * @property {string} filter
- * @property {string} ttl
- * @property {'conservative' | 'balanced' | 'aggressive'} policy
- * @property {string} staleWhileRevalidate
- * @property {string} staleIfError
- * @property {number[]} status
- * @property {'enforce' | 'shadow'} mode
- */
+export interface OverrideForm {
+	id: string
+	description: string
+	action: 'cache' | 'bypass'
+	filter: string
+	ttl: string
+	policy: 'conservative' | 'balanced' | 'aggressive'
+	staleWhileRevalidate: string
+	staleIfError: string
+	status: number[]
+	mode: 'enforce' | 'shadow'
+}
 
 export const DEFAULT_POLICY = 'balanced'
 export const DEFAULT_TTL = '1h'
 
-/** @type {Record<string, string>} */
-export const actionLabels = {
+export const actionLabels: Record<string, string> = {
 	cache: 'Cache',
 	bypass: 'Bypass'
 }
 
-/** @type {Record<string, string>} */
-export const policyLabels = {
+export const policyLabels: Record<string, string> = {
 	conservative: 'Conservative',
 	balanced: 'Balanced',
 	aggressive: 'Aggressive'
 }
 
-/** @type {Record<string, string>} */
-export const modeLabels = {
+export const modeLabels: Record<string, string> = {
 	enforce: 'Enforce',
 	shadow: 'Shadow'
 }
@@ -43,8 +39,7 @@ export const modeLabels = {
 // TTL presets covering the API's allowed 1s..720h range. Zones loaded with a
 // ttl outside this list still render — the edit page appends the loaded value
 // as an extra option.
-/** @type {{ value: string, label: string }[]} */
-export const ttlOptions = [
+export const ttlOptions: { value: string, label: string }[] = [
 	{ value: '1m', label: '1 minute' },
 	{ value: '5m', label: '5 minutes' },
 	{ value: '1h', label: '1 hour' },
@@ -53,18 +48,14 @@ export const ttlOptions = [
 	{ value: '168h', label: '7 days' }
 ]
 
-/**
- * @param {Api.CacheOverride} [override]
- * @returns {OverrideForm}
- */
-export function overrideForm (override) {
+export function overrideForm (override?: Api.CacheOverride): OverrideForm {
 	return {
 		id: override?.id ?? '',
 		description: override?.description ?? '',
 		action: override?.action ?? 'cache',
 		filter: override?.filter ?? '',
 		ttl: override?.ttl ?? DEFAULT_TTL,
-		policy: /** @type {OverrideForm['policy']} */ (override?.policy ?? DEFAULT_POLICY),
+		policy: (override?.policy ?? DEFAULT_POLICY) as OverrideForm['policy'],
 		staleWhileRevalidate: override?.staleWhileRevalidate ?? '',
 		staleIfError: override?.staleIfError ?? '',
 		status: override?.status ?? [],
@@ -74,10 +65,8 @@ export function overrideForm (override) {
 
 /**
  * Generate a stable, unique override id that doesn't collide with `taken`.
- * @param {string[]} taken
- * @returns {string}
  */
-export function genId (taken) {
+export function genId (taken: string[]): string {
 	let id
 	do {
 		id = 'override-' + Math.random().toString(36).slice(2, 8)
@@ -87,14 +76,9 @@ export function genId (taken) {
 
 // Map API overrides to form rows: order by priority (lower matches first) so
 // the visible order is the match order, and give every row a unique id.
-/**
- * @param {Api.CacheOverride[]} [apiOverrides]
- * @returns {OverrideForm[]}
- */
-export function normalizeOverrides (apiOverrides) {
+export function normalizeOverrides (apiOverrides?: Api.CacheOverride[]): OverrideForm[] {
 	const sorted = [...(apiOverrides ?? [])].sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0))
-	/** @type {string[]} */
-	const taken = []
+	const taken: string[] = []
 	return sorted.map((o) => {
 		const f = overrideForm(o)
 		if (!f.id || taken.includes(f.id)) f.id = genId(taken)
@@ -107,14 +91,9 @@ export function normalizeOverrides (apiOverrides) {
 // the top override matches first. For action 'bypass' the API rejects
 // ttl/policy/status/stale_*, so those are OMITTED; for action 'cache' they
 // are included.
-/**
- * @param {OverrideForm[]} overrides
- * @returns {Api.CacheOverride[]}
- */
-export function toApiOverrides (overrides) {
+export function toApiOverrides (overrides: OverrideForm[]): Api.CacheOverride[] {
 	return overrides.map((o, i) => {
-		/** @type {Api.CacheOverride} */
-		const base = {
+		const base: Api.CacheOverride = {
 			id: o.id,
 			description: o.description,
 			action: o.action,
@@ -127,8 +106,7 @@ export function toApiOverrides (overrides) {
 			// meaningless and rejected by the API, so omit them.
 			return base
 		}
-		/** @type {number[]} */
-		const status = (o.status ?? [])
+		const status: number[] = (o.status ?? [])
 			.map((s) => Number(s))
 			.filter((s) => Number.isInteger(s) && s > 0)
 		return {
@@ -145,10 +123,8 @@ export function toApiOverrides (overrides) {
 /**
  * Human summary of an override for the manage table, e.g. "Cache 1h (balanced)"
  * or "Bypass".
- * @param {OverrideForm} o
- * @returns {string}
  */
-export function describeOverride (o) {
+export function describeOverride (o: OverrideForm): string {
 	if (o.action === 'bypass') return 'Bypass'
 	const policy = policyLabels[o.policy] ?? o.policy
 	return `Cache ${o.ttl} (${(policy ?? '').toLowerCase()})`

--- a/src/lib/charts/util.ts
+++ b/src/lib/charts/util.ts
@@ -9,28 +9,29 @@
 /**
  * A single (x, y) sample. `x` is unix-ms on a time axis, or the category index
  * on a category axis.
- * @typedef {Object} ChartPoint
- * @property {number} x
- * @property {number} y
  */
+export interface ChartPoint {
+	x: number
+	y: number
+}
 
 /**
  * One drawable line for {@link LineChart}.
- * @typedef {Object} LineSeries
- * @property {string} name
- * @property {ChartPoint[]} points
- * @property {string} [color]   CSS color; falls back to the shared palette
- * @property {boolean} [dashed]
- * @property {boolean} [area]   fill a gradient under the line
  */
+export interface LineSeries {
+	name: string
+	points: ChartPoint[]
+	color?: string // CSS color; falls back to the shared palette
+	dashed?: boolean
+	area?: boolean // fill a gradient under the line
+}
 
 /**
  * The default series palette, drawn from the design tokens. Each entry is a CSS
  * color string; setting it via inline `style` (fill/stroke/stop-color) lets the
  * chart recolor instantly when the theme toggles, no re-render needed.
- * @type {string[]}
  */
-export const palette = [
+export const palette: string[] = [
 	'hsl(var(--hsl-primary))',
 	'hsl(var(--hsl-accent))',
 	'hsl(var(--hsl-info))',
@@ -42,10 +43,8 @@ export const palette = [
 /**
  * Round a span up to a "nice" number (1, 2, 5 × 10ⁿ) — the classic axis-tick
  * rounding so gridlines land on readable values.
- * @param {number} range
- * @param {boolean} round  round to nearest nice number vs. ceil
  */
-function niceNum (range, round) {
+function niceNum (range: number, round: boolean): number {
 	const exp = Math.floor(Math.log10(range))
 	const frac = range / Math.pow(10, exp)
 	let nice
@@ -63,12 +62,8 @@ function niceNum (range, round) {
 
 /**
  * Compute a y-axis scale with round tick values covering [min, max].
- * @param {number} min
- * @param {number} max
- * @param {number} [targetTicks]
- * @returns {{ min: number, max: number, ticks: number[] }}
  */
-export function niceScale (min, max, targetTicks = 5) {
+export function niceScale (min: number, max: number, targetTicks = 5): { min: number, max: number, ticks: number[] } {
 	if (!Number.isFinite(min) || !Number.isFinite(max)) {
 		min = 0
 		max = 1
@@ -80,7 +75,7 @@ export function niceScale (min, max, targetTicks = 5) {
 	const step = niceNum((max - min) / Math.max(1, targetTicks - 1), true)
 	const niceMin = Math.floor(min / step) * step
 	const niceMax = Math.ceil(max / step) * step
-	const ticks = []
+	const ticks: number[] = []
 	// Guard against float drift adding a phantom final tick.
 	for (let v = niceMin; v <= niceMax + step * 0.5; v += step) {
 		ticks.push(Math.round(v * 1e6) / 1e6)
@@ -93,16 +88,15 @@ const MIB = KIB * 1024
 const GIB = MIB * 1024
 const TIB = GIB * 1024
 
-/** Trim to at most `digits` decimals, dropping trailing zeros. @param {number} v @param {number} [digits] */
-function trim (v, digits = 2) {
+/** Trim to at most `digits` decimals, dropping trailing zeros. */
+function trim (v: number, digits = 2): string {
 	return Number(v.toFixed(digits)).toString()
 }
 
 /**
  * Binary byte formatting (Ki/Mi/Gi/Ti) for axis labels and tooltips.
- * @param {number} v
  */
-export function formatBytes (v) {
+export function formatBytes (v: number): string {
 	const a = Math.abs(v)
 	if (a >= TIB) return trim(v / TIB) + 'Ti'
 	if (a >= GIB) return trim(v / GIB) + 'Gi'
@@ -113,9 +107,8 @@ export function formatBytes (v) {
 
 /**
  * Compact, locale-aware number for non-byte axes (vCPU-seconds, rps, counts).
- * @param {number} v
  */
-export function formatNumber (v) {
+export function formatNumber (v: number): string {
 	if (!Number.isFinite(v)) return '0'
 	const a = Math.abs(v)
 	if (a >= 1_000_000) return trim(v / 1_000_000) + 'M'
@@ -123,20 +116,17 @@ export function formatNumber (v) {
 	return Number(v.toFixed(2)).toLocaleString()
 }
 
-/**
- * @typedef {Object} Pt
- * @property {number} x  pixel x
- * @property {number} y  pixel y
- */
+interface Pt {
+	x: number // pixel x
+	y: number // pixel y
+}
 
 /**
  * Build an SVG path `d` through the points. With `smooth`, uses a Catmull-Rom
  * spline converted to cubic béziers for organic curves; otherwise straight
  * segments.
- * @param {Pt[]} pts
- * @param {boolean} [smooth]
  */
-export function linePath (pts, smooth = false) {
+export function linePath (pts: Pt[], smooth = false): string {
 	if (pts.length === 0) return ''
 	if (pts.length === 1) return `M${pts[0].x},${pts[0].y}`
 	if (!smooth) {
@@ -160,11 +150,8 @@ export function linePath (pts, smooth = false) {
 /**
  * Build a closed area path: the line across the top, then down to `baseY` and
  * back. Returns '' for fewer than two points (nothing meaningful to fill).
- * @param {Pt[]} pts
- * @param {number} baseY  pixel y of the zero baseline
- * @param {boolean} [smooth]
  */
-export function areaPath (pts, baseY, smooth = false) {
+export function areaPath (pts: Pt[], baseY: number, smooth = false): string {
 	if (pts.length < 2) return ''
 	const top = linePath(pts, smooth)
 	return `${top}L${pts[pts.length - 1].x},${baseY}L${pts[0].x},${baseY}Z`

--- a/src/lib/deployment/podName.ts
+++ b/src/lib/deployment/podName.ts
@@ -7,8 +7,7 @@
 // helpers strip that prefix wherever it appears, leaving just the pod-specific
 // suffix (`<replicaSetHash>-<podHash>`).
 
-/** @param {string} s */
-function escapeRegExp (s) {
+function escapeRegExp (s: string): string {
 	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
@@ -16,13 +15,10 @@ function escapeRegExp (s) {
  * Build a function that strips the deployment's `<kubeName>-<projectID>-` prefix
  * from any text — a bare pod name (logs) or pod references embedded in free-text
  * event messages.
- *
- * @param {{ internalAddress?: string }} [deployment]
- * @returns {(text?: string) => string}
  */
-export function podPrefixStripper (deployment) {
+export function podPrefixStripper (deployment?: { internalAddress?: string }): (text?: string) => string {
 	const addr = (deployment?.internalAddress ?? '').trim()
-	const alts = []
+	const alts: string[] = []
 	// Primary: the exact service name (`<kubeName>-<projectID>`). Guard against
 	// the field ever being an IP or empty by requiring the `<name>-<digits>`
 	// shape so we never build a prefix that matches arbitrary text.

--- a/src/lib/modal/index.ts
+++ b/src/lib/modal/index.ts
@@ -3,28 +3,21 @@ import 'sweetalert2/dist/sweetalert2.min.css'
 
 /**
  * Escape a string for safe interpolation into a SweetAlert `html` body.
- * @param {string} s
- * @returns {string}
  */
-function escapeHtml (s) {
+function escapeHtml (s: string): string {
 	return s.replace(/[&<>"']/g, (c) => (
-		{ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] ?? c
+		({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' } as Record<string, string>)[c] ?? c
 	))
 }
 
-/**
- * @typedef {Object} ModalConfirmOptions
- * @property {string} [title]
- * @property {string} [html]
- * @property {string} [yes]
- * @property {function?} [callback]
- */
+interface ModalConfirmOptions {
+	title?: string
+	html?: string
+	yes?: string
+	callback?: (() => void) | null
+}
 
-/**
- * @param {ModalConfirmOptions} options
- * @returns {Promise<boolean>}
- */
-export async function confirm ({ title, html, yes, callback }) {
+export async function confirm ({ title, html, yes, callback }: ModalConfirmOptions): Promise<boolean> {
 	const result = await Swal.fire({
 		title: 'Are you sure?',
 		text: title,
@@ -49,17 +42,12 @@ export async function confirm ({ title, html, yes, callback }) {
 	return true
 }
 
-/**
- * @typedef {Object} ModalErrorOptions
- * @property {string | Api.Error | unknown} [error]
- * @property {Function} [callback]
- */
+interface ModalErrorOptions {
+	error?: string | Api.Error | unknown
+	callback?: (() => void) | null
+}
 
-/**
- * @param {ModalErrorOptions} options
- * @returns {Promise<void>}
- */
-export async function error ({ error, callback }) {
+export async function error ({ error, callback }: ModalErrorOptions): Promise<void> {
 	if (!error) {
 		callback?.()
 		return
@@ -109,16 +97,11 @@ export async function error ({ error, callback }) {
 	callback?.()
 }
 
-/**
- * @typedef {Object} ModalSuccessOptions
- * @property {string} [content]
- */
+interface ModalSuccessOptions {
+	content?: string
+}
 
-/**
- * @param {ModalSuccessOptions} options
- * @returns {Promise<void>}
- */
-export async function success ({ content }) {
+export async function success ({ content }: ModalSuccessOptions): Promise<void> {
 	await Swal.fire({
 		title: 'Success',
 		text: content,

--- a/src/lib/search/index.ts
+++ b/src/lib/search/index.ts
@@ -3,16 +3,16 @@ import { projectMenu } from '$lib/nav'
 
 /**
  * A single searchable item shown in the command palette.
- *
- * @typedef {Object} SearchEntry
- * @property {string} id        stable key, unique across all entries
- * @property {string} group     section heading, e.g. "Deployments" / "Go to"
- * @property {string} icon      Font Awesome class, e.g. `fa-rocket`
- * @property {string} label     primary text (the thing you'd type)
- * @property {string} [sublabel] secondary text (location, target, …)
- * @property {string} [keywords] extra text folded into search only, never shown
- * @property {string} href      navigation target
  */
+export interface SearchEntry {
+	id: string // stable key, unique across all entries
+	group: string // section heading, e.g. "Deployments" / "Go to"
+	icon: string // Font Awesome class, e.g. `fa-rocket`
+	label: string // primary text (the thing you'd type)
+	sublabel?: string // secondary text (location, target, …)
+	keywords?: string // extra text folded into search only, never shown
+	href: string // navigation target
+}
 
 const enc = encodeURIComponent
 
@@ -20,16 +20,15 @@ const enc = encodeURIComponent
  * Resource sources fanned out on open. Each calls a project-scoped `*.list`
  * endpoint and maps every item to a {@link SearchEntry}. Keep the labels to the
  * fields a user would actually type to find the resource.
- *
- * @typedef {Object} ResourceSource
- * @property {string} group
- * @property {string} icon
- * @property {string} fn                          api function name
- * @property {(it: any, project: string) => { key: string, label: string, sublabel?: string, href: string }} map
  */
+interface ResourceSource {
+	group: string
+	icon: string
+	fn: string // api function name
+	map: (it: any, project: string) => { key: string, label: string, sublabel?: string, href: string }
+}
 
-/** @type {ResourceSource[]} */
-const resourceSources = [
+const resourceSources: ResourceSource[] = [
 	{
 		group: 'Deployments',
 		icon: 'fa-rocket',
@@ -159,20 +158,15 @@ const resourceSources = [
  *
  * The current project is excluded — switching to where you already are is a
  * no-op and would just be visual noise in the palette.
- *
- * @param {Api.Project[]} projects
- * @param {string} currentProject
- * @param {{ url: { search: string }, data: { overrideRedirect?: string } }} page
- * @returns {SearchEntry[]}
  */
-export function projectEntries (projects, currentProject, page) {
+export function projectEntries (projects: Api.Project[], currentProject: string, page: { url: { search: string }, data: { overrideRedirect?: string } }): SearchEntry[] {
 	const overrideRedirect = page.data?.overrideRedirect || ''
 	return projects
 		.filter((p) => p.project !== currentProject)
 		.map((p) => {
 			const q = new URLSearchParams(page.url.search)
 			q.set('project', p.project)
-			return /** @type {SearchEntry} */ ({
+			return ({
 				id: `project:${p.project}`,
 				group: 'Switch project',
 				icon: 'fa-folder-open',
@@ -181,18 +175,15 @@ export function projectEntries (projects, currentProject, page) {
 				// `p.id` is the numeric project number — searchable but not shown.
 				keywords: p.id,
 				href: `${overrideRedirect}?${q.toString()}`
-			})
+			} as SearchEntry)
 		})
 }
 
 /**
  * Navigation entries — the sidebar sections, jumpable by name. Always available
  * (no fetch) so the palette is useful the instant it opens.
- *
- * @param {string} project
- * @returns {SearchEntry[]}
  */
-export function navEntries (project) {
+export function navEntries (project: string): SearchEntry[] {
 	return projectMenu.map((m) => ({
 		id: `nav:${m.id}`,
 		group: 'Go to',
@@ -211,30 +202,25 @@ export function navEntries (project) {
  * background fan-out, so a single transient `api: unauthorized` (e.g. one of the
  * parallel requests hitting a momentary backend/DB blip) must NOT fire the
  * global `onUnauth` handler and reload the whole app out from under the user.
- *
- * @param {string} project
- * @param {typeof fetch} fetch
- * @returns {Promise<SearchEntry[]>}
  */
-export async function fetchResourceEntries (project, fetch) {
+export async function fetchResourceEntries (project: string, fetch: typeof globalThis.fetch): Promise<SearchEntry[]> {
 	const settled = await Promise.all(resourceSources.map(async (src) => {
 		try {
-			/** @type {Api.Response<Api.List<any>>} */
-			const res = await api.invoke(src.fn, { project }, fetch, { silent: true })
+			const res = await api.invoke<Api.List<any>>(src.fn, { project }, fetch, { silent: true })
 			const items = res.result?.items ?? []
 			return items.map((it) => {
 				const m = src.map(it, project)
-				return /** @type {SearchEntry} */ ({
+				return ({
 					id: `${src.fn}:${m.key}`,
 					group: src.group,
 					icon: src.icon,
 					label: m.label,
 					sublabel: m.sublabel,
 					href: m.href
-				})
+				} as SearchEntry)
 			})
 		} catch {
-			return /** @type {SearchEntry[]} */ ([])
+			return ([] as SearchEntry[])
 		}
 	}))
 	return settled.flat()
@@ -243,12 +229,8 @@ export async function fetchResourceEntries (project, fetch) {
 /**
  * Token AND-match over label + sublabel + group, mirroring the project picker:
  * every whitespace-separated token must appear somewhere in the haystack.
- *
- * @param {SearchEntry[]} entries
- * @param {string} query
- * @returns {SearchEntry[]}
  */
-export function filterEntries (entries, query) {
+export function filterEntries (entries: SearchEntry[], query: string): SearchEntry[] {
 	const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
 	if (!tokens.length) return entries
 	return entries.filter((e) => {

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -15,31 +15,16 @@ const HEALTHY_STATUS_URL =
 	'data:application/json,' +
 	encodeURIComponent(JSON.stringify({ count: 1, ready: 1, succeeded: 0, failed: 0 }))
 
-/**
- * @template T
- * @param {T} [result]
- * @returns {{ ok: true, result: T }}
- */
-const ok = (result = /** @type {T} */ ({})) => ({ ok: true, result })
+const ok = <T>(result: T = ({} as T)): { ok: true, result: T } => ({ ok: true, result })
 
-/**
- * @param {string} message
- * @returns {{ ok: false, error: { message: string } }}
- */
-const err = (message) => ({ ok: false, error: { message } })
+const err = (message: string): { ok: false, error: { message: string } } => ({ ok: false, error: { message } })
 
-/**
- * @template T
- * @param {T[]} items
- */
-const list = (items) => ok({ items })
+const list = <T>(items: T[]) => ok({ items })
 
 /**
  * Synthesize a metric line: a single named series of [unixSeconds, value] points.
- * @param {string} name
- * @param {number} base
  */
-function metricLine (name, base) {
+function metricLine (name: string, base: number) {
 	const now = Math.floor(Date.now() / 1000)
 	const points = Array.from({ length: 30 }, (_, i) => {
 		const wobble = Math.sin(i / 3) * base * 0.25
@@ -54,18 +39,15 @@ function metricLine (name, base) {
 // stripping (only the trailing pod hash should show).
 const MOCK_PODS = ['d128-77-7d8f9b6c5-x2k9p', 'd128-77-7d8f9b6c5-q8m2t']
 
-/** @param {number} base */
-function metricPodLines (base) {
+function metricPodLines (base: number) {
 	return MOCK_PODS.map((name, i) => metricLine(name, base * (i === 0 ? 1 : 0.72))[0])
 }
 
 /**
  * dailyMetricLine builds a single daily series — one [unixSeconds, value] point
  * per day at midnight for the trailing 30 days — for the daily usage charts.
- * @param {string} name
- * @param {number} base
  */
-function dailyMetricLine (name, base) {
+function dailyMetricLine (name: string, base: number) {
 	const day = 86400
 	const now = Math.floor(Date.now() / 1000)
 	const today = now - (now % day)
@@ -131,7 +113,6 @@ const billingAccounts = [
 	}
 ]
 
-/** @param {string} [project] */
 function deployment (project = 'acme') {
 	return {
 		project,
@@ -142,8 +123,8 @@ function deployment (project = 'acme') {
 		image: 'registry.deploys.app/acme/web:latest',
 		env: { NODE_ENV: 'production', PORT: '8080' },
 		envGroups: ['shared'],
-		command: [],
-		args: [],
+		command: [] as string[],
+		args: [] as string[],
 		workloadIdentity: '',
 		pullSecret: '',
 		mountData: {},
@@ -165,7 +146,7 @@ function deployment (project = 'acme') {
 			requireGoogleLogin: true,
 			allowedEmails: ['owner@acme.io'],
 			allowedDomains: ['acme.io']
-		},
+		} as null | { requireGoogleLogin: boolean, allowedEmails: string[], allowedDomains: string[] },
 		// Hostnames only — both the Detail and Deployment pages prepend the
 		// scheme themselves.
 		url: 'web.acme.rcf2.deploys.app',
@@ -199,10 +180,6 @@ function deployment (project = 'acme') {
 // and release-sha rollback offline.
 const STATIC_RELEASE_SHA = 'a1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff00'
 
-/**
- * @param {string} [project]
- * @param {string} [releaseSha]
- */
 function staticDeployment (project = 'acme', releaseSha = STATIC_RELEASE_SHA) {
 	return {
 		...deployment(project),
@@ -214,8 +191,8 @@ function staticDeployment (project = 'acme', releaseSha = STATIC_RELEASE_SHA) {
 		image: '',
 		site: `site://deploys-static/${project}/website@${releaseSha}`,
 		siteManifestDigest: releaseSha,
-		command: [],
-		args: [],
+		command: [] as string[],
+		args: [] as string[],
 		minReplicas: 0,
 		maxReplicas: 0,
 		port: 0,
@@ -380,27 +357,18 @@ const wafZone = {
 	createdBy: USER_EMAIL
 }
 
-/** @type {Record<string, number>} */
-const wafRangeSeconds = { '1h': 3600, '6h': 21600, '12h': 43200, '1d': 86400, '7d': 604800, '30d': 2592000 }
+const wafRangeSeconds: Record<string, number> = { '1h': 3600, '6h': 21600, '12h': 43200, '1d': 86400, '7d': 604800, '30d': 2592000 }
 
 // Synthetic match metrics for the seed zone, so the firewall index sparkline +
 // total and the metrics page have something to draw. Scatters counts across the
 // requested window per (rule, action), mirroring waf.metrics' shape (sparse
 // buckets, grand total).
-/** @param {string} [timeRange] */
-function wafMetrics (timeRange) {
+function wafMetrics (timeRange?: string) {
 	const now = Math.floor(Date.now() / 1000)
 	const windowSeconds = wafRangeSeconds[timeRange ?? '1d'] ?? wafRangeSeconds['1d']
 
-	/**
-	 * @param {string} ruleId
-	 * @param {Api.WafAction} action
-	 * @param {number} buckets  // how many active samples
-	 * @param {number} scale    // max count per sample
-	 */
-	const makeSeries = (ruleId, action, buckets, scale) => {
-		/** @type {[number, number][]} */
-		const points = []
+	const makeSeries = (ruleId: string, action: Api.WafAction, buckets: number, scale: number) => {
+		const points: [number, number][] = []
 		let total = 0
 		for (let i = 0; i < buckets; i++) {
 			const ts = now - Math.floor(Math.random() * windowSeconds)
@@ -422,32 +390,23 @@ function wafMetrics (timeRange) {
 }
 
 // Bucket widths per range, matching waf.metrics / waf.limitMetrics server-side.
-/** @type {Record<string, number>} */
-const wafBucketSeconds = { '1h': 60, '6h': 300, '12h': 600, '1d': 1200, '7d': 3600, '30d': 14400 }
+const wafBucketSeconds: Record<string, number> = { '1h': 60, '6h': 300, '12h': 600, '1d': 1200, '7d': 3600, '30d': 14400 }
 
 // Synthetic rate-limit metrics for the seed zone's two limits, so the
 // "Rate limit activity" section has a trend to draw. Each limit gets an
 // `allowed` series with large counts and a `limited` series with small counts,
 // tuned so the limited share lands around the limit's target with some
 // time variation across the window.
-/** @param {string} [timeRange] */
-function wafLimitMetrics (timeRange) {
+function wafLimitMetrics (timeRange?: string) {
 	const now = Math.floor(Date.now() / 1000)
 	const range = timeRange ?? '1d'
 	const windowSeconds = wafRangeSeconds[range] ?? wafRangeSeconds['1d']
 	const bucket = wafBucketSeconds[range] ?? wafBucketSeconds['1d']
 	const from = now - windowSeconds
 
-	/**
-	 * @param {string} limitId
-	 * @param {number} base   typical allowed count per bucket
-	 * @param {number} share  typical limited share (0..1)
-	 */
-	const makeLimit = (limitId, base, share) => {
-		/** @type {[number, number][]} */
-		const allowed = []
-		/** @type {[number, number][]} */
-		const limited = []
+	const makeLimit = (limitId: string, base: number, share: number) => {
+		const allowed: [number, number][] = []
+		const limited: [number, number][] = []
 		let allowedTotal = 0
 		let limitedTotal = 0
 		for (let ts = from + bucket; ts <= now; ts += bucket) {
@@ -482,8 +441,7 @@ function wafLimitMetrics (timeRange) {
 // times the zone has been read while pending; the deployer is simulated by
 // flipping the zone from pending → success after the first poll, so the index
 // spinner visibly resolves on its own. Lets create → manage flow work too.
-/** @type {Map<string, { description: string, polls: number }>} */
-const wafConfigured = new Map()
+const wafConfigured = new Map<string, { description: string, polls: number }>()
 
 /**
  * Build a WAF zone for a session-created location. `advance` simulates the
@@ -491,10 +449,8 @@ const wafConfigured = new Map()
  * pending/create and the next list — after the page polls — settles to success,
  * making the spinner resolve on its own. waf.get reads observe the same state
  * without advancing it.
- * @param {string} location
- * @param {boolean} [advance]
  */
-function wafConfiguredZone (location, advance = false) {
+function wafConfiguredZone (location: string, advance = false) {
 	const entry = wafConfigured.get(location) ?? { description: '', polls: 0 }
 	const status = entry.polls > 0 ? 'success' : 'pending'
 	if (advance) {
@@ -560,21 +516,12 @@ const cacheZone = {
 // sparkline + total and the metrics page have something to draw. Scatters
 // counts across the requested window per (override, action, result), mirroring
 // cache.metrics' shape (sparse buckets, grand total). Reuses wafRangeSeconds.
-/** @param {string} [timeRange] */
-function cacheMetrics (timeRange) {
+function cacheMetrics (timeRange?: string) {
 	const now = Math.floor(Date.now() / 1000)
 	const windowSeconds = wafRangeSeconds[timeRange ?? '1d'] ?? wafRangeSeconds['1d']
 
-	/**
-	 * @param {string} overrideId
-	 * @param {Api.CacheAction} action
-	 * @param {Api.CacheMetricsSeries['result']} result
-	 * @param {number} buckets  // how many active samples
-	 * @param {number} scale    // max count per sample
-	 */
-	const makeSeries = (overrideId, action, result, buckets, scale) => {
-		/** @type {[number, number][]} */
-		const points = []
+	const makeSeries = (overrideId: string, action: Api.CacheAction, result: Api.CacheMetricsSeries['result'], buckets: number, scale: number) => {
+		const points: [number, number][] = []
 		let total = 0
 		for (let i = 0; i < buckets; i++) {
 			const ts = now - Math.floor(Math.random() * windowSeconds)
@@ -600,18 +547,15 @@ function cacheMetrics (timeRange) {
 // this dev session, mapped to { description, polls }. Mirrors wafConfigured —
 // the simulated deployer flips a freshly created zone from pending → success
 // after the first list read, so the index spinner resolves on its own.
-/** @type {Map<string, { description: string, polls: number }>} */
-const cacheConfigured = new Map()
+const cacheConfigured = new Map<string, { description: string, polls: number }>()
 
 /**
  * Build a cache zone for a session-created location. `advance` simulates the
  * deployer: set on cache.list reads (the index poll) so the first list shows
  * pending/create and the next list settles to success. cache.get reads observe
  * the same state without advancing it.
- * @param {string} location
- * @param {boolean} [advance]
  */
-function cacheConfiguredZone (location, advance = false) {
+function cacheConfiguredZone (location: string, advance = false) {
 	const entry = cacheConfigured.get(location) ?? { description: '', polls: 0 }
 	const status = entry.polls > 0 ? 'success' : 'pending'
 	if (advance) {
@@ -691,7 +635,16 @@ const permissions = [
 	'serviceAccount.list', 'serviceAccount.get', 'serviceAccount.create'
 ]
 
-const serviceAccounts = [
+interface ServiceAccount {
+	sid: string
+	email: string
+	name: string
+	description: string
+	createdAt: string
+	createdBy: string
+}
+
+const serviceAccounts: ServiceAccount[] = [
 	{
 		sid: 'sa_mock_ci',
 		email: 'ci@acme.serviceaccount.deploys.app',
@@ -702,8 +655,21 @@ const serviceAccounts = [
 	}
 ]
 
+interface GithubLink {
+	repositoryId: number
+	repository: string
+	installationId: number
+	serviceAccount: string
+	serviceAccountEmail: string
+	productionBranch: string
+	trigger: string
+	workflowConfig?: any
+	createdAt: string
+	createdBy: string
+}
+
 // github repo links — mutated by github.link / github.unlink within a session.
-const githubLinks = [
+const githubLinks: GithubLink[] = [
 	{
 		repositoryId: 812345678,
 		repository: 'acme/web',
@@ -957,8 +923,7 @@ const invoices = [
 	}
 ]
 
-/** @param {(typeof invoices)[number]} inv */
-function invoiceListItem (inv) {
+function invoiceListItem (inv: (typeof invoices)[number]) {
 	return {
 		id: inv.id,
 		number: inv.number,
@@ -987,8 +952,7 @@ const dropboxItems = [
 	}
 ]
 
-/** @type {Record<string, (args: any) => object>} */
-const handlers = {
+const handlers: Record<string, (args: any) => object> = {
 	'me.get': () => ok({ email: USER_EMAIL }),
 	// The mock user is a full-access owner, so every permission probe passes.
 	'me.authorized': () => ok({ authorized: true }),
@@ -1413,11 +1377,8 @@ const handlers = {
 /**
  * Resolve a mock response for an API function. Unknown functions return an
  * empty-but-ok payload so list/get callers degrade gracefully.
- * @param {string} fn
- * @param {object} [args]
- * @returns {object}
  */
-export function mockInvoke (fn, args = {}) {
+export function mockInvoke (fn: string, args: object = {}): object {
 	const handler = handlers[fn]
 	if (!handler) {
 		console.warn(`[mock] no fixture for "${fn}" — returning empty ok response`)

--- a/src/lib/server/redirect.ts
+++ b/src/lib/server/redirect.ts
@@ -13,11 +13,8 @@
  *  - must not point back at the auth endpoints themselves (avoids a sign-in loop)
  *
  * Returns the safe path, or '' when the input is missing or fails any check.
- *
- * @param {string | null | undefined} value
- * @returns {string}
  */
-export function sanitizeRedirect (value) {
+export function sanitizeRedirect (value: string | null | undefined): string {
 	if (!value) return ''
 	if (!value.startsWith('/')) return ''
 	if (value.startsWith('//')) return ''

--- a/src/lib/waf/countries.ts
+++ b/src/lib/waf/countries.ts
@@ -2,14 +2,12 @@
 // by the WAF country field so the picker can show both the code (what the rule
 // stores / what edge geo-IP emits) and the human-readable name.
 
-/**
- * @typedef {Object} Country
- * @property {string} code  ISO 3166-1 alpha-2 code (uppercase)
- * @property {string} name  English short name
- */
+export interface Country {
+	code: string // ISO 3166-1 alpha-2 code (uppercase)
+	name: string // English short name
+}
 
-/** @type {Country[]} */
-export const countries = [
+export const countries: Country[] = [
 	{ code: 'AD', name: 'Andorra' },
 	{ code: 'AE', name: 'United Arab Emirates' },
 	{ code: 'AF', name: 'Afghanistan' },
@@ -261,26 +259,21 @@ export const countries = [
 	{ code: 'ZW', name: 'Zimbabwe' }
 ]
 
-/** @type {Record<string, string>} */
-const nameByCode = Object.fromEntries(countries.map((c) => [c.code, c.name]))
+const nameByCode: Record<string, string> = Object.fromEntries(countries.map((c) => [c.code, c.name]))
 
 /**
  * Human-readable name for a country code, or the code itself when unknown (so an
  * out-of-list value loaded from an existing rule still renders).
- * @param {string} code
- * @returns {string}
  */
-export function countryName (code) {
+export function countryName (code: string): string {
 	return nameByCode[String(code ?? '').toUpperCase()] ?? code
 }
 
 /**
  * Label combining code and name, e.g. `"TH — Thailand"`. Falls back to the bare
  * code for unknown values.
- * @param {string} code
- * @returns {string}
  */
-export function countryLabel (code) {
+export function countryLabel (code: string): string {
 	const c = String(code ?? '').toUpperCase()
 	const name = nameByCode[c]
 	return name ? `${c} — ${name}` : code

--- a/src/lib/waf/expression.ts
+++ b/src/lib/waf/expression.ts
@@ -9,11 +9,10 @@
 // the modal UI stays thin.
 
 /**
- * Escape a JS string for use inside a CEL double-quoted string literal.
- * @param {string} v
- * @returns {string} the inner contents (no surrounding quotes)
+ * Escape a JS string for use inside a CEL double-quoted string literal. Returns
+ * the inner contents (no surrounding quotes).
  */
-export function celString (v) {
+export function celString (v: string): string {
 	return String(v ?? '')
 		.replace(/\\/g, '\\\\')
 		.replace(/"/g, '\\"')
@@ -22,28 +21,23 @@ export function celString (v) {
 		.replace(/\t/g, '\\t')
 }
 
-/** @param {string} v */
-function quote (v) {
+function quote (v: string): string {
 	return `"${celString(v)}"`
 }
 
-/**
- * @typedef {'string' | 'ip' | 'numeric' | 'tls' | 'country' | 'asn'} FieldType
- */
+export type FieldType = 'string' | 'ip' | 'numeric' | 'tls' | 'country' | 'asn'
 
-/**
- * @typedef {Object} FieldMeta
- * @property {string} value         stable key used in the spec
- * @property {string} label         human label shown in the Select
- * @property {FieldType} type       drives which operators/options apply
- * @property {boolean} [hasName]    true → field needs an extra name input (header/arg/cookie)
- * @property {string} [accessor]    fixed CEL accessor (fields without a name)
- * @property {string} [accessorMap] CEL map accessor template, `<name>` replaced (fields with a name)
- * @property {string[]} [suggestions] free-text combobox suggestions (datalist) for equals/not_equals
- */
+export interface FieldMeta {
+	value: string // stable key used in the spec
+	label: string // human label shown in the Select
+	type: FieldType // drives which operators/options apply
+	hasName?: boolean // true → field needs an extra name input (header/arg/cookie)
+	accessor?: string // fixed CEL accessor (fields without a name)
+	accessorMap?: string // CEL map accessor template, `<name>` replaced (fields with a name)
+	suggestions?: string[] // free-text combobox suggestions (datalist) for equals/not_equals
+}
 
-/** @type {FieldMeta[]} */
-export const fields = [
+export const fields: FieldMeta[] = [
 	{ value: 'method', label: 'Method', type: 'string', accessor: 'request.method', suggestions: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] },
 	{ value: 'path', label: 'Path', type: 'string', accessor: 'request.path' },
 	{ value: 'host', label: 'Host', type: 'string', accessor: 'request.host' },
@@ -61,23 +55,19 @@ export const fields = [
 	{ value: 'cookie', label: 'Cookie', type: 'string', hasName: true, accessorMap: 'request.cookies["<name>"]' }
 ]
 
-/** @type {Record<string, FieldMeta>} */
-const fieldByValue = Object.fromEntries(fields.map((f) => [f.value, f]))
+const fieldByValue: Record<string, FieldMeta> = Object.fromEntries(fields.map((f) => [f.value, f]))
 
-/** @param {string} value @returns {FieldMeta | undefined} */
-export function getField (value) {
+export function getField (value: string): FieldMeta | undefined {
 	return fieldByValue[value]
 }
 
-/**
- * @typedef {Object} OperatorMeta
- * @property {string} value
- * @property {string} label
- * @property {boolean} [multi]  true → operand is a list of values (textarea)
- */
+export interface OperatorMeta {
+	value: string
+	label: string
+	multi?: boolean // true → operand is a list of values (textarea)
+}
 
-/** @type {OperatorMeta[]} */
-const stringOperators = [
+const stringOperators: OperatorMeta[] = [
 	{ value: 'equals', label: 'equals' },
 	{ value: 'not_equals', label: 'not equals' },
 	{ value: 'in_list', label: 'is in', multi: true },
@@ -94,9 +84,8 @@ const stringOperators = [
  * String operators backed by a standard CEL string method. `negate` wraps the
  * call in a leading `!`. Single source of truth for both the generator and the
  * inverse parser (`operatorByMethod`).
- * @type {Record<string, { method: 'startsWith' | 'endsWith', negate: boolean }>}
  */
-const methodOperators = {
+const methodOperators: Record<string, { method: 'startsWith' | 'endsWith', negate: boolean }> = {
 	starts_with: { method: 'startsWith', negate: false },
 	not_starts_with: { method: 'startsWith', negate: true },
 	ends_with: { method: 'endsWith', negate: false },
@@ -104,12 +93,11 @@ const methodOperators = {
 }
 
 /** Reverse of `methodOperators`, keyed `"<method>:<negate>"`. */
-const operatorByMethod = Object.fromEntries(
+const operatorByMethod: Record<string, string> = Object.fromEntries(
 	Object.entries(methodOperators).map(([op, m]) => [`${m.method}:${m.negate}`, op])
 )
 
-/** @type {OperatorMeta[]} */
-const ipOperators = [
+const ipOperators: OperatorMeta[] = [
 	{ value: 'in_cidr', label: 'in CIDR' },
 	{ value: 'ip_equals', label: 'equals' }
 ]
@@ -118,17 +106,15 @@ const ipOperators = [
  * Operators for fields matched by exact value or list membership (country code,
  * ASN). `in_list` / `not_in_list` build a CEL `in […]` membership; the field
  * type decides whether operands are quoted (country) or raw ints (asn).
- * @type {OperatorMeta[]}
  */
-const membershipOperators = [
+const membershipOperators: OperatorMeta[] = [
 	{ value: 'equals', label: 'equals' },
 	{ value: 'not_equals', label: 'not equals' },
 	{ value: 'in_list', label: 'is in', multi: true },
 	{ value: 'not_in_list', label: 'is not in', multi: true }
 ]
 
-/** @type {OperatorMeta[]} */
-const numericOperators = [
+const numericOperators: OperatorMeta[] = [
 	{ value: 'num_eq', label: '==' },
 	{ value: 'num_ne', label: '!=' },
 	{ value: 'num_lt', label: '<' },
@@ -137,8 +123,7 @@ const numericOperators = [
 	{ value: 'num_ge', label: '>=' }
 ]
 
-/** @type {Record<string, string>} */
-const numericOps = {
+const numericOps: Record<string, string> = {
 	num_eq: '==',
 	num_ne: '!=',
 	num_lt: '<',
@@ -149,10 +134,8 @@ const numericOps = {
 
 /**
  * Operators available for a given field type.
- * @param {FieldType} type
- * @returns {OperatorMeta[]}
  */
-export function operatorsForType (type) {
+export function operatorsForType (type: FieldType): OperatorMeta[] {
 	switch (type) {
 	case 'ip': return ipOperators
 	case 'numeric': return numericOperators
@@ -168,49 +151,41 @@ export function operatorsForType (type) {
  * fields, but the HTTP method is a closed set of tokens (GET/POST/…), so only
  * exact-match and list membership make sense — prefix/suffix/regex/contains are
  * not offered.
- * @param {FieldMeta | undefined} field
- * @returns {OperatorMeta[]}
  */
-export function operatorsForField (field) {
+export function operatorsForField (field: FieldMeta | undefined): OperatorMeta[] {
 	if (!field) return stringOperators
 	if (field.value === 'method') return membershipOperators
 	return operatorsForType(field.type)
 }
 
-/** @param {string} op */
-export function isMultiOperator (op) {
+export function isMultiOperator (op: string): boolean {
 	return op === 'contains_any' || op === 'in_list' || op === 'not_in_list'
 }
 
 /**
  * Split a multi-value input into a clean list. Accepts newline- or
  * comma-separated values; trims each and drops the empties.
- * @param {string} raw
- * @returns {string[]}
  */
-export function parseList (raw) {
+export function parseList (raw: string): string[] {
 	return String(raw ?? '')
 		.split(/[\n,]/)
 		.map((s) => s.trim())
 		.filter((s) => s.length > 0)
 }
 
-/**
- * @typedef {Object} ExpressionSpec
- * @property {string} field            field key (see `fields`)
- * @property {string} [name]           name for header/arg/cookie fields
- * @property {string} operator         operator key
- * @property {string} [value]          single operand (equals/regex/cidr/numeric)
- * @property {string} [values]         raw multi-value text (any-of operators)
- * @property {boolean} [tls]           TLS on/off for a `'tls'` field (https vs http)
- */
+export interface ExpressionSpec {
+	field: string // field key (see `fields`)
+	name?: string // name for header/arg/cookie fields
+	operator: string // operator key
+	value?: string // single operand (equals/regex/cidr/numeric)
+	values?: string // raw multi-value text (any-of operators)
+	tls?: boolean // TLS on/off for a `'tls'` field (https vs http)
+}
 
 /**
  * Resolve the raw CEL accessor for a spec's field (no transforms applied).
- * @param {ExpressionSpec} spec
- * @returns {string}
  */
-function resolveAccessor (spec) {
+function resolveAccessor (spec: ExpressionSpec): string {
 	const f = fieldByValue[spec.field]
 	if (!f) return ''
 	if (f.hasName) {
@@ -225,11 +200,8 @@ function resolveAccessor (spec) {
  * Returns an empty string when the spec is incomplete (e.g. missing value, an
  * empty any-of list, or a name-bearing field with no name) so the caller can
  * disable Insert.
- *
- * @param {ExpressionSpec} spec
- * @returns {string}
  */
-export function buildExpression (spec) {
+export function buildExpression (spec: ExpressionSpec): string {
 	const f = fieldByValue[spec.field]
 	if (!f) return ''
 	if (f.hasName && !(spec.name ?? '').trim()) return ''
@@ -237,8 +209,7 @@ export function buildExpression (spec) {
 	const accessor = resolveAccessor(spec)
 	if (!accessor) return ''
 
-	/** @type {string} */
-	let snippet
+	let snippet: string
 
 	if (f.type === 'tls') {
 		// TLS on/off toggle — ignore the operator. ON → https, OFF → http.
@@ -325,37 +296,27 @@ export function buildExpression (spec) {
 
 /**
  * Combine a generated snippet with an existing expression.
- * @param {string} existing
- * @param {string} snippet
- * @param {'and' | 'or' | 'replace'} mode
- * @returns {string}
  */
-export function combineExpression (existing, snippet, mode) {
+export function combineExpression (existing: string, snippet: string, mode: 'and' | 'or' | 'replace'): string {
 	const e = (existing ?? '').trim()
 	if (!e || mode === 'replace') return snippet
 	if (mode === 'or') return `${e} || ${snippet}`
 	return `${e} && ${snippet}`
 }
 
-/**
- * @typedef {'and' | 'or'} Combinator
- */
+export type Combinator = 'and' | 'or'
 
-/**
- * @typedef {Object} ExpressionGroup
- * @property {Combinator} combinator
- * @property {ExpressionSpec[]} conditions
- */
+export interface ExpressionGroup {
+	combinator: Combinator
+	conditions: ExpressionSpec[]
+}
 
 /**
  * Build a flat group of conditions joined by a single boolean operator. This is
  * the multi-condition counterpart to `buildExpression` and the exact string
  * `parseExpression` is the inverse of.
- * @param {Combinator} combinator
- * @param {ExpressionSpec[]} conditions
- * @returns {string}
  */
-export function buildGroup (combinator, conditions) {
+export function buildGroup (combinator: Combinator, conditions: ExpressionSpec[]): string {
 	return (conditions ?? [])
 		.map(buildExpression)
 		.filter(Boolean)
@@ -364,11 +325,10 @@ export function buildGroup (combinator, conditions) {
 
 /**
  * Un-escape the inner contents of a CEL double-quoted string literal. Exact
- * inverse of `celString` (reverses `\\ \" \n \r \t`).
- * @param {string} inner  contents between the surrounding quotes
- * @returns {string}
+ * inverse of `celString` (reverses `\\ \" \n \r \t`). `inner` is the contents
+ * between the surrounding quotes.
  */
-function unescapeCelString (inner) {
+function unescapeCelString (inner: string): string {
 	let out = ''
 	for (let i = 0; i < inner.length; i++) {
 		const c = inner[i]
@@ -394,10 +354,8 @@ function unescapeCelString (inner) {
  * Match a single double-quoted CEL string literal at the START of `s`. Returns
  * the decoded value and the index just past the closing quote, or `null` if `s`
  * doesn't begin with a well-formed literal. Honours `\"`/`\\` escapes.
- * @param {string} s
- * @returns {{ value: string, end: number } | null}
  */
-function matchStringLiteral (s) {
+function matchStringLiteral (s: string): { value: string, end: number } | null {
 	if (s[0] !== '"') return null
 	let i = 1
 	let inner = ''
@@ -427,14 +385,10 @@ function matchStringLiteral (s) {
  * Returns `{ parts, op }` where `op` is the single boolean operator seen
  * (`'and'`, `'or'`, or `null` for a single part). Returns `null` when BOTH `&&`
  * and `||` appear at the top level (a "complex" expression).
- * @param {string} s
- * @returns {{ parts: string[], op: Combinator | null } | null}
  */
-function splitTopLevel (s) {
-	/** @type {string[]} */
-	const parts = []
-	/** @type {Combinator | null} */
-	let op = null
+function splitTopLevel (s: string): { parts: string[], op: Combinator | null } | null {
+	const parts: string[] = []
+	let op: Combinator | null = null
 	let depth = 0
 	let start = 0
 	let i = 0
@@ -479,12 +433,12 @@ function splitTopLevel (s) {
 }
 
 /** Map a fixed CEL accessor back to its field key. */
-const fieldByAccessor = Object.fromEntries(
+const fieldByAccessor: Record<string, string> = Object.fromEntries(
 	fields.filter((f) => f.accessor).map((f) => [f.accessor, f.value])
 )
 
 /** Map a named-map field's `request.xxx[` prefix back to its field key. */
-const nameFieldByPrefix = Object.fromEntries(
+const nameFieldByPrefix: Record<string, string> = Object.fromEntries(
 	fields
 		.filter((f) => f.hasName && f.accessorMap)
 		.map((f) => [(f.accessorMap ?? '').split('["<name>"]')[0], f.value])
@@ -494,10 +448,8 @@ const nameFieldByPrefix = Object.fromEntries(
  * Parse a single accessor at the START of `s` (a fixed `request.x` accessor or a
  * named `request.headers["name"]` form). Returns the resolved field key, the
  * optional decoded name, and the index just past the accessor — or `null`.
- * @param {string} s
- * @returns {{ field: string, name?: string, end: number } | null}
  */
-function matchAccessor (s) {
+function matchAccessor (s: string): { field: string, name?: string, end: number } | null {
 	// Named map accessor: `request.headers["..."]` etc. Try these first since the
 	// fixed-accessor table has no overlap with the map prefixes.
 	for (const prefix of Object.keys(nameFieldByPrefix)) {
@@ -510,8 +462,7 @@ function matchAccessor (s) {
 	}
 	// Fixed accessors — pick the longest matching one so e.g. `request.host`
 	// isn't shadowed by a shorter prefix (none currently overlap, but be safe).
-	/** @type {string | null} */
-	let best = null
+	let best: string | null = null
 	for (const accessor of Object.keys(fieldByAccessor)) {
 		if (s.startsWith(accessor) && (!best || accessor.length > best.length)) best = accessor
 	}
@@ -528,14 +479,11 @@ function matchAccessor (s) {
  * Parse the bracketed, comma-separated quoted list at the START of `s`
  * (`["a", "b"]` exactly as the generator emits). Returns the decoded items and
  * the consumed length, or `null` when malformed.
- * @param {string} s
- * @returns {{ items: string[], end: number } | null}
  */
-function matchList (s) {
+function matchList (s: string): { items: string[], end: number } | null {
 	if (s[0] !== '[') return null
 	let i = 1
-	/** @type {string[]} */
-	const items = []
+	const items: string[] = []
 	// Empty list is never emitted (buildExpression returns '' for it).
 	while (true) {
 		const lit = matchStringLiteral(s.slice(i))
@@ -552,14 +500,11 @@ function matchList (s) {
  * Parse the bracketed, comma-separated integer list at the START of `s`
  * (`[13335, 16509]` exactly as the generator emits). Returns the items (as
  * strings) and the consumed length, or `null` when malformed.
- * @param {string} s
- * @returns {{ items: string[], end: number } | null}
  */
-function matchIntList (s) {
+function matchIntList (s: string): { items: string[], end: number } | null {
 	if (s[0] !== '[') return null
 	let i = 1
-	/** @type {string[]} */
-	const items = []
+	const items: string[] = []
 	// Empty list is never emitted (buildExpression returns '' for it).
 	while (true) {
 		const m = /^\d+/.exec(s.slice(i))
@@ -576,10 +521,8 @@ function matchIntList (s) {
  * Parse the `<accessor>.startsWith("v")` / `.endsWith("v")` method forms — each
  * optionally negated with a leading `!` (the "not …" operators). String fields
  * only. Returns the spec or `null`.
- * @param {string} s
- * @returns {ExpressionSpec | null}
  */
-function parseMethodCall (s) {
+function parseMethodCall (s: string): ExpressionSpec | null {
 	let negate = false
 	let body = s
 	if (body.startsWith('!')) {
@@ -591,8 +534,7 @@ function parseMethodCall (s) {
 	const field = getField(acc.field)
 	if (!field || field.type !== 'string') return null
 	const rest = body.slice(acc.end)
-	/** @type {'startsWith' | 'endsWith' | null} */
-	let method = null
+	let method: 'startsWith' | 'endsWith' | null = null
 	if (rest.startsWith('.startsWith(')) method = 'startsWith'
 	else if (rest.startsWith('.endsWith(')) method = 'endsWith'
 	if (!method) return null
@@ -613,10 +555,8 @@ function parseMethodCall (s) {
  * Parse exactly one CEL condition (a single conjunct) back into an
  * `ExpressionSpec`. Strict: only forms `buildExpression` can emit are accepted.
  * Returns `null` for anything else.
- * @param {string} part
- * @returns {ExpressionSpec | null}
  */
-function parseCondition (part) {
+function parseCondition (part: string): ExpressionSpec | null {
 	const s = part.trim()
 	if (!s) return null
 
@@ -761,19 +701,15 @@ function parseCondition (part) {
  * operator, or returns `null` when the string is not EXACTLY representable by
  * the visual builder (mixed `&&`/`||`, grouping, unknown functions, wrappers,
  * malformed input). A false "complex" is acceptable; a wrong parse is not.
- *
- * @param {string} cel
- * @returns {ExpressionGroup | null}
  */
-export function parseExpression (cel) {
+export function parseExpression (cel: string): ExpressionGroup | null {
 	const trimmed = String(cel ?? '').trim()
 	if (trimmed === '') return { combinator: 'and', conditions: [] }
 
 	const split = splitTopLevel(trimmed)
 	if (!split) return null
 
-	/** @type {ExpressionSpec[]} */
-	const conditions = []
+	const conditions: ExpressionSpec[] = []
 	for (const part of split.parts) {
 		const spec = parseCondition(part)
 		if (!spec) return null

--- a/src/lib/waf/limits.ts
+++ b/src/lib/waf/limits.ts
@@ -5,36 +5,34 @@
 /**
  * One characteristic of the bucket key. Header/cookie carry a name; the rest
  * round-trip as a bare keyword ('ip', 'host', 'country', 'asn').
- * @typedef {Object} KeyRow
- * @property {'ip' | 'host' | 'country' | 'asn' | 'header' | 'cookie'} type
- * @property {string} name
  */
+export interface KeyRow {
+	type: 'ip' | 'host' | 'country' | 'asn' | 'header' | 'cookie'
+	name: string
+}
 
-/**
- * @typedef {Object} LimitForm
- * @property {string} id
- * @property {string} description
- * @property {KeyRow[]} key
- * @property {number} rate
- * @property {string} window
- * @property {'fixed' | 'sliding'} algorithm
- * @property {'enforce' | 'shadow'} mode
- * @property {number} status
- * @property {string} message
- * @property {string} filter
- */
+export interface LimitForm {
+	id: string
+	description: string
+	key: KeyRow[]
+	rate: number
+	window: string
+	algorithm: 'fixed' | 'sliding'
+	mode: 'enforce' | 'shadow'
+	status: number
+	message: string
+	filter: string
+}
 
 export const DEFAULT_LIMIT_STATUS = 429
 export const DEFAULT_LIMIT_MESSAGE = 'Too Many Requests'
 
-/** @type {Record<string, string>} */
-export const modeLabels = {
+export const modeLabels: Record<string, string> = {
 	enforce: 'Enforce',
 	shadow: 'Shadow'
 }
 
-/** @type {Record<KeyRow['type'], string>} */
-export const keyTypeLabels = {
+export const keyTypeLabels: Record<KeyRow['type'], string> = {
 	ip: 'IP address',
 	host: 'Host',
 	country: 'Country',
@@ -46,8 +44,7 @@ export const keyTypeLabels = {
 // Window presets covering the API's allowed 1s..1h range. Zones loaded with a
 // window outside this list still render — the edit page appends the loaded
 // value as an extra option.
-/** @type {{ value: string, label: string }[]} */
-export const windowOptions = [
+export const windowOptions: { value: string, label: string }[] = [
 	{ value: '1s', label: '1 second' },
 	{ value: '10s', label: '10 seconds' },
 	{ value: '30s', label: '30 seconds' },
@@ -60,10 +57,8 @@ export const windowOptions = [
 
 /**
  * Parse an API key part ('ip', 'header:x-api-key', …) into a form row.
- * @param {string} part
- * @returns {KeyRow}
  */
-export function parseKeyPart (part) {
+export function parseKeyPart (part: string): KeyRow {
 	if (part.startsWith('header:')) return { type: 'header', name: part.slice('header:'.length) }
 	if (part.startsWith('cookie:')) return { type: 'cookie', name: part.slice('cookie:'.length) }
 	if (part === 'host' || part === 'country' || part === 'asn') return { type: part, name: '' }
@@ -75,10 +70,8 @@ export function parseKeyPart (part) {
  * an empty name are incomplete and yield ''. Header names are normalized to
  * lowercase (HTTP headers are case-insensitive — parapet does the same);
  * cookie names keep their spelling (cookies match case-sensitively).
- * @param {KeyRow} row
- * @returns {string}
  */
-export function keyRowToApi (row) {
+export function keyRowToApi (row: KeyRow): string {
 	if (row.type === 'header' || row.type === 'cookie') {
 		const name = row.name.trim()
 		if (!name) return ''
@@ -90,10 +83,8 @@ export function keyRowToApi (row) {
 /**
  * Human label for an API key, e.g. ['ip', 'header:x-api-key'] →
  * "IP + Header x-api-key".
- * @param {string[]} [key]
- * @returns {string}
  */
-export function describeKey (key) {
+export function describeKey (key?: string[]): string {
 	const parts = (key && key.length > 0 ? key : ['ip']).map((part) => {
 		const row = parseKeyPart(part)
 		if (row.type === 'header' || row.type === 'cookie') {
@@ -104,11 +95,7 @@ export function describeKey (key) {
 	return parts.join(' + ')
 }
 
-/**
- * @param {Api.WafLimit} [limit]
- * @returns {LimitForm}
- */
-export function limitForm (limit) {
+export function limitForm (limit?: Api.WafLimit): LimitForm {
 	return {
 		id: limit?.id ?? '',
 		description: limit?.description ?? '',
@@ -125,10 +112,8 @@ export function limitForm (limit) {
 
 /**
  * Generate a stable, unique limit id that doesn't collide with `taken`.
- * @param {string[]} taken
- * @returns {string}
  */
-export function genLimitId (taken) {
+export function genLimitId (taken: string[]): string {
 	let id
 	do {
 		id = 'limit-' + Math.random().toString(36).slice(2, 8)
@@ -138,12 +123,9 @@ export function genLimitId (taken) {
 
 /**
  * Map API limits to form rows, giving every row a unique id.
- * @param {Api.WafLimit[]} [apiLimits]
- * @returns {LimitForm[]}
  */
-export function normalizeLimits (apiLimits) {
-	/** @type {string[]} */
-	const taken = []
+export function normalizeLimits (apiLimits?: Api.WafLimit[]): LimitForm[] {
+	const taken: string[] = []
 	return (apiLimits ?? []).map((l) => {
 		const f = limitForm(l)
 		if (!f.id || taken.includes(f.id)) f.id = genLimitId(taken)
@@ -156,13 +138,10 @@ export function normalizeLimits (apiLimits) {
  * Map form rows back to the API limit shape. Key rows are deduped (and
  * incomplete header/cookie rows dropped), falling back to ['ip'] when nothing
  * valid remains.
- * @param {LimitForm[]} limits
- * @returns {Api.WafLimit[]}
  */
-export function toApiLimits (limits) {
+export function toApiLimits (limits: LimitForm[]): Api.WafLimit[] {
 	return limits.map((l) => {
-		/** @type {string[]} */
-		const key = []
+		const key: string[] = []
 		for (const row of l.key) {
 			const part = keyRowToApi(row)
 			if (part && !key.includes(part)) key.push(part)

--- a/src/lib/waf/rules.ts
+++ b/src/lib/waf/rules.ts
@@ -3,31 +3,25 @@
 // logs/metrics as rule_id), so they must survive reordering. Order = execution
 // order, with `priority` derived from index on every whole-zone write.
 
-/**
- * @typedef {Object} RuleForm
- * @property {string} id
- * @property {string} description
- * @property {string} expression
- * @property {'log' | 'allow' | 'block'} action
- * @property {number | null} status
- * @property {string} message
- */
+export interface RuleForm {
+	id: string
+	description: string
+	expression: string
+	action: 'log' | 'allow' | 'block'
+	status: number | null
+	message: string
+}
 
 export const DEFAULT_STATUS = 403
 export const DEFAULT_MESSAGE = 'Forbidden'
 
-/** @type {Record<string, string>} */
-export const actionLabels = {
+export const actionLabels: Record<string, string> = {
 	log: 'Log',
 	allow: 'Allow',
 	block: 'Block'
 }
 
-/**
- * @param {Api.WafRule} [rule]
- * @returns {RuleForm}
- */
-export function ruleForm (rule) {
+export function ruleForm (rule?: Api.WafRule): RuleForm {
 	return {
 		id: rule?.id ?? '',
 		description: rule?.description ?? '',
@@ -40,10 +34,8 @@ export function ruleForm (rule) {
 
 /**
  * Generate a stable, unique rule id that doesn't collide with `taken`.
- * @param {string[]} taken
- * @returns {string}
  */
-export function genId (taken) {
+export function genId (taken: string[]): string {
 	let id
 	do {
 		id = 'rule-' + Math.random().toString(36).slice(2, 8)
@@ -53,14 +45,9 @@ export function genId (taken) {
 
 // Map API rules to form rows: order by priority (lower runs first) so the
 // visible order is the execution order, and give every row a unique id.
-/**
- * @param {Api.WafRule[]} [apiRules]
- * @returns {RuleForm[]}
- */
-export function normalizeRules (apiRules) {
+export function normalizeRules (apiRules?: Api.WafRule[]): RuleForm[] {
 	const sorted = [...(apiRules ?? [])].sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0))
-	/** @type {string[]} */
-	const taken = []
+	const taken: string[] = []
 	return sorted.map((r) => {
 		const f = ruleForm(r)
 		if (!f.id || taken.includes(f.id)) f.id = genId(taken)
@@ -71,11 +58,7 @@ export function normalizeRules (apiRules) {
 
 // Map form rows back to the API rule shape. Priority follows row order — the
 // top rule runs first; status + message only apply when blocking.
-/**
- * @param {RuleForm[]} rules
- * @returns {Api.WafRule[]}
- */
-export function toApiRules (rules) {
+export function toApiRules (rules: RuleForm[]): Api.WafRule[] {
 	return rules.map((r, i) => ({
 		id: r.id,
 		description: r.description,

--- a/src/routes/(auth)/(project)/+layout.server.js
+++ b/src/routes/(auth)/(project)/+layout.server.js
@@ -1,5 +1,0 @@
-export function load ({ locals }) {
-	return {
-		restoreProject: locals.project || ''
-	}
-}

--- a/src/routes/(auth)/(project)/+layout.server.ts
+++ b/src/routes/(auth)/(project)/+layout.server.ts
@@ -1,0 +1,7 @@
+import type { LayoutServerLoad } from './$types'
+
+export const load: LayoutServerLoad = ({ locals }) => {
+	return {
+		restoreProject: locals.project || ''
+	}
+}

--- a/src/routes/api/[fn]/+server.ts
+++ b/src/routes/api/[fn]/+server.ts
@@ -1,10 +1,10 @@
+import type { RequestHandler } from './$types'
 import { env } from '$env/dynamic/private'
 import { mockInvoke } from '$lib/server/mock'
 
 const endpoint = env.API_ENDPOINT || 'https://api.deploys.app'
 
-/** @type {import('@sveltejs/kit').RequestHandler} */
-export async function POST ({ locals, params, request }) {
+export const POST: RequestHandler = async ({ locals, params, request }) => {
 	// dev mock: short-circuit to static fixtures, no token required
 	if (env.MOCK_API) {
 		const args = await request.json().catch(() => ({}))

--- a/src/routes/api/dropbox/+server.ts
+++ b/src/routes/api/dropbox/+server.ts
@@ -1,5 +1,6 @@
-/** @type {import('./$types').RequestHandler} */
-export async function POST ({ locals, request, url }) {
+import type { RequestHandler } from './$types'
+
+export const POST: RequestHandler = async ({ locals, request, url }) => {
 	const token = locals.token
 	const project = url.searchParams.get('project')
 	const filename = url.searchParams.get('filename') ?? ''
@@ -17,8 +18,7 @@ export async function POST ({ locals, request, url }) {
 		})
 	}
 
-	/** @type {Record<string, string>} */
-	const headers = {
+	const headers: Record<string, string> = {
 		accept: 'application/json',
 		'content-type': request.headers.get('content-type') ?? 'application/octet-stream',
 		'param-project': project,

--- a/src/routes/api/mock-events/+server.ts
+++ b/src/routes/api/mock-events/+server.ts
@@ -7,6 +7,7 @@
 // that drift forward as the page sits open so the relative-time column
 // keeps updating naturally.
 
+import type { RequestHandler } from './$types'
 import { env } from '$env/dynamic/private'
 
 // Pod references use full id-named pod names (`d128-77-<rsHash>-<podHash>`) so
@@ -32,9 +33,8 @@ const WARNINGS = [
 /**
  * Build a varied, reasonably-realistic feed where timestamps are anchored to
  * "now" so the events page's relative-time column shows fresh values.
- * @param {number} count
  */
-function buildFeed (count) {
+function buildFeed (count: number) {
 	const now = Date.now()
 	const out = []
 	for (let i = 0; i < count; i++) {
@@ -52,8 +52,7 @@ function buildFeed (count) {
 	return out
 }
 
-/** @type {import('@sveltejs/kit').RequestHandler} */
-export async function GET () {
+export const GET: RequestHandler = async () => {
 	if (!env.MOCK_API) return new Response('not found', { status: 404 })
 
 	const events = buildFeed(12 + (Math.random() * 8 | 0))

--- a/src/routes/api/mock-logs/+server.ts
+++ b/src/routes/api/mock-logs/+server.ts
@@ -10,6 +10,7 @@
 // (severity colouring, pod chips, throughput meter, buffer fill, …) can be
 // exercised against something realistic via `bun dev:mock`.
 
+import type { RequestHandler } from './$types'
 import { env } from '$env/dynamic/private'
 
 // Full pod names (`<kubeName>-<projectID>-<rsHash>-<podHash>`) for an id-named
@@ -60,15 +61,13 @@ function nextEntry () {
 	}
 }
 
-/** @type {import('@sveltejs/kit').RequestHandler} */
-export async function GET ({ url }) {
+export const GET: RequestHandler = async ({ url }) => {
 	if (!env.MOCK_API) return new Response('not found', { status: 404 })
 
 	const wantsText = url.searchParams.get('type') === 'text' || url.searchParams.get('raw') === '1'
 
 	const enc = new TextEncoder()
-	/** @type {ReturnType<typeof setTimeout> | undefined} */
-	let timer
+	let timer: ReturnType<typeof setTimeout> | undefined
 	let closed = false
 
 	const stream = new ReadableStream({

--- a/src/routes/auth/callback/+server.ts
+++ b/src/routes/auth/callback/+server.ts
@@ -1,10 +1,10 @@
+import type { RequestHandler } from './$types'
 import { env } from '$env/dynamic/private'
 import { sanitizeRedirect } from '$lib/server/redirect'
 
 const authEndpoint = env.AUTH_ENDPOINT || 'https://auth.deploys.app'
 
-/** @type {import('@sveltejs/kit').RequestHandler} */
-export async function GET ({ cookies, url }) {
+export const GET: RequestHandler = async ({ cookies, url }) => {
 	const state = url.searchParams.get('state') ?? ''
 	const code = url.searchParams.get('code') ?? ''
 

--- a/src/routes/auth/signin/+server.ts
+++ b/src/routes/auth/signin/+server.ts
@@ -1,3 +1,4 @@
+import type { RequestHandler } from './$types'
 import { env } from '$env/dynamic/private'
 import { sanitizeRedirect } from '$lib/server/redirect'
 
@@ -7,9 +8,8 @@ const webcrypto = crypto
 
 /**
  * randomState generates a random string for OAuth2 state
- * @returns {string}
  */
-function randomState () {
+function randomState (): string {
 	const x = new Uint8Array(16)
 	webcrypto.getRandomValues(x)
 	return Array.from(x, (d) => d.toString(16).padStart(2, '0')).join('')
@@ -17,10 +17,8 @@ function randomState () {
 
 /**
  * base64url encodes bytes without padding (RFC 4648 §5) — the encoding PKCE uses.
- * @param {Uint8Array} bytes
- * @returns {string}
  */
-function base64url (bytes) {
+function base64url (bytes: Uint8Array): string {
 	let s = ''
 	for (const b of bytes) {
 		s += String.fromCharCode(b)
@@ -31,9 +29,8 @@ function base64url (bytes) {
 /**
  * randomCodeVerifier returns a high-entropy PKCE code_verifier (RFC 7636):
  * base64url of 32 random bytes (43 chars, within the 43–128 range).
- * @returns {string}
  */
-function randomCodeVerifier () {
+function randomCodeVerifier (): string {
 	const x = new Uint8Array(32)
 	webcrypto.getRandomValues(x)
 	return base64url(x)
@@ -43,16 +40,13 @@ function randomCodeVerifier () {
  * codeChallengeS256 derives the S256 PKCE code_challenge from a verifier:
  * base64url(SHA-256(verifier)), no padding (RFC 7636 §4.2). auth verifies this
  * at /token against the code_verifier we present in the callback.
- * @param {string} verifier
- * @returns {Promise<string>}
  */
-async function codeChallengeS256 (verifier) {
+async function codeChallengeS256 (verifier: string): Promise<string> {
 	const digest = await webcrypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier))
 	return base64url(new Uint8Array(digest))
 }
 
-/** @type {import('@sveltejs/kit').RequestHandler} */
-export async function GET ({ cookies, url }) {
+export const GET: RequestHandler = async ({ cookies, url }) => {
 	const state = randomState()
 
 	// PKCE (OAuth 2.1): console stays a confidential client (it still sends its

--- a/src/routes/auth/signout/+server.ts
+++ b/src/routes/auth/signout/+server.ts
@@ -1,10 +1,10 @@
+import type { RequestHandler } from './$types'
 import { env } from '$env/dynamic/private'
 
 const authEndpoint = env.AUTH_ENDPOINT || 'https://auth.deploys.app'
 const landing = 'https://www.deploys.app/'
 
-/** @type {import('@sveltejs/kit').RequestHandler} */
-export async function POST ({ locals }) {
+export const POST: RequestHandler = async ({ locals }) => {
 	const token = locals.token
 
 	if (token) {


### PR DESCRIPTION
## What

Batch 2 of the [JS → TS migration](https://github.com/deploys-app/console/pull/239). Converts the **foundational non-UI layer** — shared `lib` utilities and the server/endpoint layer — to fully-strict TypeScript, following the conventions established in the pilot. **No behavior or UI change.**

### Converted (20 files)
**lib:** `cache/overrides`, `charts/util`, `deployment/podName`, `modal`, `search`, `server/mock`, `server/redirect`, `waf/countries`, `waf/expression`, `waf/limits`, `waf/rules`

**server / endpoints:** `hooks.server.ts` (typed `Handle`), `(project)/+layout.server.ts` (`LayoutServerLoad`), and the `api/[fn]`, `api/dropbox`, `api/mock-events`, `api/mock-logs`, `auth/callback`, `auth/signin`, `auth/signout` endpoints (`+server.ts`, each method typed as `RequestHandler` from `./$types`).

### How
- JSDoc `@typedef {Object}` → exported `interface`; `@type`/`@param`/`@returns` lifted into real TS types; inline `/** @type {T} */ (expr)` casts → `expr as T`.
- SvelteKit endpoints converted to the typed `export const GET: RequestHandler = …` form.
- Shared `Api.*` types used directly from the global namespace.

### Verification
- `bun check` → **0 errors / 0 warnings** (691 files)
- `bun lint` → clean
- `bun build` → succeeds

### Remaining after this
~83 `.js` (route `load` files) + ~103 `.svelte` components, to follow in subsequent batches (routes next, then components).

🤖 Generated with [Claude Code](https://claude.com/claude-code)