### PR TITLE
chore: migrate shared components to TypeScript (batch 4)

### DIFF
--- a/src/lib/components/Chart.svelte
+++ b/src/lib/components/Chart.svelte
@@ -1,42 +1,44 @@
-<script>
+<script lang="ts">
 	import LineChart from '$lib/components/LineChart.svelte'
 	import { formatBytes, formatNumber } from '$lib/charts/util'
+	import type { LineSeries } from '$lib/charts/util'
 
 	/**
 	 * Metric time-series panel: a titled card wrapping {@link LineChart}. Accepts
 	 * the platform's metric shape — a set of named series, each carrying one or
 	 * more lines of `[unixSeconds, value]` points — and flattens it for drawing.
-	 *
-	 * @typedef {Object} Line
-	 * @property {string} name
-	 * @property {[number, number][]} points   [unixSeconds, value]
-	 *
-	 * @typedef {Object} Series
-	 * @property {string} prefix
-	 * @property {Line[]} lines
-	 * @property {string} [dashStyle]   any value → rendered dashed (e.g. limits)
-	 * @property {string} [color]       'red' maps to the danger token
-	 *
-	 * @typedef {Object} Props
-	 * @property {string} title
-	 * @property {string} unit          'bytes' formats Ki/Mi/Gi; else plain number
-	 * @property {Series[]} series
-	 * @property {'line' | 'spline'} [type]
-	 * @property {string} [range]       e.g. '1h', '6hagg' — sizes the time window
 	 */
 
-	/** @type {Props} */
-	const { title, unit, series, type = 'line', range = '' } = $props()
+	interface Line {
+		name: string
+		points: [number, number][] // [unixSeconds, value]
+	}
 
-	/** @param {string} [c] */
-	function resolveColor (c) {
+	interface Series {
+		prefix: string
+		lines: Line[]
+		dashStyle?: string // any value → rendered dashed (e.g. limits)
+		color?: string // 'red' maps to the danger token
+	}
+
+	interface Props {
+		title: string
+		unit: string // 'bytes' formats Ki/Mi/Gi; else plain number
+		series: Series[]
+		type?: 'line' | 'spline'
+		range?: string // e.g. '1h', '6hagg' — sizes the time window
+	}
+
+	const { title, unit, series, type = 'line', range = '' }: Props = $props()
+
+	function resolveColor (c?: string): string | undefined {
 		if (!c) return undefined
 		if (c === 'red') return 'hsl(var(--hsl-negative))'
 		return c
 	}
 
 	/** Turn the range token ('6hagg', '1d', …) into a window length in ms. */
-	function rangeToMs (/** @type {string} */ r) {
+	function rangeToMs (r: string): number | null {
 		if (!r) return null
 		const base = r.replace('agg', '')
 		const num = parseInt(base)
@@ -56,8 +58,7 @@
 	// '-' boundary so whole name segments are removed (never a hash mid-token).
 	// This also hides the otherwise-opaque `0d<id>` resource name.
 	const podPrefixLen = $derived.by(() => {
-		/** @type {string[]} */
-		const names = []
+		const names: string[] = []
 		for (const s of series ?? []) {
 			for (const l of (s.lines ?? [])) names.push(l.name ?? '')
 		}
@@ -73,8 +74,7 @@
 		return cut >= 0 ? cut + 1 : 0
 	})
 
-	/** @param {string} name */
-	function podLabel (name) {
+	function podLabel (name: string): string {
 		return name.slice(podPrefixLen) || name
 	}
 
@@ -85,8 +85,7 @@
 	// layered over it.
 	const flat = $derived.by(() => {
 		let areaUsed = false
-		/** @type {import('$lib/charts/util').LineSeries[]} */
-		const out = []
+		const out: LineSeries[] = []
 		for (const s of series ?? []) {
 			const lines = s.lines ?? []
 			for (const l of lines) {
@@ -118,7 +117,7 @@
 
 	const xDomain = $derived.by(() => {
 		const ms = rangeToMs(range)
-		return ms ? /** @type {[number, number]} */ ([lastTs - ms, lastTs]) : null
+		return ms ? ([lastTs - ms, lastTs] as [number, number]) : null
 	})
 </script>
 

--- a/src/lib/components/CountrySelect.svelte
+++ b/src/lib/components/CountrySelect.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import OptionSelect from '$lib/components/OptionSelect.svelte'
 	import { countries, countryLabel } from '$lib/waf/countries'
 
@@ -9,23 +9,26 @@
 	 *
 	 * Single mode binds `value` (one code). Multi mode binds `tags` (an array of
 	 * codes) and renders the chosen countries as chips.
-	 *
-	 * @typedef {Object} Props
-	 * @property {boolean} [multi]      multi-select (chips) vs single value
-	 * @property {string} [value]       single mode — selected code
-	 * @property {string[]} [tags]      multi mode — selected codes
-	 * @property {string} [id]          id for the inner input (label association)
-	 * @property {string} [placeholder]
 	 */
+	interface Props {
+		/** multi-select (chips) vs single value */
+		multi?: boolean
+		/** single mode — selected code */
+		value?: string
+		/** multi mode — selected codes */
+		tags?: string[]
+		/** id for the inner input (label association) */
+		id?: string
+		placeholder?: string
+	}
 
-	/** @type {Props} */
 	let {
 		multi = false,
 		value = $bindable(''),
 		tags = $bindable([]),
 		id,
 		placeholder = 'Search country or code'
-	} = $props()
+	}: Props = $props()
 
 	// Code in mono (`code`), name as the row text (`name`), and "CODE — Name" as
 	// the resting/chip label — matching the prior bespoke rendering.

--- a/src/lib/components/CreateServiceAccountModal.svelte
+++ b/src/lib/components/CreateServiceAccountModal.svelte
@@ -1,15 +1,14 @@
-<script>
+<script lang="ts">
 	import api from '$lib/api'
 
-	/**
-	 * @typedef {Object} Props
-	 * @property {string} project
-	 * @property {boolean} [canGrantRole] Whether the current user may grant the deploy role (needs role.bind, plus role.create when the github-deploy role doesn't exist). Defaults to true for safety.
-	 * @property {(sa: { sid: string, name: string, email: string }) => void} oncreated
-	 */
+	interface Props {
+		project: string
+		/** Whether the current user may grant the deploy role (needs role.bind, plus role.create when the github-deploy role doesn't exist). Defaults to true for safety. */
+		canGrantRole?: boolean
+		oncreated: (sa: { sid: string, name: string, email: string }) => void
+	}
 
-	/** @type {Props} */
-	const { project, canGrantRole = true, oncreated } = $props()
+	const { project, canGrantRole = true, oncreated }: Props = $props()
 
 	let isActive = $state(false)
 	let sid = $state('github-deploy')
@@ -18,12 +17,11 @@
 	// open() runs, so the initial value here is never user-visible.
 	let grantRole = $state(true)
 	let submitting = $state(false)
-	/** @type {string} */
 	let errorMessage = $state('')
 
 	const canSubmit = $derived(sid.trim() !== '' && name.trim() !== '' && !submitting)
 
-	export function open () {
+	export function open (): void {
 		sid = 'github-deploy'
 		name = 'GitHub Deploy'
 		// Default the checkbox on, but keep it off when the user can't grant roles.
@@ -37,8 +35,7 @@
 		isActive = false
 	}
 
-	/** @param {MouseEvent} e */
-	function onBackdrop (e) {
+	function onBackdrop (e: MouseEvent) {
 		if (e.target === e.currentTarget) close()
 	}
 
@@ -84,7 +81,7 @@
 
 			// Re-fetch to resolve the real service account email.
 			let email = `${cleanSid}@${project}.serviceaccount.deploys.app`
-			const listResp = await api.invoke('serviceAccount.list', { project }, fetch)
+			const listResp = await api.invoke<Api.List<Api.ServiceAccount>>('serviceAccount.list', { project }, fetch)
 			if (listResp.ok) {
 				const found = (listResp.result?.items ?? []).find((s) => s.sid === cleanSid)
 				if (found?.email) email = found.email

--- a/src/lib/components/DangerZone.svelte
+++ b/src/lib/components/DangerZone.svelte
@@ -1,13 +1,13 @@
-<script>
-	/**
-	 * @typedef {Object} Props
-	 * @property {string} [title]
-	 * @property {string} [description]
-	 * @property {import('svelte').Snippet} [children]
-	 */
+<script lang="ts">
+	import type { Snippet } from 'svelte'
 
-	/** @type {Props} */
-	const { title = 'Danger zone', description = '', children } = $props()
+	interface Props {
+		title?: string
+		description?: string
+		children?: Snippet
+	}
+
+	const { title = 'Danger zone', description = '', children }: Props = $props()
 </script>
 
 <section class="danger-zone">

--- a/src/lib/components/EditGithubLinkModal.svelte
+++ b/src/lib/components/EditGithubLinkModal.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
 
@@ -7,15 +7,16 @@
 	 * deploy trigger, and production branch. The repository and installation id
 	 * are immutable, so only the mutable fields are editable here. Calls
 	 * github.update.
-	 *
-	 * @typedef {Object} Props
-	 * @property {string} project
-	 * @property {{ sid: string, name: string }[]} serviceAccounts  selectable service accounts in the project
-	 * @property {() => void} onsaved  called after a successful update so the parent can reload the link list
 	 */
+	interface Props {
+		project: string
+		/** selectable service accounts in the project */
+		serviceAccounts: { sid: string, name: string }[]
+		/** called after a successful update so the parent can reload the link list */
+		onsaved: () => void
+	}
 
-	/** @type {Props} */
-	const { project, serviceAccounts, onsaved } = $props()
+	const { project, serviceAccounts, onsaved }: Props = $props()
 
 	let isActive = $state(false)
 	// Identifies the link being edited; repository is display-only.
@@ -49,8 +50,7 @@
 
 	const canSubmit = $derived(serviceAccount !== '' && !submitting)
 
-	/** @param {Api.GithubLink} link */
-	export function open (link) {
+	export function open (link: Api.GithubLink): void {
 		repositoryId = link.repositoryId
 		repository = link.repository
 		serviceAccount = link.serviceAccount
@@ -68,8 +68,7 @@
 		isActive = false
 	}
 
-	/** @param {MouseEvent} e */
-	function onBackdrop (e) {
+	function onBackdrop (e: MouseEvent) {
 		if (e.target === e.currentTarget) close()
 	}
 

--- a/src/lib/components/EnvGroupModal.svelte
+++ b/src/lib/components/EnvGroupModal.svelte
@@ -1,15 +1,12 @@
-<script>
+<script lang="ts">
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 
-	let group = $state(/** @type {?Api.EnvGroup} */ (null))
+	let group = $state<Api.EnvGroup | null>(null)
 	let isActive = $state(false)
 
 	const entries = $derived(Object.entries(group?.env ?? {}))
 
-	/**
-	 * @param {Api.EnvGroup} g
-	 */
-	export function open (g) {
+	export function open (g: Api.EnvGroup): void {
 		group = g
 		isActive = true
 	}

--- a/src/lib/components/InvoiceStatusBadge.svelte
+++ b/src/lib/components/InvoiceStatusBadge.svelte
@@ -1,11 +1,9 @@
-<script>
-	/**
-	 * @typedef {Object} Props
-	 * @property {Api.InvoiceStatus} status
-	 */
+<script lang="ts">
+	interface Props {
+		status: Api.InvoiceStatus
+	}
 
-	/** @type {Props} */
-	const { status } = $props()
+	const { status }: Props = $props()
 
 	const badge = $derived.by(() => {
 		if (status === 'paid') return { icon: 'fa-circle-check', cls: 'is-positive', label: 'Paid' }

--- a/src/lib/components/LineChart.svelte
+++ b/src/lib/components/LineChart.svelte
@@ -1,29 +1,28 @@
-<script>
+<script lang="ts">
 	import dayjs from 'dayjs'
 	import { palette, niceScale, linePath, areaPath } from '$lib/charts/util'
+	import type { LineSeries } from '$lib/charts/util'
 
 	/**
 	 * A responsive, theme-reactive SVG line/area chart. Drives both the metric
 	 * charts (time x-axis) and the billing report (category x-axis). Colors are
 	 * CSS-var strings applied via inline `style`, so a theme toggle recolors the
 	 * chart with no re-render and no canvas redraw.
-	 *
-	 * @typedef {import('$lib/charts/util').LineSeries} LineSeries
-	 *
-	 * @typedef {Object} Props
-	 * @property {LineSeries[]} series
-	 * @property {'time' | 'category'} [xType]
-	 * @property {string[]} [categories]      labels when xType is 'category'
-	 * @property {[number, number] | null} [xDomain]  explicit [min,max] for time
-	 * @property {boolean} [smooth]           spline vs. straight segments
-	 * @property {number} [height]
-	 * @property {(v: number) => string} [formatY]
-	 * @property {(v: number) => string} [formatValue]  tooltip value (defaults to formatY)
-	 * @property {string} [valueSuffix]       appended in the tooltip
-	 * @property {boolean} [legend]
 	 */
 
-	/** @type {Props} */
+	interface Props {
+		series: LineSeries[]
+		xType?: 'time' | 'category'
+		categories?: string[] // labels when xType is 'category'
+		xDomain?: [number, number] | null // explicit [min,max] for time
+		smooth?: boolean // spline vs. straight segments
+		height?: number
+		formatY?: (v: number) => string
+		formatValue?: (v: number) => string // tooltip value (defaults to formatY)
+		valueSuffix?: string // appended in the tooltip
+		legend?: boolean
+	}
+
 	const {
 		series,
 		xType = 'time',
@@ -35,18 +34,16 @@
 		formatValue,
 		valueSuffix = '',
 		legend = false
-	} = $props()
+	}: Props = $props()
 
 	const PAD = { top: 14, right: 16, bottom: 26, left: 52 }
 
 	let width = $state(0)
-	/** @type {SVGSVGElement | undefined} */
-	let svgEl = $state()
-	/** index into `frame`, or null when not hovering */
-	let hover = $state(/** @type {number | null} */ (null))
+	let svgEl = $state<SVGSVGElement | undefined>()
+	// index into `frame`, or null when not hovering
+	let hover = $state<number | null>(null)
 
-	/** @param {HTMLElement} node */
-	function track (node) {
+	function track (node: HTMLElement) {
 		const ro = new ResizeObserver((entries) => {
 			width = entries[0].contentRect.width
 		})
@@ -54,14 +51,14 @@
 		return { destroy: () => ro.disconnect() }
 	}
 
-	const colorOf = (/** @type {LineSeries} */ s, /** @type {number} */ i) =>
+	const colorOf = (s: LineSeries, i: number): string =>
 		s.color ?? palette[i % palette.length]
 
 	// ── Domains ────────────────────────────────────────────────────────────
 	const allY = $derived(series.flatMap((s) => s.points.map((p) => p.y)))
 	const yScaleInfo = $derived(niceScale(0, allY.length ? Math.max(...allY) : 0, 5))
 
-	const xExtent = $derived.by(() => {
+	const xExtent = $derived.by((): [number, number] => {
 		if (xType === 'category') return [0, Math.max(0, categories.length - 1)]
 		if (xDomain) return xDomain
 		const xs = series.flatMap((s) => s.points.map((p) => p.x))
@@ -79,13 +76,13 @@
 		y1: height - PAD.bottom
 	})
 
-	const xScale = $derived((/** @type {number} */ v) => {
+	const xScale = $derived((v: number) => {
 		const [lo, hi] = xExtent
 		if (xType === 'category' && hi === lo) return (plot.x0 + plot.x1) / 2
 		return plot.x0 + ((v - lo) / (hi - lo)) * (plot.x1 - plot.x0)
 	})
 
-	const yScale = $derived((/** @type {number} */ v) => {
+	const yScale = $derived((v: number) => {
 		const { min, max } = yScaleInfo
 		return plot.y1 - ((v - min) / (max - min)) * (plot.y1 - plot.y0)
 	})
@@ -117,9 +114,9 @@
 		const [lo, hi] = xExtent
 		const span = hi - lo
 		const day = 86400000
-		if (span <= 2 * day) return (/** @type {number} */ v) => dayjs(v).format('HH:mm')
-		if (span <= 8 * day) return (/** @type {number} */ v) => dayjs(v).format('ddd HH:mm')
-		return (/** @type {number} */ v) => dayjs(v).format('MMM D')
+		if (span <= 2 * day) return (v: number) => dayjs(v).format('HH:mm')
+		if (span <= 8 * day) return (v: number) => dayjs(v).format('ddd HH:mm')
+		return (v: number) => dayjs(v).format('MMM D')
 	})
 
 	const xTicks = $derived.by(() => {
@@ -127,8 +124,7 @@
 			const n = categories.length
 			if (n === 0) return []
 			const stride = n <= 8 ? 1 : Math.ceil(n / 6)
-			/** @type {{ px: number, label: string, anchor: string }[]} */
-			const out = []
+			const out: { px: number, label: string, anchor: string }[] = []
 			for (let i = 0; i < n; i += stride) {
 				out.push({ px: xScale(i), label: categories[i], anchor: i === 0 ? 'start' : i >= n - 1 ? 'end' : 'middle' })
 			}
@@ -158,8 +154,7 @@
 		return { px: f.px, header, rows }
 	})
 
-	/** @param {PointerEvent} e */
-	function onMove (e) {
+	function onMove (e: PointerEvent) {
 		if (!frame.length || !svgEl) return
 		const rect = svgEl.getBoundingClientRect()
 		const px = e.clientX - rect.left
@@ -176,14 +171,12 @@
 	// points even when the finger strays outside the SVG, and reveal the nearest
 	// point on a plain tap. `touch-action: pan-y` leaves vertical page scroll to
 	// the browser, which fires pointercancel and clears the readout on a scroll.
-	/** @param {PointerEvent} e */
-	function onDown (e) {
+	function onDown (e: PointerEvent) {
 		if (e.pointerType !== 'mouse') svgEl?.setPointerCapture?.(e.pointerId)
 		onMove(e)
 	}
 
-	/** @param {PointerEvent} e */
-	function onUp (e) {
+	function onUp (e: PointerEvent) {
 		if (e.pointerType !== 'mouse') hover = null
 	}
 </script>
@@ -245,7 +238,7 @@
 			{#if tip}
 				<line class="crosshair" x1={tip.px} x2={tip.px} y1={plot.y0} y2={plot.y1} />
 				{#each drawn as d (d.name)}
-					{@const yv = d.byX.get(frame[/** @type {number} */ (hover)].x)}
+					{@const yv = d.byX.get(frame[hover as number].x)}
 					{#if yv != null}
 						<circle class="marker" cx={tip.px} cy={yScale(yv)} r="3.5" style:fill={d.color} />
 					{/if}
@@ -264,7 +257,7 @@
 					<div class="tip-row">
 						<span class="tip-dot" style:background={row.color}></span>
 						<span class="tip-name">{row.name}</span>
-						<span class="tip-val">{fmtVal(/** @type {number} */ (row.y))}{valueSuffix}</span>
+						<span class="tip-val">{fmtVal(row.y as number)}{valueSuffix}</span>
 					</div>
 				{/each}
 			</div>

--- a/src/lib/components/OptionSelect.svelte
+++ b/src/lib/components/OptionSelect.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { untrack } from 'svelte'
 
 	/**
@@ -9,35 +9,36 @@
 	 *
 	 * Single mode binds `value` (one value). Multi mode binds `tags` (an array of
 	 * values) and renders the chosen options as chips.
-	 *
-	 * @typedef {Object} Option
-	 * @property {string} value
-	 * @property {string} label        chip + resting display text
-	 * @property {string} [code]       optional mono prefix shown in the row
-	 * @property {string} [name]       row text after the code (e.g. country name)
-	 *
-	 * @typedef {Object} Props
-	 * @property {Option[]} options
-	 * @property {boolean} [multi]      multi-select (chips) vs single value
-	 * @property {string} [value]       single mode — selected value
-	 * @property {string[]} [tags]      multi mode — selected values
-	 * @property {string} [id]          id for the inner input (label association)
-	 * @property {string} [placeholder]
-	 * @property {string} [emptyText]   shown when no option matches the query
-	 * @property {boolean} [allowCustom] offer the typed text as a new value when it
-	 *                                   isn't one of `options` (e.g. an HTTP method
-	 *                                   outside the known set). Off for closed sets
-	 *                                   like country codes.
-	 * @property {(value: string) => void} [onchange] notified with the committed
-	 *                                   value whenever an option (or custom value)
-	 *                                   is picked.
-	 * @property {boolean} [resetOnSelect] single mode — don't rest on the pick:
-	 *                                   clear the field and keep the menu open so the
-	 *                                   next value can be typed right away, turning
-	 *                                   the control into an "add to a list" picker.
 	 */
 
-	/** @type {Props} */
+	interface Option {
+		value: string
+		label: string // chip + resting display text
+		code?: string // optional mono prefix shown in the row
+		name?: string // row text after the code (e.g. country name)
+	}
+
+	interface Props {
+		options: Option[]
+		multi?: boolean // multi-select (chips) vs single value
+		value?: string // single mode — selected value
+		tags?: string[] // multi mode — selected values
+		id?: string // id for the inner input (label association)
+		placeholder?: string
+		emptyText?: string // shown when no option matches the query
+		// offer the typed text as a new value when it isn't one of `options` (e.g.
+		// an HTTP method outside the known set). Off for closed sets like country
+		// codes.
+		allowCustom?: boolean
+		// notified with the committed value whenever an option (or custom value) is
+		// picked.
+		onchange?: (value: string) => void
+		// single mode — don't rest on the pick: clear the field and keep the menu
+		// open so the next value can be typed right away, turning the control into
+		// an "add to a list" picker.
+		resetOnSelect?: boolean
+	}
+
 	let {
 		options,
 		multi = false,
@@ -49,10 +50,10 @@
 		allowCustom = false,
 		onchange,
 		resetOnSelect = false
-	} = $props()
+	}: Props = $props()
 
 	/** Resting/chip label for a stored value (falls back to the bare value). */
-	function labelOf (/** @type {string} */ v) {
+	function labelOf (v: string) {
 		return options.find((o) => o.value === v)?.label ?? v
 	}
 
@@ -64,10 +65,8 @@
 
 	const listboxId = $derived(`${id ?? 'opt'}-listbox`)
 
-	/** @type {HTMLInputElement | undefined} */
-	let inputEl = $state()
-	/** @type {HTMLDivElement | undefined} */
-	let listEl = $state()
+	let inputEl = $state<HTMLInputElement | undefined>()
+	let listEl = $state<HTMLDivElement | undefined>()
 
 	// In single mode the resting input text is the selected label; treat it as an
 	// empty query so opening the menu shows the whole list rather than filtering
@@ -116,8 +115,7 @@
 		})
 	})
 
-	/** @param {Option} o */
-	function commit (o) {
+	function commit (o: Option) {
 		if (multi) {
 			if (!tags.includes(o.value)) tags = [...tags, o.value]
 			query = ''
@@ -158,8 +156,7 @@
 		onchange?.(v)
 	}
 
-	/** @param {number} i */
-	function removeTag (i) {
+	function removeTag (i: number) {
 		tags = tags.filter((_, idx) => idx !== i)
 		inputEl?.focus()
 	}
@@ -186,8 +183,7 @@
 		activeIndex = matches.length > 0 ? 0 : -1
 	}
 
-	/** @param {number} dir */
-	function moveActive (dir) {
+	function moveActive (dir: number) {
 		if (matches.length === 0) return
 		let i = activeIndex + dir
 		if (i < 0) i = matches.length - 1
@@ -195,8 +191,7 @@
 		activeIndex = i
 	}
 
-	/** @param {KeyboardEvent} e */
-	function onKeydown (e) {
+	function onKeydown (e: KeyboardEvent) {
 		switch (e.key) {
 		case 'ArrowDown':
 			e.preventDefault()
@@ -231,12 +226,10 @@
 		}
 	}
 
-	const optionId = (/** @type {number} */ i) => `${id ?? 'opt'}-opt-${i}`
+	const optionId = (i: number) => `${id ?? 'opt'}-opt-${i}`
 
-	/** @type {(node: HTMLElement, handler: () => void) => { destroy(): void }} */
-	function clickOutside (node, handler) {
-		/** @param {MouseEvent} e */
-		function onDown (e) {
+	function clickOutside (node: HTMLElement, handler: () => void): { destroy(): void } {
+		function onDown (e: MouseEvent) {
 			if (e.target instanceof Node && !node.contains(e.target)) handler()
 		}
 		document.addEventListener('mousedown', onDown)

--- a/src/lib/components/OutcomeBadge.svelte
+++ b/src/lib/components/OutcomeBadge.svelte
@@ -1,11 +1,9 @@
-<script>
-	/**
-	 * @typedef {Object} Props
-	 * @property {Api.AuditOutcome} outcome
-	 */
+<script lang="ts">
+	interface Props {
+		outcome: Api.AuditOutcome
+	}
 
-	/** @type {Props} */
-	const { outcome } = $props()
+	const { outcome }: Props = $props()
 
 	const badge = $derived.by(() => {
 		if (outcome === 'success') return { icon: 'fa-circle-check', cls: 'is-positive', label: 'Success' }

--- a/src/lib/components/PayInvoiceModal.svelte
+++ b/src/lib/components/PayInvoiceModal.svelte
@@ -1,27 +1,23 @@
-<script>
+<script lang="ts">
 	// Max upload size, mirrors api.MaxTransferSlipSize (10 MiB). The server
 	// enforces this too; checking here gives instant feedback.
 	const MAX_SIZE = 10 * 1024 * 1024
 
-	/**
-	 * @typedef {Object} Props
-	 * @property {() => void} [onuploaded] called after a slip is accepted
-	 */
+	interface Props {
+		/** called after a slip is accepted */
+		onuploaded?: () => void
+	}
 
-	/** @type {Props} */
-	const { onuploaded } = $props()
+	const { onuploaded }: Props = $props()
 
-	let invoice = $state(/** @type {?Api.Invoice} */ (null))
+	let invoice = $state<Api.Invoice | null>(null)
 	let isActive = $state(false)
 	let uploading = $state(false)
 	let error = $state('')
-	let selectedFile = $state(/** @type {?File} */ (null))
-	let elFile = $state(/** @type {?HTMLInputElement} */ (null))
+	let selectedFile = $state<File | null>(null)
+	let elFile = $state<HTMLInputElement | null>(null)
 
-	/**
-	 * @param {Api.Invoice} inv
-	 */
-	export function open (inv) {
+	export function open (inv: Api.Invoice): void {
 		invoice = inv
 		selectedFile = null
 		error = ''
@@ -38,17 +34,13 @@
 	 * Close only when the backdrop itself is clicked, not when a click inside
 	 * the panel bubbles up — otherwise interacting with the form would dismiss
 	 * the modal.
-	 * @param {MouseEvent} e
 	 */
-	function onBackdrop (e) {
+	function onBackdrop (e: MouseEvent) {
 		if (e.target === e.currentTarget) close()
 	}
 
-	/**
-	 * @param {Event} e
-	 */
-	function onFileChange (e) {
-		const input = /** @type {HTMLInputElement} */ (e.currentTarget)
+	function onFileChange (e: Event) {
+		const input = e.currentTarget as HTMLInputElement
 		const f = input.files?.[0] ?? null
 		error = ''
 		if (f && f.size > MAX_SIZE) {
@@ -86,10 +78,7 @@
 		}
 	}
 
-	/**
-	 * @param {number} n
-	 */
-	function fileSize (n) {
+	function fileSize (n: number): string {
 		if (n < 1024) return `${n} B`
 		if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
 		return `${(n / 1024 / 1024).toFixed(1)} MB`

--- a/src/lib/components/ProjectMetrics.svelte
+++ b/src/lib/components/ProjectMetrics.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { tick, untrack } from 'svelte'
 	import { page } from '$app/stores'
 	import { replaceState } from '$app/navigation'
@@ -10,13 +10,18 @@
 	 * Daily project-level usage charts read from the project.metrics RPC. CPU,
 	 * memory, disk and replicas are per-day average levels; egress is the day's
 	 * total bytes (pod + cache + WAF); static storage is the day's gauge.
-	 *
-	 * @typedef {Object} Props
-	 * @property {string} project
 	 */
 
-	/** @type {Props} */
-	const { project } = $props()
+	interface Props {
+		project: string
+	}
+
+	interface Series {
+		prefix: string
+		lines: Api.UsageMetricsLine[]
+	}
+
+	const { project }: Props = $props()
 
 	const rangeOptions = [
 		{ value: '7d', label: '7 Days' },
@@ -28,19 +33,18 @@
 		range: $page.url.searchParams.get('range') || '30d'
 	})
 
-	let cpu = $state([])
-	let memory = $state([])
-	let egress = $state([])
-	let replica = $state([])
-	let disk = $state([])
-	let storage = $state([])
+	let cpu = $state<Series[]>([])
+	let memory = $state<Series[]>([])
+	let egress = $state<Series[]>([])
+	let replica = $state<Series[]>([])
+	let disk = $state<Series[]>([])
+	let storage = $state<Series[]>([])
 
 	async function fetchMetrics (clear = false) {
 		// `range` is read untracked so the project-keyed effect below isn't also
 		// triggered by range changes — those refresh via the Select's onchange.
 		const range = untrack(() => filter.range)
-		/** @type {Api.Response<Api.ProjectMetricsResult>} */
-		const resp = await api.invoke('project.metrics', { project, timeRange: range }, fetch)
+		const resp: Api.Response<Api.ProjectMetricsResult> = await api.invoke('project.metrics', { project, timeRange: range }, fetch)
 		if (!resp.ok) {
 			return
 		}

--- a/src/lib/components/Secret.svelte
+++ b/src/lib/components/Secret.svelte
@@ -1,13 +1,11 @@
-<script>
+<script lang="ts">
 
-	/**
-	 * @typedef {Object} Props
-	 * @property {string} value
-	 * @property {boolean} [show]
-	 */
+	interface Props {
+		value: string
+		show?: boolean
+	}
 
-	/** @type {Props} */
-	const { value, show = false } = $props()
+	const { value, show = false }: Props = $props()
 
 	let isHidden = $derived(!show)
 

--- a/src/lib/components/Select.svelte
+++ b/src/lib/components/Select.svelte
@@ -1,35 +1,30 @@
-<script>
-	/**
-	 * @typedef {'positive' | 'warning' | 'negative' | 'muted'} Tone
-	 */
+<script lang="ts">
+	type Tone = 'positive' | 'warning' | 'negative' | 'muted'
 
-	/**
-	 * @typedef {Object} Option
-	 * @property {string | number} [value]
-	 * @property {string} [label]
-	 * @property {boolean} [disabled]
-	 * @property {boolean} [separator]
-	 * @property {Tone} [dot] leading status dot, colored by tone
-	 * @property {string} [badge] trailing pill text
-	 * @property {Tone} [badgeTone] pill color (defaults to muted)
-	 */
+	interface Option {
+		value?: string | number
+		label?: string
+		disabled?: boolean
+		separator?: boolean
+		dot?: Tone // leading status dot, colored by tone
+		badge?: string // trailing pill text
+		badgeTone?: Tone // pill color (defaults to muted)
+	}
 
-	/**
-	 * @typedef {Object} Props
-	 * @property {string | number} [value]
-	 * @property {Option[]} options
-	 * @property {string} [placeholder]
-	 * @property {boolean} [required]
-	 * @property {boolean} [disabled]
-	 * @property {boolean} [editable] free-text combobox mode: a typed value is allowed alongside picking an option
-	 * @property {string} [id]
-	 * @property {string} [name]
-	 * @property {(value: string | number) => void} [onchange]
-	 * @property {boolean} [resetOnSelect]
-	 * @property {string} [class]
-	 */
+	interface Props {
+		value?: string | number
+		options: Option[]
+		placeholder?: string
+		required?: boolean
+		disabled?: boolean
+		editable?: boolean // free-text combobox mode: a typed value is allowed alongside picking an option
+		id?: string
+		name?: string
+		onchange?: (value: string | number) => void
+		resetOnSelect?: boolean
+		class?: string
+	}
 
-	/** @type {Props} */
 	let {
 		value = $bindable(''),
 		options,
@@ -42,11 +37,11 @@
 		onchange,
 		resetOnSelect = false,
 		class: className = ''
-	} = $props()
+	}: Props = $props()
 
 	const uid = $props.id()
 	const listboxId = `${uid}-listbox`
-	const optionId = (/** @type {number} */ i) => `${uid}-opt-${i}`
+	const optionId = (i: number) => `${uid}-opt-${i}`
 
 	let open = $state(false)
 	let activeIndex = $state(-1)
@@ -57,12 +52,9 @@
 	// works, and re-arm on blur for the next focus.
 	let autofillGuard = $state(true)
 
-	/** @type {HTMLButtonElement | undefined} */
-	let triggerEl = $state()
-	/** @type {HTMLInputElement | undefined} */
-	let inputEl = $state()
-	/** @type {HTMLDivElement | undefined} */
-	let listEl = $state()
+	let triggerEl = $state<HTMLButtonElement | undefined>()
+	let inputEl = $state<HTMLInputElement | undefined>()
+	let listEl = $state<HTMLDivElement | undefined>()
 
 	// Editable mode filters the visible options by case-insensitive substring of
 	// the typed value. Non-editable mode always shows the full list.
@@ -75,8 +67,7 @@
 	)
 
 	let typeahead = ''
-	/** @type {ReturnType<typeof setTimeout> | undefined} */
-	let typeaheadTimer
+	let typeaheadTimer: ReturnType<typeof setTimeout> | undefined
 
 	const selectedOption = $derived(
 		options.find((o) => !o.separator && (o.value ?? '') === value)
@@ -84,14 +75,12 @@
 	const displayLabel = $derived(selectedOption ? selectedOption.label : placeholder)
 	const hasSelection = $derived(!!selectedOption)
 
-	/** @param {number} i */
-	function isSelectable (i) {
+	function isSelectable (i: number) {
 		const o = visibleOptions[i]
 		return !!o && !o.separator && !o.disabled
 	}
 
-	/** @param {Option} opt */
-	function commit (opt) {
+	function commit (opt: Option) {
 		if (opt.separator || opt.disabled) return
 		const v = opt.value ?? ''
 		value = v
@@ -124,8 +113,7 @@
 		return -1
 	}
 
-	/** @param {number} dir */
-	function moveActive (dir) {
+	function moveActive (dir: number) {
 		let i = activeIndex
 		for (let step = 0; step < visibleOptions.length; step++) {
 			i += dir
@@ -138,8 +126,7 @@
 		}
 	}
 
-	/** @param {string} char */
-	function typeaheadSearch (char) {
+	function typeaheadSearch (char: string) {
 		clearTimeout(typeaheadTimer)
 		typeahead += char.toLowerCase()
 		typeaheadTimer = setTimeout(() => { typeahead = '' }, 500)
@@ -149,8 +136,7 @@
 		if (match >= 0) activeIndex = match
 	}
 
-	/** @param {KeyboardEvent} e */
-	function onKeydown (e) {
+	function onKeydown (e: KeyboardEvent) {
 		if (disabled) return
 		switch (e.key) {
 		case 'ArrowDown':
@@ -193,8 +179,7 @@
 
 	// Keydown handler for the editable (free-text) trigger input. Printable keys
 	// fall through to edit the input; only navigation/commit keys are handled.
-	/** @param {KeyboardEvent} e */
-	function onInputKeydown (e) {
+	function onInputKeydown (e: KeyboardEvent) {
 		if (disabled) return
 		switch (e.key) {
 		case 'ArrowDown':
@@ -234,10 +219,8 @@
 		onchange?.(value)
 	}
 
-	/** @type {(node: HTMLElement, handler: () => void) => { destroy(): void }} */
-	function clickOutside (node, handler) {
-		/** @param {MouseEvent} e */
-		function onDown (e) {
+	function clickOutside (node: HTMLElement, handler: () => void): { destroy(): void } {
+		function onDown (e: MouseEvent) {
 			if (e.target instanceof Node && !node.contains(e.target)) handler()
 		}
 		document.addEventListener('mousedown', onDown)

--- a/src/lib/components/Sparkline.svelte
+++ b/src/lib/components/Sparkline.svelte
@@ -1,20 +1,18 @@
-<script>
+<script lang="ts">
 	// Tiny inline bar chart for sparse time-series (e.g. WAF matches per minute).
 	// Bars are positioned by timestamp across [from, to] so quiet periods read as
 	// gaps rather than being collapsed, and heights are normalized to the window's
 	// peak. Cheap enough to render one per table row (plain SVG, no chart lib).
 
-	/**
-	 * @typedef {Object} Props
-	 * @property {[number, number][]} points  // [unixSeconds, value], time-ordered
-	 * @property {number} [from]   // x-domain start (unix seconds); defaults to first point
-	 * @property {number} [to]     // x-domain end (unix seconds); defaults to last point
-	 * @property {number} [width]
-	 * @property {number} [height]
-	 */
+	interface Props {
+		points?: [number, number][] // [unixSeconds, value], time-ordered
+		from?: number // x-domain start (unix seconds); defaults to first point
+		to?: number // x-domain end (unix seconds); defaults to last point
+		width?: number
+		height?: number
+	}
 
-	/** @type {Props} */
-	const { points = [], from, to, width = 96, height = 28 } = $props()
+	const { points = [], from, to, width = 96, height = 28 }: Props = $props()
 
 	const start = $derived(from ?? points[0]?.[0] ?? 0)
 	const end = $derived(to ?? points[points.length - 1]?.[0] ?? 1)

--- a/src/lib/components/StatusIcon.svelte
+++ b/src/lib/components/StatusIcon.svelte
@@ -1,14 +1,12 @@
-<script>
+<script lang="ts">
 
-	/**
-	 * @typedef {Object} Props
-	 * @property {string} status
-	 */
+	interface Props {
+		status: string
+	}
 
-	/** @type {Props} */
-	const { status } = $props()
+	const { status }: Props = $props()
 
-	const iconClassByStatus = {
+	const iconClassByStatus: Record<string, string> = {
 		pending: 'fa-solid fa-spinner-third fa-spin',
 		success: 'fa-solid fa-check-circle text-positive/80',
 		error: 'fa-solid fa-times text-negative/80',

--- a/src/lib/components/TagInput.svelte
+++ b/src/lib/components/TagInput.svelte
@@ -1,18 +1,18 @@
-<script>
-	/**
-	 * @typedef {Object} Props
-	 * @property {string[]} tags        bindable list of committed chips
-	 * @property {string} [placeholder] placeholder for the text input
-	 * @property {string} [id]          id for the inner input (label association)
-	 */
+<script lang="ts">
+	interface Props {
+		/** bindable list of committed chips */
+		tags?: string[]
+		/** placeholder for the text input */
+		placeholder?: string
+		/** id for the inner input (label association) */
+		id?: string
+	}
 
-	/** @type {Props} */
-	let { tags = $bindable([]), placeholder = '', id } = $props()
+	let { tags = $bindable([]), placeholder = '', id }: Props = $props()
 
 	let draft = $state('')
 
-	/** @type {HTMLInputElement | undefined} */
-	let inputEl = $state()
+	let inputEl = $state<HTMLInputElement | undefined>()
 
 	// Commit the current draft as a chip: trim, ignore empties, de-dupe.
 	function commit () {
@@ -23,14 +23,12 @@
 		tags = [...tags, v]
 	}
 
-	/** @param {number} i */
-	function remove (i) {
+	function remove (i: number) {
 		tags = tags.filter((_, idx) => idx !== i)
 		inputEl?.focus()
 	}
 
-	/** @param {KeyboardEvent} e */
-	function onkeydown (e) {
+	function onkeydown (e: KeyboardEvent) {
 		if (e.key === 'Enter') {
 			e.preventDefault()
 			commit()

--- a/src/lib/components/UsageMetrics.svelte
+++ b/src/lib/components/UsageMetrics.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { tick, untrack } from 'svelte'
 	import { page } from '$app/stores'
 	import { replaceState } from '$app/navigation'
@@ -10,14 +10,19 @@
 	 * Daily egress + storage usage charts for a project-level feature (Dropbox,
 	 * Registry). Data comes from a `*.metrics` RPC returning `{ egress, storage }`
 	 * series of `[unixSeconds, value]` points, one point per day.
-	 *
-	 * @typedef {Object} Props
-	 * @property {string} project
-	 * @property {string} fn         api function, e.g. 'dropbox.metrics'
 	 */
 
-	/** @type {Props} */
-	const { project, fn } = $props()
+	interface Props {
+		project: string
+		fn: string // api function, e.g. 'dropbox.metrics'
+	}
+
+	interface Series {
+		prefix: string
+		lines: Api.UsageMetricsLine[]
+	}
+
+	const { project, fn }: Props = $props()
 
 	const rangeOptions = [
 		{ value: '7d', label: '7 Days' },
@@ -29,15 +34,14 @@
 		range: $page.url.searchParams.get('range') || '30d'
 	})
 
-	let egress = $state([])
-	let storage = $state([])
+	let egress = $state<Series[]>([])
+	let storage = $state<Series[]>([])
 
 	async function fetchMetrics (clear = false) {
 		// `range` is read untracked so the project-keyed effect below isn't also
 		// triggered by range changes — those refresh via the Select's onchange.
 		const range = untrack(() => filter.range)
-		/** @type {Api.Response<Api.UsageMetricsResult>} */
-		const resp = await api.invoke(fn, { project, timeRange: range }, fetch)
+		const resp: Api.Response<Api.UsageMetricsResult> = await api.invoke(fn, { project, timeRange: range }, fetch)
 		if (!resp.ok) {
 			return
 		}

--- a/src/lib/components/WafActivityChart.svelte
+++ b/src/lib/components/WafActivityChart.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import dayjs from 'dayjs'
 	import { niceScale } from '$lib/charts/util'
 
@@ -7,23 +7,23 @@
 	 * (block / log / allow). Data arrives pre-bucketed onto a shared time grid so
 	 * the segments align cleanly. Pure SVG — colors come from the design tokens
 	 * via CSS `var()`, so a theme toggle recolors the bars instantly.
-	 *
-	 * @typedef {Object} ActivitySeries
-	 * @property {Api.WafAction} action
-	 * @property {string} name
-	 * @property {[number, number][]} data   [unixMs, count]
-	 *
-	 * @typedef {Object} Props
-	 * @property {ActivitySeries[]} series   bottom-to-top stacking order
-	 * @property {number} from   x-extreme start, unix ms
-	 * @property {number} to     x-extreme end, unix ms
 	 */
 
-	/** @type {Props} */
-	const { series, from, to } = $props()
+	interface ActivitySeries {
+		action: Api.WafAction
+		name: string
+		data: [number, number][] // [unixMs, count]
+	}
 
-	/** @type {Record<Api.WafAction, string>} */
-	const actionColor = {
+	interface Props {
+		series: ActivitySeries[] // bottom-to-top stacking order
+		from: number // x-extreme start, unix ms
+		to: number // x-extreme end, unix ms
+	}
+
+	const { series, from, to }: Props = $props()
+
+	const actionColor: Record<Api.WafAction, string> = {
 		block: 'hsl(var(--hsl-negative))',
 		log: 'hsl(var(--hsl-warning))',
 		allow: 'hsl(var(--hsl-positive))'
@@ -33,12 +33,10 @@
 	const height = 320
 
 	let width = $state(0)
-	/** @type {SVGSVGElement | undefined} */
-	let svgEl = $state()
-	let hover = $state(/** @type {number | null} */ (null))
+	let svgEl = $state<SVGSVGElement | undefined>()
+	let hover = $state<number | null>(null)
 
-	/** @param {HTMLElement} node */
-	function track (node) {
+	function track (node: HTMLElement) {
 		const ro = new ResizeObserver((entries) => {
 			width = entries[0].contentRect.width
 		})
@@ -74,10 +72,10 @@
 		y1: height - PAD.bottom
 	})
 
-	const xScale = $derived((/** @type {number} */ v) =>
+	const xScale = $derived((v: number) =>
 		plot.x0 + ((v - from) / (to - from || 1)) * (plot.x1 - plot.x0))
 
-	const yScale = $derived((/** @type {number} */ v) =>
+	const yScale = $derived((v: number) =>
 		plot.y1 - ((v - yInfo.min) / (yInfo.max - yInfo.min)) * (plot.y1 - plot.y0))
 
 	const colW = $derived.by(() => {
@@ -102,9 +100,9 @@
 	const timeFmt = $derived.by(() => {
 		const span = to - from
 		const day = 86400000
-		if (span <= 2 * day) return (/** @type {number} */ v) => dayjs(v).format('HH:mm')
-		if (span <= 8 * day) return (/** @type {number} */ v) => dayjs(v).format('ddd HH:mm')
-		return (/** @type {number} */ v) => dayjs(v).format('MMM D')
+		if (span <= 2 * day) return (v: number) => dayjs(v).format('HH:mm')
+		if (span <= 8 * day) return (v: number) => dayjs(v).format('ddd HH:mm')
+		return (v: number) => dayjs(v).format('MMM D')
 	})
 
 	const xTicks = $derived.by(() => {
@@ -123,8 +121,7 @@
 		return { px: col.cx, header: dayjs(col.x).format('MMM D, HH:mm'), total: col.total, rows }
 	})
 
-	/** @param {PointerEvent} e */
-	function onMove (e) {
+	function onMove (e: PointerEvent) {
 		if (!columns.length || !svgEl) return
 		const rect = svgEl.getBoundingClientRect()
 		const px = e.clientX - rect.left
@@ -141,14 +138,12 @@
 	// columns even when the finger strays outside the SVG, and reveal the nearest
 	// column on a plain tap. `touch-action: pan-y` leaves vertical page scroll to
 	// the browser, which fires pointercancel and clears the readout on a scroll.
-	/** @param {PointerEvent} e */
-	function onDown (e) {
+	function onDown (e: PointerEvent) {
 		if (e.pointerType !== 'mouse') svgEl?.setPointerCapture?.(e.pointerId)
 		onMove(e)
 	}
 
-	/** @param {PointerEvent} e */
-	function onUp (e) {
+	function onUp (e: PointerEvent) {
 		if (e.pointerType !== 'mouse') hover = null
 	}
 </script>

--- a/src/lib/components/WafConditionBuilder.svelte
+++ b/src/lib/components/WafConditionBuilder.svelte
@@ -1,24 +1,18 @@
-<script>
+<script lang="ts">
 	import { untrack } from 'svelte'
 	import WafConditionRow from '$lib/components/WafConditionRow.svelte'
 	import { buildGroup, parseExpression } from '$lib/waf/expression'
+	import type { ExpressionSpec, Combinator } from '$lib/waf/expression'
 
-	/**
-	 * @typedef {import('$lib/waf/expression').ExpressionSpec} ExpressionSpec
-	 * @typedef {import('$lib/waf/expression').Combinator} Combinator
-	 */
+	interface Props {
+		expression?: string // bindable CEL expression — kept in two-way sync with the rows
+	}
 
-	/**
-	 * @typedef {Object} Props
-	 * @property {string} expression  bindable CEL expression — kept in two-way sync with the rows
-	 */
-
-	/** @type {Props} */
-	let { expression = $bindable('') } = $props()
+	let { expression = $bindable('') }: Props = $props()
 
 	/** A fresh blank condition row. */
-	function blankCondition () {
-		return /** @type {ExpressionSpec} */ ({ field: 'path', operator: 'equals', value: '' })
+	function blankCondition (): ExpressionSpec {
+		return { field: 'path', operator: 'equals', value: '' }
 	}
 
 	// Seed the rows + combinator from the incoming expression. A non-parseable
@@ -26,10 +20,8 @@
 	// `canUseVisual`), but fall back to empty if it does.
 	const seed = untrack(() => parseExpression(expression)) ?? { combinator: 'and', conditions: [] }
 
-	/** @type {ExpressionSpec[]} */
-	let conditions = $state(seed.conditions)
-	/** @type {Combinator} */
-	let combinator = $state(seed.combinator)
+	let conditions = $state<ExpressionSpec[]>(seed.conditions)
+	let combinator = $state<Combinator>(seed.combinator)
 
 	// The CEL string this builder's current rows generate.
 	const generated = $derived(buildGroup(combinator, conditions))
@@ -61,8 +53,7 @@
 		conditions = [...conditions, blankCondition()]
 	}
 
-	/** @param {number} i */
-	function removeCondition (i) {
+	function removeCondition (i: number) {
 		conditions = conditions.filter((_, idx) => idx !== i)
 	}
 

--- a/src/lib/components/WafConditionRow.svelte
+++ b/src/lib/components/WafConditionRow.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import Select from '$lib/components/Select.svelte'
 	import TagInput from '$lib/components/TagInput.svelte'
 	import CountrySelect from '$lib/components/CountrySelect.svelte'
@@ -10,20 +10,15 @@
 		isMultiOperator,
 		parseList
 	} from '$lib/waf/expression'
+	import type { ExpressionSpec } from '$lib/waf/expression'
 
-	/**
-	 * @typedef {import('$lib/waf/expression').ExpressionSpec} ExpressionSpec
-	 */
+	interface Props {
+		condition: ExpressionSpec // bindable structured condition
+		onremove: () => void // remove this row
+		removable?: boolean // show the remove button (default true)
+	}
 
-	/**
-	 * @typedef {Object} Props
-	 * @property {ExpressionSpec} condition  bindable structured condition
-	 * @property {() => void} onremove       remove this row
-	 * @property {boolean} [removable]       show the remove button (default true)
-	 */
-
-	/** @type {Props} */
-	let { condition = $bindable(), onremove, removable = true } = $props()
+	let { condition = $bindable(), onremove, removable = true }: Props = $props()
 
 	const fieldMeta = $derived(getField(condition.field))
 	const fieldType = $derived(fieldMeta?.type ?? 'string')


### PR DESCRIPTION
## What

Batch 4 of the [JS → TS migration](https://github.com/deploys-app/console/pull/239). Converts **all 21 remaining shared components** in `src/lib/components/` to `<script lang="ts">` with fully-strict TypeScript (the 5 pilot components were already done) — **`src/lib/components/` is now 100% TypeScript**. No behavior/markup/style change.

### Converted
- **Badges/icons:** `InvoiceStatusBadge`, `OutcomeBadge`, `StatusIcon`, `Secret`, `DangerZone`
- **Select family:** `Select`, `OptionSelect`
- **Inputs/modals:** `TagInput`, `CountrySelect`, `CreateServiceAccountModal`, `EditGithubLinkModal`, `EnvGroupModal`, `PayInvoiceModal`
- **SVG charts:** `Chart`, `LineChart`, `Sparkline`, `WafActivityChart`
- **Metrics + WAF builders:** `ProjectMetrics`, `UsageMetrics`, `WafConditionBuilder`, `WafConditionRow`

### How
JSDoc `@typedef`/`@type` lifted into `interface` + real annotations; props via `const {…}: Props = $props()`; runes typed as `$state<T>(…)`; chart and WAF-builder types reused from the already-converted `lib/charts/util.ts` and `lib/waf/expression.ts`.

### Verification
- `bun check` → **0 errors / 0 warnings**
- `bun lint` → clean
- `bun build` → succeeds

### No visual change
Pure type refactor. Representative pages exercising the converted components render identically:

**Metrics** (`ProjectMetrics`, `Chart`, `LineChart`):
![metrics](https://raw.githubusercontent.com/deploys-app/console/screenshots/242-metrics.png)

**WAF create** (`Select`, form controls):
![waf-create](https://raw.githubusercontent.com/deploys-app/console/screenshots/242-waf-create.png)

**Audit log** (`OutcomeBadge`, filter `Select`s):
![audit-log](https://raw.githubusercontent.com/deploys-app/console/screenshots/242-audit-log.png)

### Remaining
~82 route-level `.svelte` files (`+page.svelte` and per-route `_components/`). Final batch(es) to come.

🤖 Generated with [Claude Code](https://claude.com/claude-code)