### PR TITLE
chore: migrate (project) route pages to TypeScript (batch 5)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@sveltejs/kit": "=2.62.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@tailwindcss/vite": "=4.3.0",
+        "@types/js-cookie": "^3.0.6",
         "@types/node": "^25.9.1",
         "@typescript-eslint/eslint-plugin": "^8.60.1",
         "@typescript-eslint/parser": "^8.60.1",
@@ -279,6 +280,8 @@
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/js-cookie": ["@types/js-cookie@3.0.6", "", {}, "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@sveltejs/kit": "=2.62.0",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@tailwindcss/vite": "=4.3.0",
+    "@types/js-cookie": "^3.0.6",
     "@types/node": "^25.9.1",
     "@typescript-eslint/eslint-plugin": "^8.60.1",
     "@typescript-eslint/parser": "^8.60.1",

--- a/src/routes/(auth)/(project)/+layout.svelte
+++ b/src/routes/(auth)/(project)/+layout.svelte
@@ -1,10 +1,12 @@
-<script>
+<script lang="ts">
+	import type { LayoutData } from './$types'
+	import type { Snippet } from 'svelte'
 	import Cookie from 'js-cookie'
 	import { onMount, setContext } from 'svelte'
 	import { page } from '$app/stores'
 	import { hasPermission } from '$lib/permission'
 
-	const { data, children } = $props()
+	const { data, children }: { data: LayoutData, children: Snippet } = $props()
 
 	const project = $derived(data.project)
 
@@ -20,8 +22,7 @@
 	// level. `can` reads $page.data at call time, so it always reflects the
 	// current project's permissions after navigation.
 	setContext('permission', {
-		/** @param {string} p */
-		can: (p) => hasPermission($page.data.permissions, $page.data.permissionsAdmin, p)
+		can: (p: string) => hasPermission($page.data.permissions, $page.data.permissionsAdmin, p)
 	})
 
 	onMount(() => {

--- a/src/routes/(auth)/(project)/+page.svelte
+++ b/src/routes/(auth)/(project)/+page.svelte
@@ -1,9 +1,10 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import { onMount } from 'svelte'
 	import api from '$lib/api'
 	import * as format from '$lib/format'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 
 	const unitGiB = 1024 * 1024 * 1024
@@ -18,18 +19,18 @@
 		}
 	})
 
-	function formatNumber (v) {
+	function formatNumber (v: number): string {
 		if (v == null || Number.isNaN(v)) return '?'
 		return v.toLocaleString(undefined, { maximumFractionDigits: 2 })
 	}
-	function formatCompact (v) {
+	function formatCompact (v: number): string {
 		if (v == null || Number.isNaN(v)) return '?'
 		return v.toLocaleString(undefined, {
 			notation: 'compact',
 			maximumFractionDigits: 2
 		})
 	}
-	function formatStorage (bytes, unitSuffix) {
+	function formatStorage (bytes: number, unitSuffix: string) {
 		const gib = bytes / unitGiB
 		if (gib >= 1024) {
 			const tib = gib / 1024
@@ -41,16 +42,16 @@
 		const full = formatNumber(gib)
 		return { value: formatCompact(gib), full, unit, tooltip: `${full} ${unit}` }
 	}
-	function billingElapsedSeconds () {
+	function billingElapsedSeconds (): number {
 		const now = new Date()
 		const start = new Date(now.getFullYear(), now.getMonth(), 1)
 		return Math.max((now.getTime() - start.getTime()) / 1000, 1)
 	}
-	function formatAvgCount (seconds, unit, rawUnit) {
+	function formatAvgCount (seconds: number, unit: string, rawUnit: string) {
 		const avg = seconds / billingElapsedSeconds()
 		return { value: formatCompact(avg), full: formatNumber(avg), unit, tooltip: `${formatNumber(seconds)} ${rawUnit}` }
 	}
-	function rawStorageTooltip (bytes) {
+	function rawStorageTooltip (bytes: number): string {
 		const r = formatStorage(bytes, 's')
 		return `${r.full} ${r.unit}`
 	}
@@ -58,10 +59,10 @@
 	// its average level divides by elapsed days — not seconds like the
 	// continuously-integrated memory/disk metrics. Floor at 1 day so the first of
 	// the month (one snapshot) reads as that snapshot, not an inflated number.
-	function billingElapsedDays () {
+	function billingElapsedDays (): number {
 		return Math.max(billingElapsedSeconds() / 86400, 1)
 	}
-	function rawStorageDayTooltip (bytes) {
+	function rawStorageDayTooltip (bytes: number): string {
 		const r = formatStorage(bytes, 'd')
 		return `${r.full} ${r.unit}`
 	}

--- a/src/routes/(auth)/(project)/+page.ts
+++ b/src/routes/(auth)/(project)/+page.ts
@@ -15,8 +15,8 @@ export const load: PageLoad = async ({ parent, fetch }) => {
 	])
 	return {
 		menu: 'dashboard',
-		usage: usage.result ?? {},
-		price: price.result ?? {},
+		usage: usage.result ?? ({} as Api.ProjectUsage),
+		price: price.result ?? ({} as Api.BillingProject),
 		auditLog: {
 			items: auditLog.result?.items ?? [],
 			error: auditLog.error

--- a/src/routes/(auth)/(project)/audit-log/+page.svelte
+++ b/src/routes/(auth)/(project)/audit-log/+page.svelte
@@ -1,4 +1,5 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import { untrack } from 'svelte'
 	import { SvelteURLSearchParams } from 'svelte/reactivity'
 	import { goto } from '$app/navigation'
@@ -15,7 +16,7 @@
 	// rows are available on the server.
 	const PAGE_SIZE = 50
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const error = $derived(data.error)
@@ -30,11 +31,7 @@
 		{ value: 'serviceAccount', label: 'Service Account' }
 	]
 
-	/**
-	 * @param {string} v
-	 * @returns {Date | null}
-	 */
-	function parseDate (v) {
+	function parseDate (v: string): Date | null {
 		if (!v) return null
 		const d = new Date(v)
 		return isNaN(d.getTime()) ? null : d
@@ -54,8 +51,7 @@
 	// Infinite-scroll state. `data.items` from the loader is just the first
 	// page; we mirror it locally so we can append on scroll, and re-sync it
 	// whenever the loader runs again (filter / project change).
-	/** @type {Api.AuditLogItem[]} */
-	let items = $state([])
+	let items = $state<Api.AuditLogItem[]>([])
 	let hasMore = $state(false)
 	let loadingMore = $state(false)
 	let loadMoreError = $state('')
@@ -81,8 +77,7 @@
 		loadingMore = false
 	})
 
-	/** @type {HTMLElement | null} */
-	let sentinel = $state(null)
+	let sentinel = $state<HTMLElement | null>(null)
 	$effect(() => {
 		if (!sentinel) return
 		const io = new IntersectionObserver((entries) => {
@@ -92,11 +87,7 @@
 		return () => io.disconnect()
 	})
 
-	/**
-	 * @param {string} v
-	 * @returns {string | undefined}
-	 */
-	function toRFC3339 (v) {
+	function toRFC3339 (v: string): string | undefined {
 		if (!v) return undefined
 		const d = new Date(v)
 		if (isNaN(d.getTime())) return undefined
@@ -109,8 +100,7 @@
 		loadingMore = true
 		loadMoreError = ''
 		try {
-			/** @type {Api.Response<Api.List<Api.AuditLogItem>>} */
-			const res = await api.invoke('auditLog.list', {
+			const res = await api.invoke<Api.List<Api.AuditLogItem>>('auditLog.list', {
 				project,
 				resourceType: data.filters.resourceType,
 				actor: data.filters.actor,
@@ -150,16 +140,13 @@
 		isDatePickerOpen = !isDatePickerOpen
 	}
 
-	function clearDateRange (e) {
+	function clearDateRange (e: Event) {
 		e.stopPropagation()
 		form.startDate = null
 		form.endDate = null
 	}
 
-	/**
-	 * @param {Event} e
-	 */
-	async function apply (e) {
+	async function apply (e: SubmitEvent) {
 		e.preventDefault()
 		if (applying) return
 		applying = true

--- a/src/routes/(auth)/(project)/cache/+page.svelte
+++ b/src/routes/(auth)/(project)/cache/+page.svelte
@@ -1,4 +1,5 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import Sparkline from '$lib/components/Sparkline.svelte'
@@ -7,13 +8,13 @@
 	import api from '$lib/api'
 	import * as format from '$lib/format'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const zones = $derived(data.zones)
 	const error = $derived(data.error)
 
-	const hasPending = $derived(zones.some((/** @type {Api.CacheZone} */ z) => z.status === 'pending'))
+	const hasPending = $derived(zones.some((z: Api.CacheZone) => z.status === 'pending'))
 
 	// While any zone is still being applied/removed by the deployer, poll
 	// cache.list so the spinner resolves to its settled state on its own. Mirrors
@@ -26,14 +27,12 @@
 	// Last 24h of cache decision activity per location, shown as an inline
 	// sparkline + total. Fetched client-side (one cache.metrics per zone, in
 	// parallel) so the table renders immediately and the charts fill in.
-	/**
-	 * @typedef {Object} Metrics
-	 * @property {boolean} loading
-	 * @property {number} total
-	 * @property {[number, number][]} points
-	 */
-	/** @type {Record<string, Metrics>} */
-	const metrics = $state({})
+	interface Metrics {
+		loading: boolean
+		total: number
+		points: [number, number][]
+	}
+	const metrics = $state<Record<string, Metrics>>({})
 
 	// Fixed 24h x-domain so bars sit at the right time-of-day even when the zone
 	// only has a few active minutes.
@@ -41,11 +40,10 @@
 	const from = to - 24 * 60 * 60
 
 	onMount(() => {
-		Promise.all(zones.map(async (/** @type {Api.CacheZone} */ z) => {
+		Promise.all(zones.map(async (z: Api.CacheZone) => {
 			metrics[z.location] = { loading: true, total: 0, points: [] }
 
-			/** @type {Api.Response<Api.CacheMetricsResult>} */
-			const res = await api.invoke('cache.metrics',
+			const res = await api.invoke<Api.CacheMetricsResult>('cache.metrics',
 				{ project, location: z.location, timeRange: '1d' }, fetch)
 
 			metrics[z.location] = {
@@ -58,20 +56,15 @@
 
 	// Collapse the per-(override, action, result) series into one total-decisions
 	// line: sum every series' value at each timestamp, then sort by time.
-	/**
-	 * @param {Api.CacheMetricsSeries[]} series
-	 * @returns {[number, number][]}
-	 */
-	function aggregate (series) {
-		/** @type {Record<number, number>} */
-		const byTs = {}
+	function aggregate (series: Api.CacheMetricsSeries[]): [number, number][] {
+		const byTs: Record<number, number> = {}
 		for (const s of series) {
 			for (const [ts, v] of s.points ?? []) {
 				byTs[ts] = (byTs[ts] ?? 0) + v
 			}
 		}
 		return Object.entries(byTs)
-			.map(([ts, v]) => /** @type {[number, number]} */ ([Number(ts), v]))
+			.map(([ts, v]) => ([Number(ts), v] as [number, number]))
 			.sort((a, b) => a[0] - b[0])
 	}
 </script>

--- a/src/routes/(auth)/(project)/cache/create/+page.svelte
+++ b/src/routes/(auth)/(project)/cache/create/+page.svelte
@@ -1,11 +1,12 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const locations = $derived(data.locations)
@@ -17,8 +18,7 @@
 
 	let saving = $state(false)
 
-	/** @param {Event} e */
-	async function save (e) {
+	async function save (e: SubmitEvent) {
 		e.preventDefault()
 		if (saving) return
 

--- a/src/routes/(auth)/(project)/cache/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/cache/edit/+page.svelte
@@ -1,4 +1,5 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import { untrack } from 'svelte'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
@@ -15,7 +16,7 @@
 		ttlOptions
 	} from '$lib/cache/overrides'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const location = $derived(data.location)
@@ -65,9 +66,9 @@
 	// textarea), same pattern as the WAF editors. The filter is optional: empty
 	// means the override applies to every request.
 	const canUseVisual = $derived(parseExpression(draft.filter) !== null)
-	let filterMode = $state(/** @type {'visual' | 'raw'} */ (
+	let filterMode = $state<'visual' | 'raw'>(
 		untrack(() => (parseExpression(draft.filter) !== null ? 'visual' : 'raw'))
-	))
+	)
 
 	// If we're in Visual but the filter becomes non-representable, fall back to
 	// raw so the disabled Visual tab can't show stale rows.
@@ -75,8 +76,7 @@
 		if (filterMode === 'visual' && !canUseVisual) filterMode = 'raw'
 	})
 
-	/** @type {{ clearExpression: () => void } | undefined} */
-	let filterBuilder = $state()
+	let filterBuilder = $state<{ clearExpression:() => void } | undefined>()
 
 	function clearFilter () {
 		if (filterMode === 'visual' && filterBuilder) filterBuilder.clearExpression()
@@ -98,14 +98,12 @@
 		return goto(`/cache/manage?project=${project}&location=${encodeURIComponent(location)}`)
 	}
 
-	/** @param {Event} e */
-	async function save (e) {
+	async function save (e: SubmitEvent) {
 		e.preventDefault()
 		if (saving || !canSave) return
 
 		// Parse the comma-separated status list into positive integers (cache only).
-		/** @type {number[]} */
-		const status = statusText
+		const status: number[] = statusText
 			.split(',')
 			.map((s) => Number(s.trim()))
 			.filter((s) => Number.isInteger(s) && s > 0)
@@ -116,7 +114,7 @@
 		try {
 			// Rebuild the zone's override list with the edited override replaced by
 			// id (or appended for create), then write the whole zone.
-			let nextOverrides
+			let nextOverrides: typeof overrides
 			if (isCreate) {
 				nextOverrides = [...overrides, edited]
 			} else {
@@ -146,10 +144,8 @@
 	// Enter inside a text field (description, ttl/stale inputs, status list) must
 	// not implicitly submit the override. Saving is deliberate, via the Save
 	// button (a <button>, where Enter still works) and the raw-CEL <textarea>.
-	/** @param {HTMLFormElement} node */
-	function blockEnterSubmit (node) {
-		/** @param {KeyboardEvent} e */
-		function onKeydown (e) {
+	function blockEnterSubmit (node: HTMLFormElement) {
+		function onKeydown (e: KeyboardEvent) {
 			if (e.key === 'Enter' && e.target instanceof HTMLInputElement) e.preventDefault()
 		}
 		node.addEventListener('keydown', onKeydown)

--- a/src/routes/(auth)/(project)/cache/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/cache/manage/+page.svelte
@@ -1,4 +1,6 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
+	import type { OverrideForm } from '$lib/cache/overrides'
 	import { untrack } from 'svelte'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
@@ -13,7 +15,7 @@
 		toApiOverrides
 	} from '$lib/cache/overrides'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const location = $derived(data.location)
@@ -42,8 +44,7 @@
 	let savingDescription = $state(false)
 
 	async function reloadZone () {
-		/** @type {Api.Response<Api.CacheZone>} */
-		const resp = await api.invoke('cache.get', { project, location }, fetch)
+		const resp = await api.invoke<Api.CacheZone>('cache.get', { project, location }, fetch)
 		if (!resp.ok) {
 			if (resp.error?.notFound) {
 				// The zone disappeared underneath us — back to the index.
@@ -61,10 +62,7 @@
 	// Persist the whole zone (priority follows row order). cache.set replaces the
 	// entire zone, so every override must always travel together. On error,
 	// surface it and reload from the server so the UI matches reality.
-	/**
-	 * @param {import('$lib/cache/overrides').OverrideForm[]} nextOverrides
-	 */
-	async function persistZone (nextOverrides) {
+	async function persistZone (nextOverrides: OverrideForm[]) {
 		const resp = await api.invoke('cache.set', {
 			project,
 			location,
@@ -79,11 +77,7 @@
 		return true
 	}
 
-	/**
-	 * @param {number} i
-	 * @param {-1 | 1} dir
-	 */
-	async function moveOverride (i, dir) {
+	async function moveOverride (i: number, dir: -1 | 1) {
 		const j = i + dir
 		if (j < 0 || j >= overrides.length) return
 		const next = [...overrides]
@@ -92,8 +86,7 @@
 		await persistZone(next)
 	}
 
-	/** @param {number} i */
-	function removeOverride (i) {
+	function removeOverride (i: number) {
 		const override = overrides[i]
 		if (!override) return
 		modal.confirm({
@@ -107,8 +100,7 @@
 		})
 	}
 
-	/** @param {import('$lib/cache/overrides').OverrideForm} override */
-	function editOverride (override) {
+	function editOverride (override: OverrideForm) {
 		goto(`/cache/edit?project=${project}&location=${encodeURIComponent(location)}&override=${encodeURIComponent(override.id)}`)
 	}
 

--- a/src/routes/(auth)/(project)/cache/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/cache/metrics/+page.svelte
@@ -1,4 +1,6 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
+	import type { LineSeries } from '$lib/charts/util'
 	import { onMount } from 'svelte'
 	import { page } from '$app/stores'
 	import { replaceState } from '$app/navigation'
@@ -8,7 +10,7 @@
 	import { actionLabels, describeOverride, modeLabels, normalizeOverrides } from '$lib/cache/overrides'
 	import LineChart from '$lib/components/LineChart.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const location = $derived(data.location)
@@ -21,12 +23,9 @@
 	))
 
 	// The three caching results, in chart stacking/legend order.
-	/** @type {Api.CacheMetricsSeries['result'][]} */
-	const RESULT_ORDER = ['applied', 'shadow', 'error']
-	/** @type {Record<string, string>} */
-	const RESULT_LABEL = { applied: 'Applied', shadow: 'Shadow', error: 'Error' }
-	/** @type {Record<string, string>} */
-	const RESULT_COLOR = {
+	const RESULT_ORDER: Api.CacheMetricsSeries['result'][] = ['applied', 'shadow', 'error']
+	const RESULT_LABEL: Record<string, string> = { applied: 'Applied', shadow: 'Shadow', error: 'Error' }
+	const RESULT_COLOR: Record<string, string> = {
 		applied: 'hsl(var(--hsl-positive))',
 		shadow: 'hsl(var(--hsl-content) / 0.45)',
 		error: 'hsl(var(--hsl-negative))'
@@ -40,10 +39,8 @@
 		{ value: '7d', label: '7D' },
 		{ value: '30d', label: '30D' }
 	]
-	/** @type {Record<string, number>} */
-	const RANGE_SECONDS = { '1h': 3600, '6h': 21600, '12h': 43200, '1d': 86400, '7d': 604800, '30d': 2592000 }
-	/** @type {Record<string, string>} */
-	const RANGE_LABEL = {
+	const RANGE_SECONDS: Record<string, number> = { '1h': 3600, '6h': 21600, '12h': 43200, '1d': 86400, '7d': 604800, '30d': 2592000 }
+	const RANGE_LABEL: Record<string, string> = {
 		'1h': 'last hour',
 		'6h': 'last 6 hours',
 		'12h': 'last 12 hours',
@@ -52,26 +49,23 @@
 		'30d': 'last 30 days'
 	}
 	// Bucket width per range — kept around 48–72 columns so lines stay legible.
-	/** @type {Record<string, number>} */
-	const BUCKET_SECONDS = { '1h': 60, '6h': 300, '12h': 600, '1d': 1800, '7d': 10800, '30d': 43200 }
+	const BUCKET_SECONDS: Record<string, number> = { '1h': 60, '6h': 300, '12h': 600, '1d': 1800, '7d': 10800, '30d': 43200 }
 
 	const initialRange = $page.url.searchParams.get('range')
 	let range = $state(initialRange && RANGE_SECONDS[initialRange] ? initialRange : '1d')
 
 	let loading = $state(true)
-	let result = $state(/** @type {Api.CacheMetricsResult | null} */ (null))
+	let result = $state<Api.CacheMetricsResult | null>(null)
 	// Anchor the time window to the moment of the latest fetch so the chart grid
 	// and "as of" line agree.
 	let fetchedAt = $state(Math.floor(Date.now() / 1000))
 
-	/** @type {ReturnType<typeof setTimeout> | undefined} */
-	let refreshTimer
+	let refreshTimer: ReturnType<typeof setTimeout> | undefined
 
 	async function fetchMetrics () {
 		loading = true
 		try {
-			/** @type {Api.Response<Api.CacheMetricsResult>} */
-			const res = await api.invoke('cache.metrics', { project, location, timeRange: range }, fetch)
+			const res = await api.invoke<Api.CacheMetricsResult>('cache.metrics', { project, location, timeRange: range }, fetch)
 			if (!res.ok) {
 				modal.error({ error: res.error })
 				return
@@ -93,8 +87,7 @@
 		}
 	}
 
-	/** @param {string} r */
-	function selectRange (r) {
+	function selectRange (r: string) {
 		if (r === range) return
 		range = r
 		const u = new URL($page.url)
@@ -113,8 +106,7 @@
 
 	// Totals per result, for the KPI tiles.
 	const byResult = $derived.by(() => {
-		/** @type {Record<string, number>} */
-		const acc = { applied: 0, shadow: 0, error: 0 }
+		const acc: Record<string, number> = { applied: 0, shadow: 0, error: 0 }
 		for (const s of result?.series ?? []) {
 			acc[s.result] = (acc[s.result] ?? 0) + s.total
 		}
@@ -138,8 +130,7 @@
 		const to = fetchedAt
 		const n = Math.max(1, Math.ceil((to - from) / bucket))
 
-		/** @type {Record<string, number[]>} */
-		const grids = { applied: new Array(n).fill(0), shadow: new Array(n).fill(0), error: new Array(n).fill(0) }
+		const grids: Record<string, number[]> = { applied: new Array(n).fill(0), shadow: new Array(n).fill(0), error: new Array(n).fill(0) }
 		for (const s of result?.series ?? []) {
 			const g = grids[s.result]
 			if (!g) continue
@@ -149,8 +140,7 @@
 			}
 		}
 
-		/** @type {import('$lib/charts/util').LineSeries[]} */
-		return RESULT_ORDER
+		const out: LineSeries[] = RESULT_ORDER
 			.filter((res) => byResult[res] > 0)
 			.map((res) => ({
 				name: RESULT_LABEL[res],
@@ -158,13 +148,13 @@
 				dashed: res === 'shadow',
 				points: grids[res].map((v, i) => ({ x: (from + i * bucket) * 1000, y: v }))
 			}))
+		return out
 	})
 
 	// Rank overrides by decision volume. Each (override, action, result) series
 	// collapses onto its override; the action of its largest series wins the badge.
 	const topOverrides = $derived.by(() => {
-		/** @type {Record<string, { overrideId: string, total: number, action: Api.CacheAction, top: number }>} */
-		const byOverride = {}
+		const byOverride: Record<string, { overrideId: string, total: number, action: Api.CacheAction, top: number }> = {}
 		for (const s of result?.series ?? []) {
 			const cur = byOverride[s.overrideId]
 			if (cur) {
@@ -182,12 +172,10 @@
 			.sort((a, b) => b.total - a.total)
 	})
 
-	/** @param {number} v */
-	function share (v) {
+	function share (v: number): number {
 		return total > 0 ? v / total : 0
 	}
-	/** @param {number} v */
-	function pct (v) {
+	function pct (v: number): string {
 		return total > 0 ? `${Math.round((v / total) * 100)}%` : '—'
 	}
 

--- a/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
@@ -1,10 +1,12 @@
-<script>
+<script lang="ts">
 	import Header from '../_components/Header.svelte'
 	import { page } from '$app/stores'
 	import { onMount } from 'svelte'
 	import api from '$lib/api'
+	import type { LayoutData } from './$types'
+	import type { Snippet } from 'svelte'
 
-	const { data, children } = $props()
+	const { data, children }: { data: LayoutData, children: Snippet } = $props()
 
 	const project = $derived(data.project)
 	const deployment = $derived(data.deployment)
@@ -23,8 +25,7 @@
 			])
 	])
 
-	/** @param {string} path */
-	function tabHref (path) {
+	function tabHref (path: string): string {
 		return `${path}?project=${project}&location=${deployment.location}&name=${deployment.name}`
 	}
 

--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { onMount } from 'svelte'
 	import { setupCopy } from '$lib/clipboard'
 	import * as format from '$lib/format'
@@ -9,19 +9,18 @@
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import Secret from '$lib/components/Secret.svelte'
 	import EnvGroupModal from '$lib/components/EnvGroupModal.svelte'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const deployment = $derived(data.deployment)
 	const location = $derived(data.location)
 
-	/** @type {?EnvGroupModal} */
-	let envGroupModal = $state(null)
+	let envGroupModal = $state<EnvGroupModal | null>(null)
 	let showAllEnv = $state(false)
 
-	/** @param {string} name */
-	async function viewEnvGroup (name) {
-		const resp = await api.invoke('envGroup.get', { project: deployment.project, name }, fetch)
+	async function viewEnvGroup (name: string) {
+		const resp = await api.invoke<Api.EnvGroup>('envGroup.get', { project: deployment.project, name }, fetch)
 		if (!resp.ok) {
 			modal.error({ error: resp.error })
 			return

--- a/src/routes/(auth)/(project)/deployment/(detail)/events/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/events/+page.svelte
@@ -1,8 +1,16 @@
-<script>
+<script lang="ts">
 	import { onMount } from 'svelte'
 	import { podPrefixStripper } from '$lib/deployment/podName'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	interface DeploymentEvent {
+		type: string
+		reason: string
+		message: string
+		lastSeen: string
+	}
+
+	const { data }: { data: PageData } = $props()
 
 	const deployment = $derived(data.deployment)
 
@@ -13,8 +21,7 @@
 
 	const POLL_INTERVAL_MS = 5000
 
-	/** @type {Array<{type: string, reason: string, message: string, lastSeen: string}>} */
-	let events = $state([])
+	let events = $state<DeploymentEvent[]>([])
 	let lastFetchOk = $state(false)
 	let lastFetchAt = $state(0)
 	let now = $state(Date.now())
@@ -47,22 +54,15 @@
 		}
 	}
 
-	/**
-	 * @param {string} type
-	 * @returns {'warn' | 'error' | 'normal'}
-	 */
-	function severityOf (type) {
+	function severityOf (type: string): 'warn' | 'error' | 'normal' {
 		const t = type.toLowerCase()
 		if (t === 'normal') return 'normal'
 		if (t === 'warning' || t === 'warn') return 'warn'
 		return 'error'
 	}
 
-	/**
-	 * @param {string | number} ts ISO 8601 or unix ms
-	 * @param {number} nowMs
-	 */
-	function relTime (ts, nowMs) {
+	// ts is ISO 8601 or unix ms
+	function relTime (ts: string | number, nowMs: number): string {
 		const t = typeof ts === 'number' ? ts : Date.parse(ts)
 		if (isNaN(t)) return ''
 		const diff = Math.max(0, nowMs - t)

--- a/src/routes/(auth)/(project)/deployment/(detail)/logs/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/logs/+page.svelte
@@ -1,9 +1,10 @@
-<script>
+<script lang="ts">
 	import { onMount } from 'svelte'
 	import { SvelteSet } from 'svelte/reactivity'
 	import { podPrefixStripper } from '$lib/deployment/podName'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const deployment = $derived(data.deployment)
 
@@ -19,25 +20,22 @@
 	const FLUSH_INTERVAL_MS = 500
 	const THROUGHPUT_WINDOW_MS = 5000
 
-	/**
-	 * @typedef {{
-	 *   id: number,
-	 *   pod: string,
-	 *   timestamp: string,
-	 *   log: string,
-	 *   severity: 'error' | 'warn' | 'debug' | 'plain'
-	 * }} LogLine
-	 */
+	interface LogLine {
+		id: number
+		pod: string
+		timestamp: string
+		log: string
+		severity: 'error' | 'warn' | 'debug' | 'plain'
+	}
 
-	/** @type {LogLine[]} newest first, exactly what is rendered */
-	let lines = $state([])
-	/** @type {LogLine[]} arrival order (oldest → newest); merged on flush */
-	const pending = []
+	// newest first, exactly what is rendered
+	let lines = $state<LogLine[]>([])
+	// arrival order (oldest → newest); merged on flush
+	const pending: LogLine[] = []
 	let nextId = 1
 
 	// Sliding-window arrival times for throughput display, pruned each tick.
-	/** @type {number[]} */
-	const recentArrivals = []
+	const recentArrivals: number[] = []
 
 	let paused = $state(false)
 	let connected = $state(false)
@@ -48,8 +46,7 @@
 	let now = $state(Date.now())
 	let filter = $state('')
 
-	/** @param {string} log */
-	function detectSeverity (log) {
+	function detectSeverity (log: string): LogLine['severity'] {
 		const t = log.toLowerCase()
 		if (/\b(error|fatal|panic|exception|critical|fail(ed|ure)?)\b/.test(t)) return 'error'
 		if (/\b(warn(ing)?|deprecated)\b/.test(t)) return 'warn'
@@ -61,18 +58,14 @@
 	// name into this palette gives every pod a stable, distinguishable
 	// colour so multi-replica streams stay visually separable.
 	const POD_HUES = [355, 28, 48, 142, 175, 205, 260, 312]
-	/** @param {string} s */
-	function podHue (s) {
+	function podHue (s: string): number {
 		let h = 0
 		for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0
 		return POD_HUES[Math.abs(h) % POD_HUES.length]
 	}
 
-	/**
-	 * @param {string} ts ISO 8601
-	 * @param {number} nowMs
-	 */
-	function relTime (ts, nowMs) {
+	// ts is ISO 8601
+	function relTime (ts: string, nowMs: number): string {
 		const t = Date.parse(ts)
 		if (isNaN(t)) return ''
 		const diff = Math.max(0, nowMs - t)
@@ -87,7 +80,7 @@
 	const filteredIds = $derived.by(() => {
 		const f = filter.trim().toLowerCase()
 		if (!f) return null
-		const s = new SvelteSet()
+		const s = new SvelteSet<number>()
 		for (const l of lines) {
 			if (l.log.toLowerCase().includes(f) || l.pod.toLowerCase().includes(f)) s.add(l.id)
 		}

--- a/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
@@ -1,11 +1,35 @@
-<script>
+<script lang="ts">
 	import { page } from '$app/stores'
 	import { replaceState } from '$app/navigation'
 	import api from '$lib/api'
 	import { onMount, tick, untrack } from 'svelte'
 	import Chart from '$lib/components/Chart.svelte'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	interface MetricLine {
+		name: string
+		points: [number, number][]
+	}
+
+	interface MetricSeries {
+		prefix: string
+		lines: MetricLine[]
+		dashStyle?: string
+		color?: string
+	}
+
+	interface DeploymentMetricsResult {
+		cpuUsage?: MetricLine[]
+		cpuLimit?: MetricLine[]
+		memoryUsage?: MetricLine[]
+		memory?: MetricLine[]
+		memoryLimit?: MetricLine[]
+		requests?: MetricLine[]
+		egress?: MetricLine[]
+		storage?: MetricLine[]
+	}
+
+	const { data }: { data: PageData } = $props()
 
 	// Two-row pill bar: top row is the rolling-window options, bottom row is
 	// the aggregate (longer) windows. Aggregate options are tagged so we can
@@ -43,13 +67,13 @@
 		range: initialRange && validRanges.has(initialRange) ? initialRange : defaultRange
 	})
 
-	let cpu = $state([])
-	let memory = $state([])
-	let request = $state([])
-	let egress = $state([])
-	let storage = $state([])
+	let cpu = $state<MetricSeries[]>([])
+	let memory = $state<MetricSeries[]>([])
+	let request = $state<MetricSeries[]>([])
+	let egress = $state<MetricSeries[]>([])
+	let storage = $state<MetricSeries[]>([])
 
-	let reloadTimeout
+	let reloadTimeout: ReturnType<typeof setTimeout> | null = null
 	let lastFetchAt = $state(0)
 	let now = $state(Date.now())
 	let fetching = $state(false)
@@ -60,7 +84,7 @@
 		fetching = true
 
 		try {
-			const resp = await api.invoke('deployment.metrics', {
+			const resp = await api.invoke<DeploymentMetricsResult>('deployment.metrics', {
 				project: deployment.project,
 				location: deployment.location,
 				name: deployment.name,
@@ -101,8 +125,7 @@
 		}
 	}
 
-	/** @param {string} value */
-	function setRange (value) {
+	function setRange (value: string) {
 		if (value === filter.range) return
 		filter.range = value
 		const u = new URL($page.url)
@@ -120,8 +143,7 @@
 		}
 	})
 
-	/** @param {number} t */
-	function relTime (t) {
+	function relTime (t: number): string {
 		if (!t) return '—'
 		const diff = Math.max(0, now - t)
 		if (diff < 60_000) return `${Math.floor(diff / 1000)}s ago`

--- a/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { onMount, getContext } from 'svelte'
 	import * as format from '$lib/format'
 	import { goto } from '$app/navigation'
@@ -6,11 +6,11 @@
 	import api from '$lib/api'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import { denyTooltip } from '$lib/permission'
+	import type { PageData } from './$types'
 
-	/** @type {{ can: (p: string) => boolean }} */
-	const { can } = getContext('permission')
+	const { can } = getContext('permission') as { can: (p: string) => boolean }
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 	const deployment = $derived(data.deployment)
 	const revisions = $derived(data.revisions)
 
@@ -22,10 +22,8 @@
 
 	/**
 	 * Per-revision artifact label: the release-sha for Static, else the image.
-	 * @param {Api.Deployment} it
-	 * @returns {string}
 	 */
-	function artifact (it) {
+	function artifact (it: Api.Deployment): string {
 		return isStatic ? format.releaseSha(it) : it.image
 	}
 
@@ -39,11 +37,7 @@
 		return () => clearInterval(t)
 	})
 
-	/**
-	 * @param {string} ts
-	 * @param {number} nowMs
-	 */
-	function relTime (ts, nowMs) {
+	function relTime (ts: string, nowMs: number): string {
 		const t = Date.parse(ts)
 		if (isNaN(t)) return ''
 		const diff = Math.max(0, nowMs - t)
@@ -62,28 +56,25 @@
 	// and the revision whose image + configuration will be redeployed. Both
 	// carry user-provided content (image refs), which Svelte interpolation
 	// escapes for free.
-	let rollbackTarget = $state(/** @type {?Api.Deployment} */ (null))
+	let rollbackTarget = $state<Api.Deployment | null>(null)
 	let rollingBack = $state(false)
 
 	// Full spec of the rollback target (deployment.get with revision returns
 	// the historical spec), fetched when the modal opens so the diff below the
 	// comparison cards can show exactly which configuration changes hands.
-	let targetSpec = $state(/** @type {?Api.Deployment} */ (null))
+	let targetSpec = $state<Api.Deployment | null>(null)
 	let targetLoading = $state(false)
 
-	/** @param {Api.Deployment} it */
-	function rollback (it) {
+	function rollback (it: Api.Deployment) {
 		rollbackTarget = it
 		loadTargetSpec(it.revision)
 	}
 
-	/** @param {number} revision */
-	async function loadTargetSpec (revision) {
+	async function loadTargetSpec (revision: number) {
 		targetSpec = null
 		targetLoading = true
 		try {
-			/** @type {Api.Response<Api.Deployment>} */
-			const resp = await api.invoke('deployment.get', {
+			const resp = await api.invoke<Api.Deployment>('deployment.get', {
 				project: deployment.project,
 				location: deployment.location,
 				name: deployment.name,
@@ -99,11 +90,7 @@
 		}
 	}
 
-	/**
-	 * @param {string[]} [xs]
-	 * @returns {string}
-	 */
-	function joinOrDash (xs) {
+	function joinOrDash (xs?: string[]): string {
 		return xs?.length ? xs.join(' ') : '—'
 	}
 
@@ -113,14 +100,8 @@
 	const specChanges = $derived.by(() => {
 		const t = targetSpec
 		if (!t) return []
-		/** @type {{ label: string, from: string, to: string }[]} */
-		const rows = []
-		/**
-		 * @param {string} label
-		 * @param {string} from
-		 * @param {string} to
-		 */
-		const add = (label, from, to) => {
+		const rows: { label: string, from: string, to: string }[] = []
+		const add = (label: string, from: string, to: string) => {
 			if (from !== to) rows.push({ label, from, to })
 		}
 		add('Type', deployment.type, t.type)
@@ -146,8 +127,7 @@
 		const from = deployment.env ?? {}
 		const to = t.env ?? {}
 		const keys = [...new Set([...Object.keys(from), ...Object.keys(to)])].sort()
-		/** @type {{ key: string, kind: 'added' | 'removed' | 'changed', from: string, to: string }[]} */
-		const rows = []
+		const rows: { key: string, kind: 'added' | 'removed' | 'changed', from: string, to: string }[] = []
 		for (const key of keys) {
 			const a = from[key]
 			const b = to[key]
@@ -169,9 +149,8 @@
 
 	/**
 	 * Close only on a true backdrop click, not on clicks inside the panel.
-	 * @param {MouseEvent} e
 	 */
-	function onRollbackBackdrop (e) {
+	function onRollbackBackdrop (e: MouseEvent) {
 		if (e.target === e.currentTarget) closeRollback()
 	}
 

--- a/src/routes/(auth)/(project)/deployment/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import DeploymentStatusIcon from '$lib/components/DeploymentStatusIcon.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as format from '$lib/format'
@@ -6,8 +6,9 @@
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import api from '$lib/api'
 	import { onMount } from 'svelte'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const deployments = $derived(data.deployments)
@@ -33,7 +34,7 @@
 	}, 4000))
 
 	// Per-type glyph + label for the chip on each row's meta line.
-	const typeMeta = {
+	const typeMeta: Record<string, { icon: string, label: string }> = {
 		WebService: { icon: 'fa-globe', label: 'Web Service' },
 		TCPService: { icon: 'fa-ethernet', label: 'TCP Service' },
 		InternalTCPService: { icon: 'fa-network-wired', label: 'Internal TCP' },
@@ -50,10 +51,8 @@
 	 * A pending delete reuses the same `status: 'pending'` as a fresh deploy, so
 	 * the action has to be checked first — otherwise a deployment being torn down
 	 * would mislabel as "Deploying".
-	 * @param {Api.Deployment} it
-	 * @returns {{ label: string, tone: string } | null}
 	 */
-	function statusPill (it) {
+	function statusPill (it: Api.Deployment): { label: string, tone: string } | null {
 		if (it.action === 'delete') {
 			return { label: 'Deleting', tone: 'negative' }
 		}

--- a/src/routes/(auth)/(project)/deployment/_components/Header.svelte
+++ b/src/routes/(auth)/(project)/deployment/_components/Header.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import DeploymentStatusIcon from '$lib/components/DeploymentStatusIcon.svelte'
 	import { getContext } from 'svelte'
 	import { page } from '$app/stores'
@@ -7,19 +7,16 @@
 	import * as format from '$lib/format'
 	import { denyTooltip } from '$lib/permission'
 
-	/**
-	 * @typedef {Object} Props
-	 * @property {Api.Deployment} deployment
-	 * @property {() => void} invalidate
-	 */
+	interface Props {
+		deployment: Api.Deployment
+		invalidate: () => void
+	}
 
-	/** @type {Props} */
-	const { deployment, invalidate } = $props()
+	const { deployment, invalidate }: Props = $props()
 
 	const project = $derived($page.data.project)
 
-	/** @type {{ can: (p: string) => boolean }} */
-	const { can } = getContext('permission')
+	const { can } = getContext('permission') as { can: (p: string) => boolean }
 
 	// Static deployments serve a release from the edge and have no container/pods.
 	// The console deploy form is container-image only (a static revision needs a

--- a/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import * as format from '$lib/format'
 	import { onMount, tick, untrack } from 'svelte'
 	import { goto } from '$app/navigation'
@@ -7,8 +7,21 @@
 	import EnvGroupModal from '$lib/components/EnvGroupModal.svelte'
 	import Select from '$lib/components/Select.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	// Editable sidecar shape used by the form. Mirrors Api.SidecarForm but keeps
+	// `type` as a plain string so the <Select> two-way binding (value:
+	// string | number) type-checks.
+	interface FormSidecar {
+		type: string
+		cloudSqlProxy: {
+			instance: string
+			port: number | null
+			credentials: string
+		}
+	}
+
+	const { data }: { data: PageData } = $props()
 
 	const locations = $derived(data.locations)
 	const quota = $derived(data.projectInfo.quota)
@@ -24,17 +37,13 @@
 		envGroups: true
 	})
 
-	/** @type {Api.PullSecret[]} */
-	let pullSecrets = $state([])
+	let pullSecrets = $state<Api.PullSecret[]>([])
 
-	/** @type {Api.WorkloadIdentity[]} */
-	let workloadIdentities = $state([])
+	let workloadIdentities = $state<Api.WorkloadIdentity[]>([])
 
-	/** @type {Api.Disk[]} */
-	let disks = $state([])
+	let disks = $state<Api.Disk[]>([])
 
-	/** @type {Api.EnvGroup[]} */
-	let envGroups = $state([])
+	let envGroups = $state<Api.EnvGroup[]>([])
 
 	const form = $state({
 		location: deployment?.location || '',
@@ -46,10 +55,8 @@
 		port: 8080,
 		protocol: 'http',
 		internal: false, // default for WebService
-		/** @type {string[]} */
-		command: [],
-		/** @type {string[]} */
-		args: [],
+		command: [] as string[],
+		args: [] as string[],
 		schedule: '',
 		disk: {
 			name: '',
@@ -66,14 +73,10 @@
 				cpu: '0'
 			}
 		},
-		/** @type {{ k: string, v: string }[]} */
-		env: [],
-		/** @type {string[]} */
-		envGroups: [],
-		/** @type {{ k: string, v: string }[]} */
-		mountData: [],
-		/** @type {Api.SidecarForm[]} */
-		sidecars: [],
+		env: [] as { k: string, v: string }[],
+		envGroups: [] as string[],
+		mountData: [] as { k: string, v: string }[],
+		sidecars: [] as FormSidecar[],
 		ttlValue: 0,
 		// unit in seconds; '0' means no auto-delete
 		ttlUnit: '0'
@@ -84,10 +87,8 @@
 	// leak as top-level request fields. We assemble a single nested `access` object
 	// after the spread instead. nil/false => public.
 	let requireGoogleLogin = $state(false)
-	/** @type {string[]} */
-	let allowedEmails = $state([])
-	/** @type {string[]} */
-	let allowedDomains = $state([])
+	let allowedEmails = $state<string[]>([])
+	let allowedDomains = $state<string[]>([])
 
 	if (deployment) {
 		form.location = deployment.location
@@ -113,7 +114,7 @@
 		form.env = Object.entries(deployment.env || {}).map(([k, v]) => ({ k, v }))
 		form.envGroups = [...(deployment.envGroups || [])]
 		form.mountData = Object.entries(deployment.mountData || {}).map(([k, v]) => ({ k, v }))
-		form.sidecars = (deployment.sidecars || []).map((s) => {
+		form.sidecars = (deployment.sidecars || []).map((s): FormSidecar => {
 			if (s.cloudSqlProxy) {
 				return {
 					type: 'cloudSqlProxy',
@@ -154,7 +155,7 @@
 			return
 		}
 
-		const resp = await api.invoke('pullSecret.list', { project, location: selectedLocation.id }, fetch)
+		const resp = await api.invoke<Api.List<Api.PullSecret>>('pullSecret.list', { project, location: selectedLocation.id }, fetch)
 		if (!resp.ok) {
 			if (resp.error?.forbidden) {
 				permission.pullSecrets = false
@@ -172,7 +173,7 @@
 			return
 		}
 
-		const resp = await api.invoke('workloadIdentity.list', { project, location: selectedLocation.id }, fetch)
+		const resp = await api.invoke<Api.List<Api.WorkloadIdentity>>('workloadIdentity.list', { project, location: selectedLocation.id }, fetch)
 		if (!resp.ok) {
 			if (resp.error?.forbidden) {
 				permission.workloadIdentities = false
@@ -190,7 +191,7 @@
 			return
 		}
 
-		const resp = await api.invoke('disk.list', { project, location: selectedLocation.id }, fetch)
+		const resp = await api.invoke<Api.List<Api.Disk>>('disk.list', { project, location: selectedLocation.id }, fetch)
 		if (!resp.ok) {
 			if (resp.error?.forbidden) {
 				permission.disks = false
@@ -203,7 +204,7 @@
 	}
 
 	async function fetchEnvGroups () {
-		const resp = await api.invoke('envGroup.list', { project }, fetch)
+		const resp = await api.invoke<Api.List<Api.EnvGroup>>('envGroup.list', { project }, fetch)
 		if (!resp.ok) {
 			if (resp.error?.forbidden) {
 				permission.envGroups = false
@@ -247,10 +248,7 @@
 
 	let envGroupInput = $state('')
 
-	/**
-	 * @param {string} name
-	 */
-	function addEnvGroup (name) {
+	function addEnvGroup (name: string) {
 		const n = name.trim()
 		if (!n || form.envGroups.includes(n)) return
 		form.envGroups = [...form.envGroups, n]
@@ -261,22 +259,15 @@
 		envGroupInput = ''
 	}
 
-	/**
-	 * @param {string} name
-	 */
-	function removeEnvGroup (name) {
+	function removeEnvGroup (name: string) {
 		form.envGroups = form.envGroups.filter((g) => g !== name)
 	}
 
 	const envGroupByName = $derived(new Map(envGroups.map((g) => [g.name, g])))
 
-	/** @type {?EnvGroupModal} */
-	let envGroupModal = $state(null)
+	let envGroupModal = $state<EnvGroupModal | null>(null)
 
-	/**
-	 * @param {string} name
-	 */
-	function viewEnvGroup (name) {
+	function viewEnvGroup (name: string) {
 		const g = envGroupByName.get(name)
 		if (!g) return
 		envGroupModal?.open(g)
@@ -314,17 +305,13 @@
 		]
 	}
 
-	/** @param {number} i */
-	function removeSidecar (i) {
+	function removeSidecar (i: number) {
 		form.sidecars = form.sidecars.filter((_, k) => k !== i)
 	}
 
 	let saving = $state(false)
 
-	/**
-	 * @param {Event} e
-	 */
-	async function save (e) {
+	async function save (e: Event) {
 		e.preventDefault()
 
 		if (saving) {
@@ -339,8 +326,8 @@
 				project,
 				...form,
 				protocol: form.type === 'WebService' ? form.protocol : '',
-				env: form.env.reduce((p, x) => { p[x.k] = x.v; return p }, {}),
-				mountData: form.mountData.reduce((p, x) => { p[x.k] = x.v; return p }, {}),
+				env: form.env.reduce<Record<string, string>>((p, x) => { p[x.k] = x.v; return p }, {}),
+				mountData: form.mountData.reduce<Record<string, string>>((p, x) => { p[x.k] = x.v; return p }, {}),
 				sidecars: convertSidecars(),
 				ttl: ttlSeconds,
 				// Set after the spread so it can never be clobbered by `...form`.

--- a/src/routes/(auth)/(project)/disk/(detail)/+layout.svelte
+++ b/src/routes/(auth)/(project)/disk/(detail)/+layout.svelte
@@ -1,10 +1,11 @@
-<script>
-	import { onMount } from 'svelte'
+<script lang="ts">
+	import { onMount, type Snippet } from 'svelte'
 	import api from '$lib/api'
 	import StatusIcon from '$lib/components/StatusIcon.svelte'
 	import { page } from '$app/stores'
+	import type { LayoutData } from './$types'
 
-	const { data, children } = $props()
+	const { data, children }: { data: LayoutData, children: Snippet } = $props()
 
 	const project = $derived(data.project)
 	const disk = $derived(data.disk)

--- a/src/routes/(auth)/(project)/disk/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/disk/(detail)/detail/+page.svelte
@@ -1,12 +1,13 @@
-<script>
+<script lang="ts">
 	import * as format from '$lib/format'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const location = $derived(data.location)

--- a/src/routes/(auth)/(project)/disk/(detail)/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/disk/(detail)/metrics/+page.svelte
@@ -1,11 +1,24 @@
-<script>
+<script lang="ts">
 	import { page } from '$app/stores'
 	import api from '$lib/api'
 	import { onMount, tick } from 'svelte'
 	import Chart from '$lib/components/Chart.svelte'
 	import Select from '$lib/components/Select.svelte'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	interface Series {
+		prefix: string
+		lines: Api.UsageMetricsLine[]
+		dashStyle?: string
+		color?: string
+	}
+
+	interface DiskMetricsResult {
+		usage?: Api.UsageMetricsLine[]
+		size?: Api.UsageMetricsLine[]
+	}
+
+	const { data }: { data: PageData } = $props()
 
 	const disk = $derived(data.disk)
 
@@ -25,16 +38,16 @@
 		range: $page.url.searchParams.get('range') || '1h'
 	})
 
-	let chart = $state([])
+	let chart = $state<Series[]>([])
 
-	let reloadTimeout
+	let reloadTimeout: ReturnType<typeof setTimeout> | null = null
 
 	async function fetchMetrics (clear = false) {
 		reloadTimeout && clearTimeout(reloadTimeout)
 		reloadTimeout = null
 
 		try {
-			const resp = await api.invoke('disk.metrics', {
+			const resp = await api.invoke<DiskMetricsResult>('disk.metrics', {
 				project: disk.project,
 				location: disk.location,
 				name: disk.name,

--- a/src/routes/(auth)/(project)/disk/+page.svelte
+++ b/src/routes/(auth)/(project)/disk/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { getContext } from 'svelte'
 	import StatusIcon from '$lib/components/StatusIcon.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
@@ -6,15 +6,15 @@
 	import * as format from '$lib/format'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import { denyTooltip } from '$lib/permission'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const disks = $derived(data.disks)
 	const error = $derived(data.error)
 
-	/** @type {{ can: (p: string) => boolean }} */
-	const { can } = getContext('permission')
+	const { can } = getContext('permission') as { can: (p: string) => boolean }
 </script>
 
 <div class="page-head">

--- a/src/routes/(auth)/(project)/disk/create/+page.svelte
+++ b/src/routes/(auth)/(project)/disk/create/+page.svelte
@@ -1,12 +1,13 @@
-<script>
+<script lang="ts">
 	import { untrack } from 'svelte'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 	const locations = $derived(data.locations)
 	const location = untrack(() => data.location)
 	const name = untrack(() => data.name)
@@ -25,10 +26,7 @@
 
 	let saving = $state(false)
 
-	/**
-	 * @param {Event} e
-	 */
-	async function save (e) {
+	async function save (e: Event) {
 		e.preventDefault()
 
 		if (saving) {

--- a/src/routes/(auth)/(project)/domain/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/+page.svelte
@@ -1,18 +1,19 @@
-<script>
+<script lang="ts">
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as modal from '$lib/modal'
 	import StatusIcon from '$lib/components/StatusIcon.svelte'
 	import api from '$lib/api'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const domains = $derived(data.domains)
 	const error = $derived(data.error)
 
-	function deleteDomain (domain) {
+	function deleteDomain (domain: Api.Domain) {
 		modal.confirm({
 			title: `Delete domain "${domain.domain}"?`,
 			yes: 'Delete',

--- a/src/routes/(auth)/(project)/domain/create/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/create/+page.svelte
@@ -1,11 +1,12 @@
-<script>
+<script lang="ts">
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 	const project = $derived(data.project)
 	const locations = $derived(data.locations)
 
@@ -17,10 +18,7 @@
 
 	let saving = $state(false)
 
-	/**
-	 * @param {Event} e
-	 */
-	async function save (e) {
+	async function save (e: Event) {
 		e.preventDefault()
 
 		if (saving) {

--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import * as format from '$lib/format'
 	import { onMount } from 'svelte'
 	import { setupCopy } from '$lib/clipboard'
@@ -9,8 +9,9 @@
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import StatusIcon from '$lib/components/StatusIcon.svelte'
 	import Swal from 'sweetalert2'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const domain = $derived(data.domain)
@@ -55,7 +56,7 @@
 		return setupCopy('.copy')
 	})
 
-	let reloadTimeout
+	let reloadTimeout: ReturnType<typeof setTimeout> | null = null
 	onMount(() => {
 		handleReload()
 		return () => {
@@ -652,7 +653,7 @@
 	</div>
 </div>
 
-{#snippet dnsRecord(type, host, value)}
+{#snippet dnsRecord(type: string, host: string, value: string)}
 	<div class="rec">
 		<span class="rec__type">{type}</span>
 		<div class="rec__body">

--- a/src/routes/(auth)/(project)/dropbox/+layout.svelte
+++ b/src/routes/(auth)/(project)/dropbox/+layout.svelte
@@ -1,5 +1,7 @@
-<script>
-	const { children } = $props()
+<script lang="ts">
+	import type { Snippet } from 'svelte'
+
+	const { children }: { children: Snippet } = $props()
 </script>
 
 {@render children?.()}

--- a/src/routes/(auth)/(project)/dropbox/+page.svelte
+++ b/src/routes/(auth)/(project)/dropbox/+page.svelte
@@ -1,24 +1,23 @@
-<script>
+<script lang="ts">
 	import ClipboardJS from 'clipboard'
 	import { onMount } from 'svelte'
 	import api from '$lib/api'
 	import * as format from '$lib/format'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const items = $derived(data.items)
 	const loadError = $derived(data.error)
 
-	/** @type {HTMLInputElement} */
-	let elFile
+	let elFile = $state<HTMLInputElement | null>(null)
 	let uploading = $state(false)
 	let dragOver = $state(false)
 	let error = $state('')
 	let justCopied = $state('')
 
-	/** @type {File | null} */
-	let selectedFile = $state(null)
+	let selectedFile = $state<File | null>(null)
 
 	onMount(() => {
 		const clip = new ClipboardJS('.copy-url')
@@ -32,11 +31,7 @@
 		return () => clip?.destroy()
 	})
 
-	/**
-	 * @param {number} bytes
-	 * @returns {string}
-	 */
-	function formatSize (bytes) {
+	function formatSize (bytes: number): string {
 		if (bytes < 1024) return `${bytes} B`
 		if (bytes < 1024 ** 2) return `${(bytes / 1024).toFixed(1)} KB`
 		if (bytes < 1024 ** 3) return `${(bytes / 1024 ** 2).toFixed(1)} MB`
@@ -44,18 +39,15 @@
 	}
 
 	function onFileChange () {
-		selectedFile = elFile.files?.[0] ?? null
+		selectedFile = elFile?.files?.[0] ?? null
 		error = ''
 	}
 
-	/**
-	 * @param {DragEvent} e
-	 */
-	function onDrop (e) {
+	function onDrop (e: DragEvent) {
 		e.preventDefault()
 		dragOver = false
 		const file = e.dataTransfer?.files?.[0]
-		if (!file) return
+		if (!file || !elFile) return
 		const dt = new DataTransfer()
 		dt.items.add(file)
 		elFile.files = dt.files
@@ -63,10 +55,7 @@
 		error = ''
 	}
 
-	/**
-	 * @param {DragEvent} e
-	 */
-	function onDragOver (e) {
+	function onDragOver (e: DragEvent) {
 		e.preventDefault()
 		dragOver = true
 	}
@@ -82,10 +71,7 @@
 		error = ''
 	}
 
-	/**
-	 * @param {Event} e
-	 */
-	async function upload (e) {
+	async function upload (e: Event) {
 		e.preventDefault()
 		if (uploading || !selectedFile) return
 

--- a/src/routes/(auth)/(project)/dropbox/usage/+page.svelte
+++ b/src/routes/(auth)/(project)/dropbox/usage/+page.svelte
@@ -1,7 +1,8 @@
-<script>
+<script lang="ts">
 	import UsageMetrics from '$lib/components/UsageMetrics.svelte'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 </script>

--- a/src/routes/(auth)/(project)/email/+page.svelte
+++ b/src/routes/(auth)/(project)/email/+page.svelte
@@ -1,9 +1,10 @@
-<script>
+<script lang="ts">
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as format from '$lib/format'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const domains = $derived(data.domains)
 	const error = $derived(data.error)

--- a/src/routes/(auth)/(project)/env-group/+page.svelte
+++ b/src/routes/(auth)/(project)/env-group/+page.svelte
@@ -1,15 +1,15 @@
-<script>
+<script lang="ts">
 	import { getContext } from 'svelte'
+	import type { PageData } from './$types'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as format from '$lib/format'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import { denyTooltip } from '$lib/permission'
 
-	/** @type {{ can: (p: string) => boolean }} */
-	const { can } = getContext('permission')
+	const { can } = getContext('permission') as { can: (p: string) => boolean }
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const envGroups = $derived(data.envGroups)

--- a/src/routes/(auth)/(project)/env-group/create/+page.svelte
+++ b/src/routes/(auth)/(project)/env-group/create/+page.svelte
@@ -1,11 +1,12 @@
-<script>
+<script lang="ts">
 	import { onMount, untrack } from 'svelte'
 	import { goto } from '$app/navigation'
+	import type { PageData } from './$types'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const envGroup = $derived(data.envGroup)
@@ -38,12 +39,9 @@
 	// 'create'. Empty when idle.
 	let savingAction = $state('')
 
-	/**
-	 * @param {Event} e
-	 * @param {boolean} [redeploy]  on update, whether to redeploy the deployments
-	 *   that reference this group so they pick up the new values. Ignored on create.
-	 */
-	async function save (e, redeploy = true) {
+	// redeploy: on update, whether to redeploy the deployments that reference this
+	// group so they pick up the new values. Ignored on create.
+	async function save (e: Event, redeploy = true) {
 		e.preventDefault()
 
 		if (saving) {
@@ -53,13 +51,13 @@
 		saving = true
 		savingAction = envGroup ? (redeploy ? 'redeploy' : 'update') : 'create'
 		try {
-			const env = form.env.reduce((p, x) => {
+			const env = form.env.reduce<Record<string, string>>((p, x) => {
 				if (x.k) p[x.k] = x.v
 				return p
 			}, {})
 
 			const fn = envGroup ? 'envgroup.update' : 'envgroup.create'
-			const args = { project, name: form.name, env }
+			const args: { project: string, name: string, env: Record<string, string>, redeploy?: boolean } = { project, name: form.name, env }
 			if (envGroup) {
 				args.redeploy = redeploy
 			}

--- a/src/routes/(auth)/(project)/env-group/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/env-group/detail/+page.svelte
@@ -1,5 +1,6 @@
-<script>
+<script lang="ts">
 	import { goto } from '$app/navigation'
+	import type { PageData } from './$types'
 	import * as format from '$lib/format'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
@@ -7,7 +8,7 @@
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import Secret from '$lib/components/Secret.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const envGroup = $derived(data.envGroup)

--- a/src/routes/(auth)/(project)/github/+page.svelte
+++ b/src/routes/(auth)/(project)/github/+page.svelte
@@ -1,4 +1,5 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
@@ -6,7 +7,7 @@
 	import * as format from '$lib/format'
 	import GitHubNav from './_components/GitHubNav.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const error = $derived(data.error)
@@ -17,21 +18,18 @@
 	// so unlink/edit can update it in place until the next load (fixes #219).
 	let links = $derived(data.links)
 
-	/** @type {EditGithubLinkModal} */
-	let editModal = $state(/** @type {any} */ (undefined))
+	let editModal = $state<EditGithubLinkModal | null>(null)
 
 	async function reloadLinks () {
-		const resp = await api.invoke('github.list', { project }, fetch)
+		const resp = await api.invoke<Api.List<Api.GithubLink>>('github.list', { project }, fetch)
 		if (resp.ok) links = resp.result?.items ?? []
 	}
 
-	/** @param {Api.GithubLink} it */
-	function edit (it) {
-		editModal.open(it)
+	function edit (it: Api.GithubLink) {
+		editModal?.open(it)
 	}
 
-	/** @param {Api.GithubLink} it */
-	function unlink (it) {
+	function unlink (it: Api.GithubLink) {
 		modal.confirm({
 			title: `Unlink ${it.repository}? Workflows from this repository will no longer be able to deploy. Existing deployments are not affected.`,
 			yes: 'Unlink',
@@ -49,13 +47,11 @@
 		})
 	}
 
-	/** @param {string} repository */
-	function workflowHref (repository) {
+	function workflowHref (repository: string) {
 		return `/github/workflow?project=${project}&repo=${encodeURIComponent(repository)}`
 	}
 
-	/** @param {Api.GithubLink['trigger']} trigger */
-	function triggerLabel (trigger) {
+	function triggerLabel (trigger: Api.GithubLink['trigger']) {
 		if (trigger === 'pr') return 'PR previews only'
 		if (trigger === 'branch') return 'Branch only'
 		return 'Branch + PR previews'

--- a/src/routes/(auth)/(project)/github/_components/GitHubNav.svelte
+++ b/src/routes/(auth)/(project)/github/_components/GitHubNav.svelte
@@ -1,16 +1,15 @@
-<script>
+<script lang="ts">
 	import { page } from '$app/stores'
 
 	/**
 	 * Shared sub-navigation for the GitHub feature. Repositories is the
 	 * overview/management view; Workflow is the standalone generator.
-	 *
-	 * @typedef {Object} Props
-	 * @property {string | null} project
 	 */
+	interface Props {
+		project: string | null
+	}
 
-	/** @type {Props} */
-	const { project } = $props()
+	const { project }: Props = $props()
 
 	const onWorkflow = $derived($page.url.pathname.startsWith('/github/workflow'))
 	const q = $derived(project ? `?project=${project}` : '')

--- a/src/routes/(auth)/(project)/github/link/+page.svelte
+++ b/src/routes/(auth)/(project)/github/link/+page.svelte
@@ -1,21 +1,20 @@
-<script>
+<script lang="ts">
 	import { onMount } from 'svelte'
 	import { goto } from '$app/navigation'
+	import type { PageData } from './$types'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
 	import CreateServiceAccountModal from '$lib/components/CreateServiceAccountModal.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const installUrl = $derived(data.installUrl)
 	const linkedRepoIds = $derived(new Set(data.linkedRepoIds))
 
-	/** @type {Api.GithubRepoItem[]} */
-	let repos = $state([])
-	/** @type {Api.Error | undefined} */
-	let repoError = $state(undefined)
+	let repos = $state<Api.GithubRepoItem[]>([])
+	let repoError = $state<Api.Error | undefined>(undefined)
 	let loadingRepos = $state(false)
 	let loadedOnce = $state(false)
 
@@ -27,12 +26,11 @@
 		loadingRepos = true
 		repoError = undefined
 		try {
-			/** @type {Record<number, Api.GithubRepoItem>} */
-			const repoMap = {}
+			const repoMap: Record<number, Api.GithubRepoItem> = {}
 
 			await Promise.all(
 				data.installationIds.map(async (installationId) => {
-					const resp = await api.invoke('github.listRepos', { project, installationId }, fetch)
+					const resp = await api.invoke<Api.List<Api.GithubRepoItem>>('github.listRepos', { project, installationId }, fetch)
 					if (!resp.ok) {
 						repoError = resp.error
 						return
@@ -76,8 +74,7 @@
 
 	// Service accounts created inline via the modal, merged with the loaded list
 	// so a freshly-created SA is immediately selectable without a full reload.
-	/** @type {{ sid: string, name: string }[]} */
-	let extraServiceAccounts = $state([])
+	let extraServiceAccounts = $state<{ sid: string, name: string }[]>([])
 
 	const serviceAccounts = $derived([...data.serviceAccounts, ...extraServiceAccounts])
 
@@ -86,11 +83,9 @@
 		label: `${sa.sid} — ${sa.name}`
 	})))
 
-	/** @type {CreateServiceAccountModal} */
-	let createServiceAccountModal = $state(/** @type {any} */ (undefined))
+	let createServiceAccountModal = $state<CreateServiceAccountModal | null>(null)
 
-	/** @param {{ sid: string, name: string, email: string }} sa */
-	function onServiceAccountCreated (sa) {
+	function onServiceAccountCreated (sa: { sid: string, name: string, email: string }) {
 		if (!extraServiceAccounts.some((s) => s.sid === sa.sid) &&
 			!data.serviceAccounts.some((s) => s.sid === sa.sid)) {
 			extraServiceAccounts = [...extraServiceAccounts, { sid: sa.sid, name: sa.name }]
@@ -253,7 +248,7 @@
 				<button
 					class="button is-variant-secondary"
 					disabled={!data.canCreateServiceAccount}
-					onclick={() => createServiceAccountModal.open()}
+					onclick={() => createServiceAccountModal?.open()}
 					title={data.canCreateServiceAccount
 						? 'Create a new deploy service account without leaving this page'
 						: 'You need the serviceAccount.create permission to create one here.'}

--- a/src/routes/(auth)/(project)/github/workflow/+page.svelte
+++ b/src/routes/(auth)/(project)/github/workflow/+page.svelte
@@ -1,5 +1,6 @@
-<script>
+<script lang="ts">
 	import { onMount, untrack } from 'svelte'
+	import type { PageData } from './$types'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
@@ -7,7 +8,7 @@
 	import { setupCopy } from '$lib/clipboard'
 	import GitHubNav from '../_components/GitHubNav.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const locations = $derived(data.locations)
@@ -16,14 +17,13 @@
 
 	const links = $derived(data.links)
 	// Mutable so a freshly-provisioned pull secret is selectable without a reload.
-	let pullSecrets = $state(untrack(() => data.pullSecrets))
+	let pullSecrets = $state<Array<Pick<Api.PullSecret, 'name' | 'location'>>>(untrack(() => data.pullSecrets))
 
 	const locationOptions = $derived(locations.map((l) => ({ value: l.id, label: l.id })))
 
 	// Derive a sensible deployment name from a `owner/name` repository: the repo
 	// name, lowercased with anything outside [a-z0-9-] folded to a hyphen.
-	/** @param {string | undefined} repository */
-	function repoToName (repository) {
+	function repoToName (repository: string | undefined) {
 		const short = (repository ?? '').split('/').pop() ?? ''
 		return short
 			.toLowerCase()
@@ -31,9 +31,29 @@
 			.replace(/^-+|-+$/g, '')
 	}
 
+	interface GenState {
+		repository: string | undefined
+		location: string
+		name: string
+		buildType: string
+		port: number
+		framework: string
+		buildCommand: string
+		outputDir: string
+		spa: boolean
+		notFound: string
+		workingDirectory: string
+		env: string
+		envGroups: string[]
+		pullSecret: string
+		protocol: string
+		requireGoogleLogin: boolean
+		allowedEmails: string
+		allowedDomains: string
+	}
+
 	// Default generator state for a repository with no saved config.
-	/** @param {string | undefined} repository */
-	function defaultGen (repository) {
+	function defaultGen (repository: string | undefined): GenState {
 		return {
 			repository,
 			location: data.locations[0]?.id ?? '',
@@ -47,7 +67,6 @@
 			notFound: '404.html',
 			workingDirectory: '',
 			env: '',
-			/** @type {string[]} */
 			envGroups: [],
 			pullSecret: '',
 			protocol: 'http',
@@ -57,19 +76,14 @@
 		}
 	}
 
-	/** @param {string | undefined} repository */
-	function savedConfigFor (repository) {
+	function savedConfigFor (repository: string | undefined) {
 		return data.links.find((l) => l.repository === repository)?.workflowConfig
 	}
 
 	// Merge a link's saved workflow config (github.setWorkflowConfig) over the
 	// defaults so the generator pre-fills the user's last-saved inputs. Missing
 	// or empty fields fall back to defaults.
-	/**
-	 * @param {string | undefined} repository
-	 * @param {Api.GitHubWorkflowConfig | undefined} cfg
-	 */
-	function genFromConfig (repository, cfg) {
+	function genFromConfig (repository: string | undefined, cfg: Api.GitHubWorkflowConfig | undefined): GenState {
 		const d = defaultGen(repository)
 		if (!cfg) return d
 		return {
@@ -118,7 +132,7 @@
 	// When the selected repository changes, pre-fill the generator from that
 	// repo's saved workflow config (or reset to defaults). The initial load is
 	// already seeded above, so this only fires on an actual switch.
-	let configLoadedRepo = untrack(() => data.initialRepo)
+	let configLoadedRepo: string | undefined = untrack(() => data.initialRepo)
 	$effect(() => {
 		const repo = gen.repository
 		if (repo === configLoadedRepo) return
@@ -144,8 +158,7 @@
 	]
 
 	// Allow-list text -> trimmed entries (split on newline or comma, blanks dropped).
-	/** @param {string} text */
-	function splitList (text) {
+	function splitList (text: string) {
 		return text.split(/[\n,]/).map((s) => s.trim()).filter(Boolean)
 	}
 	const allowedEmailsList = $derived(splitList(gen.allowedEmails))
@@ -158,15 +171,13 @@
 			.map((g) => ({ value: g.name, label: g.name }))
 	)
 
-	/** @param {string} name */
-	function addEnvGroup (name) {
+	function addEnvGroup (name: string) {
 		const n = name.trim()
 		if (!n || gen.envGroups.includes(n)) return
 		gen.envGroups = [...gen.envGroups, n]
 	}
 
-	/** @param {string} name */
-	function removeEnvGroup (name) {
+	function removeEnvGroup (name: string) {
 		gen.envGroups = gen.envGroups.filter((g) => g !== name)
 	}
 
@@ -193,6 +204,12 @@
 
 	let creatingPullSecret = $state(false)
 	let pullSecretError = $state('')
+
+	// serviceAccount.get returns the account plus its keys (with the one-time
+	// secret on a freshly minted key) — wider than Api.ServiceAccount.
+	type ServiceAccountWithKeys = Api.ServiceAccount & {
+		keys?: Array<{ createdAt: string, secret?: string }>
+	}
 
 	// Provision a dedicated pull-only service account (registry.pull), mint a
 	// key, and create a pull secret for it in the selected location — then select
@@ -224,7 +241,7 @@
 			}
 
 			// 2. Resolve the SA email + existing keys.
-			let getResp = await api.invoke('serviceAccount.get', { project, id: PULL_SA_SID }, fetch)
+			let getResp = await api.invoke<ServiceAccountWithKeys>('serviceAccount.get', { project, id: PULL_SA_SID }, fetch)
 			if (!getResp.ok) {
 				pullSecretError = getResp.error?.message ?? 'Failed to read the pull service account.'
 				return
@@ -264,7 +281,7 @@
 					pullSecretError = keyResp.error?.message ?? 'Failed to create a service account key.'
 					return
 				}
-				getResp = await api.invoke('serviceAccount.get', { project, id: PULL_SA_SID }, fetch)
+				getResp = await api.invoke<ServiceAccountWithKeys>('serviceAccount.get', { project, id: PULL_SA_SID }, fetch)
 				if (!getResp.ok) {
 					pullSecretError = getResp.error?.message ?? 'Failed to read the new key.'
 					return
@@ -316,7 +333,7 @@
 	// Build the action's `with:` block, emitting only the keys the user set so
 	// the generated workflow stays minimal.
 	function withBlock () {
-		const out = []
+		const out: string[] = []
 		out.push(`        project: ${project}`)
 		out.push(`        location: ${gen.location}`)
 		out.push(`        name: ${gen.name || 'web'}`)

--- a/src/routes/(auth)/(project)/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/metrics/+page.svelte
@@ -1,7 +1,8 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import ProjectMetrics from '$lib/components/ProjectMetrics.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 	const project = $derived(data.project)
 </script>
 

--- a/src/routes/(auth)/(project)/pull-secret/+page.svelte
+++ b/src/routes/(auth)/(project)/pull-secret/+page.svelte
@@ -1,11 +1,12 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import StatusIcon from '$lib/components/StatusIcon.svelte'
 	import * as format from '$lib/format'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const pullSecrets = $derived(data.pullSecrets)

--- a/src/routes/(auth)/(project)/pull-secret/create/+page.svelte
+++ b/src/routes/(auth)/(project)/pull-secret/create/+page.svelte
@@ -1,12 +1,14 @@
-<script>
+<script lang="ts">
 	import { goto } from '$app/navigation'
+	// @ts-expect-error workaround for missing type
 	import validUrl from 'valid-url'
+	import type { PageData } from './$types'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const locations = $derived(data.locations)
@@ -21,10 +23,7 @@
 
 	let saving = $state(false)
 
-	/**
-	 * @param {Event} e
-	 */
-	async function save (e) {
+	async function save (e: Event) {
 		e.preventDefault()
 
 		if (saving) {

--- a/src/routes/(auth)/(project)/pull-secret/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/pull-secret/detail/+page.svelte
@@ -1,13 +1,14 @@
-<script>
+<script lang="ts">
 	import { setupCopy } from '$lib/clipboard'
 	import { onMount } from 'svelte'
 	import { goto } from '$app/navigation'
+	import type { PageData } from './$types'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const location = $derived(data.location)

--- a/src/routes/(auth)/(project)/registry/(list)/+layout.svelte
+++ b/src/routes/(auth)/(project)/registry/(list)/+layout.svelte
@@ -1,5 +1,7 @@
-<script>
-	const { children } = $props()
+<script lang="ts">
+	import type { Snippet } from 'svelte'
+
+	const { children }: { children: Snippet } = $props()
 </script>
 
 {@render children?.()}

--- a/src/routes/(auth)/(project)/registry/(list)/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/(list)/+page.svelte
@@ -1,17 +1,18 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const repositories = $derived(data.repositories)
 	const error = $derived(data.error)
 
-	function deleteRepository (name) {
+	function deleteRepository (name: string) {
 		modal.confirm({
 			title: `Delete "${name}"?`,
 			yes: 'Delete',

--- a/src/routes/(auth)/(project)/registry/(list)/usage/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/(list)/usage/+page.svelte
@@ -1,7 +1,8 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import UsageMetrics from '$lib/components/UsageMetrics.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 </script>

--- a/src/routes/(auth)/(project)/registry/detail/+layout.svelte
+++ b/src/routes/(auth)/(project)/registry/detail/+layout.svelte
@@ -1,8 +1,10 @@
-<script>
+<script lang="ts">
+	import type { LayoutData } from './$types'
+	import type { Snippet } from 'svelte'
 	import * as format from '$lib/format'
 	import { page } from '$app/stores'
 
-	const { data, children } = $props()
+	const { data, children }: { data: LayoutData, children: Snippet } = $props()
 
 	const project = $derived(data.project)
 	const repository = $derived(data.repository)

--- a/src/routes/(auth)/(project)/registry/detail/manifests/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/detail/manifests/+page.svelte
@@ -1,4 +1,5 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import * as format from '$lib/format'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
@@ -6,13 +7,13 @@
 	import api from '$lib/api'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const manifests = $derived(data.manifests)
 	const error = $derived(data.error)
 
-	function deleteManifest (digest) {
+	function deleteManifest (digest: string) {
 		modal.confirm({
 			title: `Delete manifest "${format.shortDigest(digest)}"?`,
 			yes: 'Delete',

--- a/src/routes/(auth)/(project)/registry/detail/tags/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/detail/tags/+page.svelte
@@ -1,4 +1,5 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import * as format from '$lib/format'
 	import { onMount } from 'svelte'
 	import { setupCopy } from '$lib/clipboard'
@@ -8,7 +9,7 @@
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const repository = $derived(data.repository)
@@ -19,7 +20,7 @@
 		return setupCopy('.copy')
 	})
 
-	function untagTag (tag) {
+	function untagTag (tag: string) {
 		modal.confirm({
 			title: `Untag "${tag}"?`,
 			yes: 'Untag',

--- a/src/routes/(auth)/(project)/role/+page.svelte
+++ b/src/routes/(auth)/(project)/role/+page.svelte
@@ -1,19 +1,17 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as format from '$lib/format'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const roles = $derived(data.roles)
 	const error = $derived(data.error)
 
-	/**
-	 * @param {string} sid
-	 */
-	function roleCanUpdate (sid) {
+	function roleCanUpdate (sid: string) {
 		return sid !== 'owner'
 	}
 </script>

--- a/src/routes/(auth)/(project)/role/bind/+page.svelte
+++ b/src/routes/(auth)/(project)/role/bind/+page.svelte
@@ -1,4 +1,5 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import { untrack } from 'svelte'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
@@ -7,7 +8,7 @@
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import Select from '$lib/components/Select.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 	const roles = $derived(data.roles)
 	const email = $derived(data.email)
 	const selected = $derived(data.selected)
@@ -23,7 +24,7 @@
 		roles: selected
 	})))
 
-	function addRole (role) {
+	function addRole (role: string) {
 		if (!role || form.roles.includes(role)) {
 			return
 		}
@@ -31,16 +32,13 @@
 		form.roles = [...form.roles, role]
 	}
 
-	function removeRole (role) {
+	function removeRole (role: string) {
 		form.roles = form.roles.filter((x) => x !== role)
 	}
 
 	let saving = $state(false)
 
-	/**
-	 * @param {Event} e
-	 */
-	async function save (e) {
+	async function save (e: Event) {
 		e.preventDefault()
 
 		if (saving) {

--- a/src/routes/(auth)/(project)/role/create/+page.svelte
+++ b/src/routes/(auth)/(project)/role/create/+page.svelte
@@ -1,4 +1,5 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import { untrack } from 'svelte'
 	import { goto } from '$app/navigation'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
@@ -7,7 +8,7 @@
 	import OptionSelect from '$lib/components/OptionSelect.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 	const role = $derived(data.role)
 	const permissions = $derived(data.permissions)
 
@@ -19,10 +20,7 @@
 		permissions: role?.permissions ?? []
 	})))
 
-	/**
-	 * @param {string} permission
-	*/
-	function addPermission (permission) {
+	function addPermission (permission: string) {
 		if (!permission || form.permissions.includes(permission)) {
 			return
 		}
@@ -32,16 +30,13 @@
 		]
 	}
 
-	function removePermission (permission) {
+	function removePermission (permission: string) {
 		form.permissions = form.permissions.filter((x) => x !== permission)
 	}
 
 	let saving = $state(false)
 
-	/**
-	 * @param {Event} e
-	 */
-	async function save (e) {
+	async function save (e: Event) {
 		e.preventDefault()
 
 		if (saving) {

--- a/src/routes/(auth)/(project)/role/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/role/detail/+page.svelte
@@ -1,4 +1,5 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import { goto } from '$app/navigation'
 	import * as format from '$lib/format'
 	import * as modal from '$lib/modal'
@@ -6,7 +7,7 @@
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const role = $derived(data.role)

--- a/src/routes/(auth)/(project)/role/users/+page.svelte
+++ b/src/routes/(auth)/(project)/role/users/+page.svelte
@@ -1,4 +1,5 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import { getContext } from 'svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as modal from '$lib/modal'
@@ -8,20 +9,16 @@
 	import { denyTooltip } from '$lib/permission'
 	import gravatarUrl from 'gravatar-url'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
-	/** @type {{ can: (p: string) => boolean }} */
-	const { can } = getContext('permission')
+	const { can } = getContext('permission') as { can: (p: string) => boolean }
 
 	const project = $derived(data.project)
 	const users = $derived(data.users)
 	const error = $derived(data.error)
 	const myEmail = $derived(data.profile?.email ?? '')
 
-	/**
-	 * @param {string} email
-	 */
-	function deleteUser (email) {
+	function deleteUser (email: string) {
 		modal.confirm({
 			title: `Delete user ${email} from project ${project}?`,
 			yes: 'Delete',

--- a/src/routes/(auth)/(project)/route/+page.svelte
+++ b/src/routes/(auth)/(project)/route/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { getContext } from 'svelte'
 	import { goto } from '$app/navigation'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
@@ -7,31 +7,24 @@
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import { denyTooltip } from '$lib/permission'
+	import type { PageData } from './$types'
 
-	/** @type {{ can: (p: string) => boolean }} */
-	const { can } = getContext('permission')
+	const { can } = getContext('permission') as { can: (p: string) => boolean }
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const routes = $derived(data.routes)
 	const error = $derived(data.error)
 
-	/**
-	 * @param {Api.Route} route
-	 */
-	function openRoute (route) {
+	function openRoute (route: Api.Route) {
 		goto(`/route/manage?project=${project}` +
 			`&location=${encodeURIComponent(route.location)}` +
 			`&domain=${encodeURIComponent(route.domain)}` +
 			`&path=${encodeURIComponent(route.path)}`)
 	}
 
-	/**
-	 * @param {KeyboardEvent} e
-	 * @param {Api.Route} route
-	 */
-	function onRowKey (e, route) {
+	function onRowKey (e: KeyboardEvent, route: Api.Route) {
 		// Only the row itself drives navigation; inner buttons handle their own keys.
 		if (e.target !== e.currentTarget) return
 		if (e.key === 'Enter' || e.key === ' ') {
@@ -40,10 +33,7 @@
 		}
 	}
 
-	/**
-	 * @param {Api.Route} route
-	 */
-	function deleteRoute (route) {
+	function deleteRoute (route: Api.Route) {
 		modal.confirm({
 			title: `Delete route ${route.domain}${route.path} in ${route.location}?`,
 			yes: 'Delete',

--- a/src/routes/(auth)/(project)/route/create/+page.svelte
+++ b/src/routes/(auth)/(project)/route/create/+page.svelte
@@ -1,11 +1,12 @@
-<script>
+<script lang="ts">
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const locations = $derived(data.locations)
@@ -27,19 +28,17 @@
 		}
 	})
 
-	const targetPlaceholder = $derived({
+	const targetPlaceholder = $derived(({
 		'redirect://': 'https://example.com',
 		'http://': '203.0.113.10:8080'
-	}[form.targetPrefix] || '')
+	} as Record<string, string>)[form.targetPrefix] || '')
 
-	const targetHint = $derived({
+	const targetHint = $derived(({
 		'http://': 'Your server’s public IP address, with an optional port (defaults to 80). Private, loopback, and link-local addresses are not allowed.'
-	}[form.targetPrefix] || '')
+	} as Record<string, string>)[form.targetPrefix] || '')
 
-	/** @type {Api.Domain[]} */
-	let domains = $state([])
-	/** @type {{ name: string, paused: boolean }[]} */
-	let deployments = $state([])
+	let domains = $state<Api.Domain[]>([])
+	let deployments = $state<{ name: string, paused: boolean }[]>([])
 
 	const selectedDomain = $derived(domains.find((x) => x.domain === form.domain))
 
@@ -49,9 +48,9 @@
 	const deploymentOptions = $derived(deployments.map((d) => ({
 		value: d.name,
 		label: d.name,
-		dot: /** @type {'warning' | 'positive'} */ (d.paused ? 'warning' : 'positive'),
+		dot: (d.paused ? 'warning' : 'positive') as 'warning' | 'positive',
 		badge: d.paused ? 'Paused' : undefined,
-		badgeTone: /** @type {'warning'} */ ('warning')
+		badgeTone: 'warning' as const
 	})))
 
 	const selectedDeploymentPaused = $derived(
@@ -63,8 +62,7 @@
 		domains = []
 		form.domain = ''
 
-		/** @type {Api.Response<Api.List<Api.Domain>>} */
-		const resp = await api.invoke('domain.list', { project, location: form.location }, fetch)
+		const resp = await api.invoke<Api.List<Api.Domain>>('domain.list', { project, location: form.location }, fetch)
 		if (!resp.ok) {
 			modal.error({ error: resp.error })
 			return
@@ -78,12 +76,12 @@
 		deployments = []
 		form.targetValue = ''
 
-		const resp = await api.invoke('deployment.list', { project }, fetch)
+		const resp = await api.invoke<Api.List<Api.Deployment>>('deployment.list', { project }, fetch)
 		if (!resp.ok) {
 			modal.error({ error: resp.error })
 			return
 		}
-		const list = resp.result.items ?? []
+		const list = resp.result?.items ?? []
 		deployments = list
 			.filter((x) => x.location === form.location)
 			.filter((x) => x.type === 'WebService' || x.type === 'Static')
@@ -98,10 +96,7 @@
 
 	let saving = $state(false)
 
-	/**
-	 * @param {Event} e
-	 */
-	async function save (e) {
+	async function save (e: SubmitEvent) {
 		e.preventDefault()
 
 		if (saving) {

--- a/src/routes/(auth)/(project)/route/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/route/edit/+page.svelte
@@ -1,12 +1,13 @@
-<script>
+<script lang="ts">
 	import { untrack } from 'svelte'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const route = $derived(data.route)
@@ -22,16 +23,14 @@
 	// the picker. http:// is validated server-side (api.validExternalTarget).
 	const targetPrefixes = ['deployment://', 'redirect://', 'http://', 'ipfs://', 'ipns://', 'dnslink://']
 
-	/** @param {string | undefined} target */
-	function splitTarget (target) {
+	function splitTarget (target: string | undefined) {
 		for (const p of targetPrefixes) {
 			if (target?.startsWith(p)) return { prefix: p, value: target.slice(p.length) }
 		}
 		return { prefix: 'deployment://', value: target ?? '' }
 	}
 
-	/** @param {Api.Route} r */
-	function buildForm (r) {
+	function buildForm (r: Api.Route) {
 		const { prefix, value } = splitTarget(r?.target)
 		const cfg = r?.config ?? {}
 		return {
@@ -52,8 +51,7 @@
 		}
 	}
 
-	/** @param {Api.Route} r */
-	const routeKey = (r) => `${r?.location}|${r?.domain}|${r?.path}`
+	const routeKey = (r: Api.Route) => `${r?.location}|${r?.domain}|${r?.path}`
 
 	let form = $state(untrack(() => buildForm(data.route)))
 	let seededKey = untrack(() => routeKey(data.route))
@@ -86,17 +84,16 @@
 		return base
 	})
 
-	const targetPlaceholder = $derived({
+	const targetPlaceholder = $derived(({
 		'redirect://': 'https://example.com',
 		'http://': '203.0.113.10:8080'
-	}[form.targetPrefix] || '')
+	} as Record<string, string>)[form.targetPrefix] || '')
 
-	const targetHint = $derived({
+	const targetHint = $derived(({
 		'http://': 'Your server’s public IP address, with an optional port (defaults to 80). Private, loopback, and link-local addresses are not allowed.'
-	}[form.targetPrefix] || '')
+	} as Record<string, string>)[form.targetPrefix] || '')
 
-	/** @type {{ name: string, paused: boolean }[]} */
-	let deployments = $state([])
+	let deployments = $state<{ name: string, paused: boolean }[]>([])
 
 	// Paused deployments stay selectable so a route can be wired up ahead of a
 	// resume, but the picker flags them and we warn that traffic won't flow until
@@ -104,9 +101,9 @@
 	const deploymentOptions = $derived(deployments.map((d) => ({
 		value: d.name,
 		label: d.name,
-		dot: /** @type {'warning' | 'positive'} */ (d.paused ? 'warning' : 'positive'),
+		dot: (d.paused ? 'warning' : 'positive') as 'warning' | 'positive',
 		badge: d.paused ? 'Paused' : undefined,
-		badgeTone: /** @type {'warning'} */ ('warning')
+		badgeTone: 'warning' as const
 	})))
 
 	const selectedDeploymentPaused = $derived(
@@ -116,17 +113,17 @@
 
 	async function fetchDeployments () {
 		deployments = []
-		const resp = await api.invoke('deployment.list', { project }, fetch)
+		const resp = await api.invoke<Api.List<Api.Deployment>>('deployment.list', { project }, fetch)
 		if (!resp.ok) {
 			modal.error({ error: resp.error })
 			return
 		}
 		const list = resp.result?.items ?? []
 		deployments = list
-			.filter((/** @type {Api.Deployment} */ x) => x.location === route.location)
-			.filter((/** @type {Api.Deployment} */ x) => x.type === 'WebService' || x.type === 'Static')
-			.filter((/** @type {Api.Deployment} */ x) => x.ttl === 0)
-			.map((/** @type {Api.Deployment} */ x) => ({ name: x.name, paused: x.action === 'pause' }))
+			.filter((x) => x.location === route.location)
+			.filter((x) => x.type === 'WebService' || x.type === 'Static')
+			.filter((x) => x.ttl === 0)
+			.map((x) => ({ name: x.name, paused: x.action === 'pause' }))
 	}
 
 	$effect(() => {
@@ -142,15 +139,13 @@
 		if (form.targetPrefix === 'deployment://') fetchDeployments()
 	}
 
-	/** @param {string} s */
-	function splitLines (s) {
+	function splitLines (s: string) {
 		return s.split('\n').map((x) => x.trim()).filter((x) => x !== '')
 	}
 
 	let saving = $state(false)
 
-	/** @param {SubmitEvent} e */
-	async function save (e) {
+	async function save (e: SubmitEvent) {
 		e.preventDefault()
 		if (saving) return
 

--- a/src/routes/(auth)/(project)/route/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/route/manage/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import * as format from '$lib/format'
 	import { goto } from '$app/navigation'
 	import { onMount } from 'svelte'
@@ -7,8 +7,9 @@
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const route = $derived(data.route)
@@ -23,8 +24,7 @@
 	// Known target schemes (mirrors api.RouteTargetPrefix).
 	const targetPrefixes = ['deployment://', 'redirect://', 'http://', 'ipfs://', 'ipns://', 'dnslink://']
 
-	/** @param {string | undefined} target */
-	function splitTarget (target) {
+	function splitTarget (target: string | undefined) {
 		for (const p of targetPrefixes) {
 			if (target?.startsWith(p)) return { prefix: p, value: target.slice(p.length) }
 		}
@@ -33,24 +33,24 @@
 
 	const parsed = $derived(splitTarget(route.target))
 	const typeLabel = $derived(
-		{
+		({
 			'deployment://': 'Deployment',
 			'redirect://': 'Redirect',
 			'http://': 'External server (HTTP)',
 			'ipfs://': 'IPFS',
 			'ipns://': 'IPNS',
 			'dnslink://': 'DNSLink'
-		}[parsed.prefix] ?? parsed.prefix
+		} as Record<string, string>)[parsed.prefix] ?? parsed.prefix
 	)
 	const targetIcon = $derived(
-		{
+		({
 			'deployment://': 'fa-cube',
 			'redirect://': 'fa-arrow-right-arrow-left',
 			'http://': 'fa-server',
 			'ipfs://': 'fa-cubes',
 			'ipns://': 'fa-cubes',
 			'dnslink://': 'fa-link'
-		}[parsed.prefix] ?? 'fa-cube'
+		} as Record<string, string>)[parsed.prefix] ?? 'fa-cube'
 	)
 
 	// deployment:// targets resolve to a deployment in the same location; link

--- a/src/routes/(auth)/(project)/service-account/+page.svelte
+++ b/src/routes/(auth)/(project)/service-account/+page.svelte
@@ -1,10 +1,11 @@
-<script>
+<script lang="ts">
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as format from '$lib/format'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const serviceAccounts = $derived(data.serviceAccounts)

--- a/src/routes/(auth)/(project)/service-account/create/+page.svelte
+++ b/src/routes/(auth)/(project)/service-account/create/+page.svelte
@@ -1,11 +1,12 @@
-<script>
+<script lang="ts">
 	import { untrack } from 'svelte'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import type { PageData } from './$types'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 	const id = $derived(data.id)
 	const serviceAccount = $derived(data.serviceAccount)
 
@@ -16,10 +17,7 @@
 	let desc = $state(untrack(() => serviceAccount?.description))
 	let saving = $state(false)
 
-	/**
-	 * @param {Event} e
-	 */
-	async function save (e) {
+	async function save (e: SubmitEvent) {
 		e.preventDefault()
 
 		if (saving) {
@@ -47,7 +45,7 @@
 <div class="breadcrumb">
 	{#if id}
 		<div class="breadcrumb-item">
-			<a href={`/service-account?project=${project}&id=${id}`} class="link"><h6>{serviceAccount.sid}</h6></a>
+			<a href={`/service-account?project=${project}&id=${id}`} class="link"><h6>{serviceAccount?.sid}</h6></a>
 		</div>
 	{:else}
 		<div class="breadcrumb-item">
@@ -80,7 +78,7 @@
 			<div class="field">
 				<label for="input-email">Email</label>
 				<div class="input">
-					<input id="input-email" value={serviceAccount.email} readonly>
+					<input id="input-email" value={serviceAccount?.email} readonly>
 				</div>
 			</div>
 		{:else}

--- a/src/routes/(auth)/(project)/service-account/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/service-account/detail/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { onMount, getContext } from 'svelte'
 	import { goto } from '$app/navigation'
 	import * as format from '$lib/format'
@@ -8,17 +8,21 @@
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import { setupCopy } from '$lib/clipboard'
 	import { denyTooltip } from '$lib/permission'
+	import type { PageData } from './$types'
 
-	/** @type {{ can: (p: string) => boolean }} */
-	const { can } = getContext('permission')
+	const { can } = getContext('permission') as { can: (p: string) => boolean }
 
 	onMount(() => setupCopy('.copy'))
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const id = $derived(data.id)
-	const serviceAccount = $derived(data.serviceAccount)
+	// serviceAccount.get returns the account plus its issued keys; the keys array
+	// isn't part of the shared Api.ServiceAccount shape, so widen it locally.
+	const serviceAccount = $derived(
+		data.serviceAccount as Api.ServiceAccount & { keys?: { secret: string }[] }
+	)
 
 	function deleteItem () {
 		modal.confirm({
@@ -57,7 +61,7 @@
 		}
 	}
 
-	function deleteKey (secret) {
+	function deleteKey (secret: string) {
 		modal.confirm({
 			title: 'Confirm delete key?',
 			yes: 'Delete',

--- a/src/routes/(auth)/(project)/waf/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/+page.svelte
@@ -1,4 +1,5 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import Sparkline from '$lib/components/Sparkline.svelte'
@@ -7,13 +8,13 @@
 	import api from '$lib/api'
 	import * as format from '$lib/format'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const firewalls = $derived(data.firewalls)
 	const error = $derived(data.error)
 
-	const hasPending = $derived(firewalls.some((/** @type {Api.WafZone} */ fw) => fw.status === 'pending'))
+	const hasPending = $derived(firewalls.some((fw: Api.WafZone) => fw.status === 'pending'))
 
 	// While any zone is still being applied/removed by the deployer, poll waf.list
 	// so the spinner resolves to its settled state on its own. Mirrors the
@@ -26,14 +27,12 @@
 	// Last 24h of match activity per location, shown as an inline sparkline +
 	// total. Fetched client-side (one waf.metrics per zone, in parallel) so the
 	// table renders immediately and the charts fill in.
-	/**
-	 * @typedef {Object} Metrics
-	 * @property {boolean} loading
-	 * @property {number} total
-	 * @property {[number, number][]} points
-	 */
-	/** @type {Record<string, Metrics>} */
-	const metrics = $state({})
+	interface Metrics {
+		loading: boolean
+		total: number
+		points: [number, number][]
+	}
+	const metrics = $state<Record<string, Metrics>>({})
 
 	// Fixed 24h x-domain so bars sit at the right time-of-day even when the zone
 	// only has a few active minutes.
@@ -41,11 +40,10 @@
 	const from = to - 24 * 60 * 60
 
 	onMount(() => {
-		Promise.all(firewalls.map(async (/** @type {Api.WafZone} */ fw) => {
+		Promise.all(firewalls.map(async (fw: Api.WafZone) => {
 			metrics[fw.location] = { loading: true, total: 0, points: [] }
 
-			/** @type {Api.Response<Api.WafMetricsResult>} */
-			const res = await api.invoke('waf.metrics',
+			const res = await api.invoke<Api.WafMetricsResult>('waf.metrics',
 				{ project, location: fw.location, timeRange: '1d' }, fetch)
 
 			metrics[fw.location] = {
@@ -58,20 +56,15 @@
 
 	// Collapse the per-(rule, action) series into one total-matches line: sum
 	// every series' value at each timestamp, then sort by time.
-	/**
-	 * @param {Api.WafMetricsSeries[]} series
-	 * @returns {[number, number][]}
-	 */
-	function aggregate (series) {
-		/** @type {Record<number, number>} */
-		const byTs = {}
+	function aggregate (series: Api.WafMetricsSeries[]): [number, number][] {
+		const byTs: Record<number, number> = {}
 		for (const s of series) {
 			for (const [ts, v] of s.points ?? []) {
 				byTs[ts] = (byTs[ts] ?? 0) + v
 			}
 		}
 		return Object.entries(byTs)
-			.map(([ts, v]) => /** @type {[number, number]} */ ([Number(ts), v]))
+			.map(([ts, v]) => ([Number(ts), v] as [number, number]))
 			.sort((a, b) => a[0] - b[0])
 	}
 </script>

--- a/src/routes/(auth)/(project)/waf/create/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/create/+page.svelte
@@ -1,11 +1,12 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const locations = $derived(data.locations)
@@ -17,8 +18,7 @@
 
 	let saving = $state(false)
 
-	/** @param {Event} e */
-	async function save (e) {
+	async function save (e: Event) {
 		e.preventDefault()
 		if (saving) return
 

--- a/src/routes/(auth)/(project)/waf/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/edit/+page.svelte
@@ -1,4 +1,5 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import { untrack } from 'svelte'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
@@ -17,7 +18,7 @@
 	} from '$lib/waf/rules'
 	import { normalizeLimits, toApiLimits } from '$lib/waf/limits'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const location = $derived(data.location)
@@ -64,9 +65,9 @@
 	// CEL textarea). Both edit the same `draft.expression` string, so switching
 	// preserves whatever is there. Start in Visual only when the seed expression
 	// is representable; otherwise open straight into raw/Expression mode.
-	let mode = $state(/** @type {'visual' | 'raw'} */ (
+	let mode = $state<'visual' | 'raw'>(
 		untrack(() => (parseExpression(draft.expression) !== null ? 'visual' : 'raw'))
-	))
+	)
 
 	// If we're in Visual but the expression becomes non-representable, fall back
 	// to raw so the disabled Visual tab can't show stale rows. (Visual edits stay
@@ -75,8 +76,7 @@
 		if (mode === 'visual' && !canUseVisual) mode = 'raw'
 	})
 
-	/** @type {{ clearExpression: () => void } | undefined} */
-	let builder = $state()
+	let builder = $state<{ clearExpression:() => void }>()
 
 	function clearExpression () {
 		if (mode === 'visual' && builder) builder.clearExpression()
@@ -87,8 +87,7 @@
 		return goto(`/waf/manage?project=${project}&location=${encodeURIComponent(location)}`)
 	}
 
-	/** @param {Event} e */
-	async function save (e) {
+	async function save (e: Event) {
 		e.preventDefault()
 		if (saving || !hasCondition) return
 
@@ -129,10 +128,8 @@
 	// value widgets it means "pick/add this value", elsewhere nothing. Saving is
 	// deliberate, via the Save button. Enter still works on the button itself
 	// (a <button>, not an <input>) and in the raw-CEL <textarea>.
-	/** @param {HTMLFormElement} node */
-	function blockEnterSubmit (node) {
-		/** @param {KeyboardEvent} e */
-		function onKeydown (e) {
+	function blockEnterSubmit (node: HTMLFormElement) {
+		function onKeydown (e: KeyboardEvent) {
 			if (e.key === 'Enter' && e.target instanceof HTMLInputElement) e.preventDefault()
 		}
 		node.addEventListener('keydown', onKeydown)

--- a/src/routes/(auth)/(project)/waf/limit/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/limit/+page.svelte
@@ -1,4 +1,5 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import { untrack } from 'svelte'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
@@ -8,6 +9,7 @@
 	import WafConditionBuilder from '$lib/components/WafConditionBuilder.svelte'
 	import { parseExpression } from '$lib/waf/expression'
 	import { normalizeRules, toApiRules } from '$lib/waf/rules'
+	import type { KeyRow } from '$lib/waf/limits'
 	import {
 		DEFAULT_LIMIT_MESSAGE,
 		keyTypeLabels,
@@ -18,7 +20,7 @@
 		windowOptions
 	} from '$lib/waf/limits'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const location = $derived(data.location)
@@ -68,9 +70,9 @@
 	// textarea), same pattern as the rule editor. The filter is optional: empty
 	// means the limit applies to every request.
 	const canUseVisual = $derived(parseExpression(draft.filter) !== null)
-	let filterMode = $state(/** @type {'visual' | 'raw'} */ (
+	let filterMode = $state<'visual' | 'raw'>(
 		untrack(() => (parseExpression(draft.filter) !== null ? 'visual' : 'raw'))
-	))
+	)
 
 	// If we're in Visual but the filter becomes non-representable, fall back to
 	// raw so the disabled Visual tab can't show stale rows.
@@ -78,8 +80,7 @@
 		if (filterMode === 'visual' && !canUseVisual) filterMode = 'raw'
 	})
 
-	/** @type {{ clearExpression: () => void } | undefined} */
-	let filterBuilder = $state()
+	let filterBuilder = $state<{ clearExpression:() => void }>()
 
 	function clearFilter () {
 		if (filterMode === 'visual' && filterBuilder) filterBuilder.clearExpression()
@@ -103,11 +104,10 @@
 	const canSave = $derived(Number(draft.rate) >= 1 && !!draft.window && keysComplete)
 
 	function addKeyRow () {
-		draft.key = [...draft.key, /** @type {import('$lib/waf/limits').KeyRow} */ ({ type: 'ip', name: '' })]
+		draft.key = [...draft.key, ({ type: 'ip', name: '' } as KeyRow)]
 	}
 
-	/** @param {number} i */
-	function removeKeyRow (i) {
+	function removeKeyRow (i: number) {
 		draft.key = draft.key.filter((_, idx) => idx !== i)
 	}
 
@@ -115,8 +115,7 @@
 		return goto(`/waf/manage?project=${project}&location=${encodeURIComponent(location)}`)
 	}
 
-	/** @param {Event} e */
-	async function save (e) {
+	async function save (e: Event) {
 		e.preventDefault()
 		if (saving || !canSave) return
 
@@ -155,10 +154,8 @@
 	// Enter inside a text field (description/rate/message, the key name inputs)
 	// must not implicitly submit the limit. Saving is deliberate, via the Save
 	// button (a <button>, where Enter still works).
-	/** @param {HTMLFormElement} node */
-	function blockEnterSubmit (node) {
-		/** @param {KeyboardEvent} e */
-		function onKeydown (e) {
+	function blockEnterSubmit (node: HTMLFormElement) {
+		function onKeydown (e: KeyboardEvent) {
 			if (e.key === 'Enter' && e.target instanceof HTMLInputElement) e.preventDefault()
 		}
 		node.addEventListener('keydown', onKeydown)

--- a/src/routes/(auth)/(project)/waf/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/manage/+page.svelte
@@ -1,14 +1,17 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import { untrack } from 'svelte'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import type { RuleForm } from '$lib/waf/rules'
 	import { actionLabels, normalizeRules, toApiRules } from '$lib/waf/rules'
+	import type { LimitForm } from '$lib/waf/limits'
 	import { describeKey, keyRowToApi, modeLabels, normalizeLimits, toApiLimits } from '$lib/waf/limits'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const location = $derived(data.location)
@@ -39,8 +42,7 @@
 	let savingDescription = $state(false)
 
 	async function reloadZone () {
-		/** @type {Api.Response<Api.WafZone>} */
-		const resp = await api.invoke('waf.get', { project, location }, fetch)
+		const resp = await api.invoke<Api.WafZone>('waf.get', { project, location }, fetch)
 		if (!resp.ok) {
 			if (resp.error?.notFound) {
 				// The zone disappeared underneath us — back to the index.
@@ -59,11 +61,7 @@
 	// Persist the whole zone (priority follows row order). waf.set replaces the
 	// entire zone, so rules and limits must always travel together. On error,
 	// surface it and reload from the server so the UI matches reality.
-	/**
-	 * @param {import('$lib/waf/rules').RuleForm[]} nextRules
-	 * @param {import('$lib/waf/limits').LimitForm[]} [nextLimits]
-	 */
-	async function persistZone (nextRules, nextLimits = limits) {
+	async function persistZone (nextRules: RuleForm[], nextLimits: LimitForm[] = limits) {
 		const resp = await api.invoke('waf.set', {
 			project,
 			location,
@@ -79,11 +77,7 @@
 		return true
 	}
 
-	/**
-	 * @param {number} i
-	 * @param {-1 | 1} dir
-	 */
-	async function moveRule (i, dir) {
+	async function moveRule (i: number, dir: -1 | 1) {
 		const j = i + dir
 		if (j < 0 || j >= rules.length) return
 		const next = [...rules]
@@ -92,8 +86,7 @@
 		await persistZone(next)
 	}
 
-	/** @param {number} i */
-	function removeRule (i) {
+	function removeRule (i: number) {
 		const rule = rules[i]
 		if (!rule) return
 		modal.confirm({
@@ -107,8 +100,7 @@
 		})
 	}
 
-	/** @param {import('$lib/waf/rules').RuleForm} rule */
-	function editRule (rule) {
+	function editRule (rule: RuleForm) {
 		goto(`/waf/edit?project=${project}&location=${encodeURIComponent(location)}&rule=${encodeURIComponent(rule.id)}`)
 	}
 
@@ -116,8 +108,7 @@
 		goto(`/waf/edit?project=${project}&location=${encodeURIComponent(location)}`)
 	}
 
-	/** @param {number} i */
-	function removeLimit (i) {
+	function removeLimit (i: number) {
 		const limit = limits[i]
 		if (!limit) return
 		modal.confirm({
@@ -131,8 +122,7 @@
 		})
 	}
 
-	/** @param {import('$lib/waf/limits').LimitForm} limit */
-	function editLimit (limit) {
+	function editLimit (limit: LimitForm) {
 		goto(`/waf/limit?project=${project}&location=${encodeURIComponent(location)}&limit=${encodeURIComponent(limit.id)}`)
 	}
 

--- a/src/routes/(auth)/(project)/waf/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/metrics/+page.svelte
@@ -1,4 +1,6 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
+	import type { LineSeries } from '$lib/charts/util'
 	import { onMount } from 'svelte'
 	import { page } from '$app/stores'
 	import { replaceState } from '$app/navigation'
@@ -10,7 +12,7 @@
 	import WafActivityChart from '$lib/components/WafActivityChart.svelte'
 	import LineChart from '$lib/components/LineChart.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const location = $derived(data.location)
@@ -19,17 +21,16 @@
 	// Rule id → its configured description/action, so the top-rules table reads
 	// in human terms rather than raw ids.
 	const ruleMeta = $derived(new Map(
-		(data.zone?.rules ?? []).map((/** @type {Api.WafRule} */ r) => [r.id, r])
+		(data.zone?.rules ?? []).map((r: Api.WafRule) => [r.id, r])
 	))
 
 	// Configured limits drive the rate-limit section: no limits, no section.
-	const limits = $derived(/** @type {Api.WafLimit[]} */ (data.zone?.limits ?? []))
+	const limits = $derived((data.zone?.limits ?? []) as Api.WafLimit[])
 	const hasLimits = $derived(limits.length > 0)
 
 	// Stacks render block on top of log on top of allow — most-severe last so it
 	// sits at the top of the column.
-	/** @type {Api.WafAction[]} */
-	const ACTION_ORDER = ['allow', 'log', 'block']
+	const ACTION_ORDER: Api.WafAction[] = ['allow', 'log', 'block']
 
 	const RANGE_OPTIONS = [
 		{ value: '1h', label: '1H' },
@@ -39,10 +40,8 @@
 		{ value: '7d', label: '7D' },
 		{ value: '30d', label: '30D' }
 	]
-	/** @type {Record<string, number>} */
-	const RANGE_SECONDS = { '1h': 3600, '6h': 21600, '12h': 43200, '1d': 86400, '7d': 604800, '30d': 2592000 }
-	/** @type {Record<string, string>} */
-	const RANGE_LABEL = {
+	const RANGE_SECONDS: Record<string, number> = { '1h': 3600, '6h': 21600, '12h': 43200, '1d': 86400, '7d': 604800, '30d': 2592000 }
+	const RANGE_LABEL: Record<string, string> = {
 		'1h': 'last hour',
 		'6h': 'last 6 hours',
 		'12h': 'last 12 hours',
@@ -51,31 +50,29 @@
 		'30d': 'last 30 days'
 	}
 	// Bucket width per range — kept around 48–72 columns so bars stay legible.
-	/** @type {Record<string, number>} */
-	const BUCKET_SECONDS = { '1h': 60, '6h': 300, '12h': 600, '1d': 1800, '7d': 10800, '30d': 43200 }
+	const BUCKET_SECONDS: Record<string, number> = { '1h': 60, '6h': 300, '12h': 600, '1d': 1800, '7d': 10800, '30d': 43200 }
 
 	const initialRange = $page.url.searchParams.get('range')
 	let range = $state(initialRange && RANGE_SECONDS[initialRange] ? initialRange : '1d')
 
 	let loading = $state(true)
-	let result = $state(/** @type {Api.WafMetricsResult | null} */ (null))
-	let limitResult = $state(/** @type {Api.WafLimitMetricsResult | null} */ (null))
+	let result = $state<Api.WafMetricsResult | null>(null)
+	let limitResult = $state<Api.WafLimitMetricsResult | null>(null)
 	// Anchor the time window to the moment of the latest fetch so the chart grid
 	// and "as of" line agree.
 	let fetchedAt = $state(Math.floor(Date.now() / 1000))
 
-	/** @type {ReturnType<typeof setTimeout> | undefined} */
-	let refreshTimer
+	let refreshTimer: ReturnType<typeof setTimeout> | undefined
 
 	async function fetchMetrics () {
 		loading = true
 		try {
 			const args = { project, location, timeRange: range }
 			const [res, limitRes] = await Promise.all([
-				/** @type {Promise<Api.Response<Api.WafMetricsResult>>} */ (api.invoke('waf.metrics', args, fetch)),
+				api.invoke<Api.WafMetricsResult>('waf.metrics', args, fetch),
 				hasLimits
-					? /** @type {Promise<Api.Response<Api.WafLimitMetricsResult>>} */ (api.invoke('waf.limitMetrics', args, fetch))
-					: Promise.resolve(/** @type {Api.Response<Api.WafLimitMetricsResult>} */ ({ ok: true, result: { series: [], total: 0 } }))
+					? api.invoke<Api.WafLimitMetricsResult>('waf.limitMetrics', args, fetch)
+					: Promise.resolve({ ok: true, result: { series: [], total: 0 } } as Api.Response<Api.WafLimitMetricsResult>)
 			])
 			if (!res.ok) {
 				modal.error({ error: res.error })
@@ -99,8 +96,7 @@
 		}
 	}
 
-	/** @param {string} r */
-	function selectRange (r) {
+	function selectRange (r: string) {
 		if (r === range) return
 		range = r
 		const u = new URL($page.url)
@@ -120,8 +116,7 @@
 
 	// Totals per action, for the KPI tiles.
 	const byAction = $derived.by(() => {
-		/** @type {Record<Api.WafAction, number>} */
-		const acc = { block: 0, log: 0, allow: 0 }
+		const acc: Record<Api.WafAction, number> = { block: 0, log: 0, allow: 0 }
 		for (const s of result?.series ?? []) {
 			acc[s.action] = (acc[s.action] ?? 0) + s.total
 		}
@@ -146,8 +141,7 @@
 		const to = fetchedAt
 		const n = Math.max(1, Math.ceil((to - from) / bucket))
 
-		/** @type {Record<Api.WafAction, number[]>} */
-		const grids = { block: new Array(n).fill(0), log: new Array(n).fill(0), allow: new Array(n).fill(0) }
+		const grids: Record<Api.WafAction, number[]> = { block: new Array(n).fill(0), log: new Array(n).fill(0), allow: new Array(n).fill(0) }
 		for (const s of result?.series ?? []) {
 			const g = grids[s.action]
 			if (!g) continue
@@ -162,16 +156,14 @@
 			.map((action) => ({
 				action,
 				name: actionLabels[action] ?? action,
-				/** @type {[number, number][]} */
-				data: grids[action].map((v, i) => [(from + i * bucket) * 1000, v])
+				data: grids[action].map((v, i) => [(from + i * bucket) * 1000, v]) as [number, number][]
 			}))
 	})
 
 	// Rank rules by match volume. Each (rule, action) series collapses onto its
 	// rule; the action of its largest series wins the badge.
 	const topRules = $derived.by(() => {
-		/** @type {Record<string, { ruleId: string, total: number, action: Api.WafAction, top: number }>} */
-		const byRule = {}
+		const byRule: Record<string, { ruleId: string, total: number, action: Api.WafAction, top: number }> = {}
 		for (const s of result?.series ?? []) {
 			const cur = byRule[s.ruleId]
 			if (cur) {
@@ -189,19 +181,16 @@
 			.sort((a, b) => b.total - a.total)
 	})
 
-	/** @param {number} v */
-	function share (v) {
+	function share (v: number) {
 		return total > 0 ? v / total : 0
 	}
-	/** @param {number} v */
-	function pct (v) {
+	function pct (v: number) {
 		return total > 0 ? `${Math.round((v / total) * 100)}%` : '—'
 	}
 
 	// Per-limit (allowed, limited) bucket counts, joined from the sparse series.
 	const limitBuckets = $derived.by(() => {
-		/** @type {Record<string, { allowed: Record<number, number>, limited: Record<number, number> }>} */
-		const byLimit = {}
+		const byLimit: Record<string, { allowed: Record<number, number>, limited: Record<number, number> }> = {}
 		for (const s of limitResult?.series ?? []) {
 			const entry = byLimit[s.limitId] ??= { allowed: {}, limited: {} }
 			const m = entry[s.result]
@@ -217,8 +206,7 @@
 	// percentage, over the union of that limit's bucket timestamps. A missing
 	// series counts as 0, so a bucket with only limited traffic reads 100%.
 	const limitShareSeries = $derived.by(() => {
-		/** @type {import('$lib/charts/util').LineSeries[]} */
-		const out = []
+		const out: LineSeries[] = []
 		for (const limit of limits) {
 			const entry = limitBuckets[limit.id]
 			if (!entry) continue
@@ -245,7 +233,7 @@
 	// traffic in the window.
 	const limitRows = $derived(limits.map((limit) => {
 		const entry = limitBuckets[limit.id]
-		const sum = (/** @type {Record<number, number> | undefined} */ m) =>
+		const sum = (m: Record<number, number> | undefined) =>
 			Object.values(m ?? {}).reduce((acc, v) => acc + v, 0)
 		const allowed = sum(entry?.allowed)
 		const limited = sum(entry?.limited)
@@ -253,8 +241,7 @@
 		return { limit, allowed, limited, traffic, share: traffic > 0 ? (limited / traffic) * 100 : null }
 	}))
 
-	/** @param {number} v */
-	function sharePct (v) {
+	function sharePct (v: number) {
 		return `${v >= 10 ? v.toFixed(1) : v.toFixed(2)}%`
 	}
 

--- a/src/routes/(auth)/(project)/workload-identity/+page.svelte
+++ b/src/routes/(auth)/(project)/workload-identity/+page.svelte
@@ -1,11 +1,12 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import StatusIcon from '$lib/components/StatusIcon.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import * as format from '$lib/format'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const workloadIdentities = $derived(data.workloadIdentities)

--- a/src/routes/(auth)/(project)/workload-identity/create/+page.svelte
+++ b/src/routes/(auth)/(project)/workload-identity/create/+page.svelte
@@ -1,11 +1,12 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const locations = $derived(data.locations)
 
@@ -19,10 +20,7 @@
 
 	let saving = $state(false)
 
-	/**
-	 * @param {Event} e
-	 */
-	async function save (e) {
+	async function save (e: Event) {
 		e.preventDefault()
 
 		if (saving) {

--- a/src/routes/(auth)/(project)/workload-identity/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/workload-identity/detail/+page.svelte
@@ -1,4 +1,5 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types'
 	import * as format from '$lib/format'
 	import { onMount } from 'svelte'
 	import { setupCopy } from '$lib/clipboard'
@@ -8,7 +9,7 @@
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 
-	const { data } = $props()
+	const { data }: { data: PageData } = $props()
 
 	const workloadIdentity = $derived(data.workloadIdentity)
 	const project = $derived(data.project)


### PR DESCRIPTION
## What

Batch 5 of the [JS → TS migration](https://github.com/deploys-app/console/pull/239). Converts **all 67 `.svelte` files under `(auth)/(project)`** — every resource page, its detail subroutes, and per-route `_components/` — to `<script lang="ts">` with fully-strict TypeScript. **No behavior/markup/style change.**

Covers: audit-log, cache, deployment, disk, domain, dropbox, email, env-group, github, metrics, pull-secret, registry, role, route, service-account, waf, workload-identity.

### How
- Page props typed via `PageData`/`LayoutData` from `./$types`; `_components/*` via `interface Props`.
- JSDoc lifted to real types; untyped `api.invoke` results given generics; `$state<T>()`, typed event handlers / `bind:this`; reused the already-TS `lib/waf/*` and `lib/charts/util` types.
- Added `@types/js-cookie`.
- Typed the dashboard load's `?? {}` fallbacks as `Api.ProjectUsage` / `Api.BillingProject` so the page can read their fields.
- A few metrics endpoints (`deployment.metrics`, `disk.metrics`) have no `Api.*` result type yet — modeled with local interfaces (candidates to centralize in `api.d.ts` later).

### Scope
Large batch — parallelized across 7 subagents by resource area, then verified as a whole.

### Verification
- `bun check` → **0 errors / 0 warnings** (775 files)
- `bun lint` → clean
- `bun build` → succeeds

### No visual change
Representative resource pages render identically:

| Deployments | Domains | Roles |
| --- | --- | --- |
| ![deployment](https://raw.githubusercontent.com/deploys-app/console/screenshots/243-deployment.png) | ![domain](https://raw.githubusercontent.com/deploys-app/console/screenshots/243-domain.png) | ![role](https://raw.githubusercontent.com/deploys-app/console/screenshots/243-role.png) |

| Registry | Routes | Env Groups |
| --- | --- | --- |
| ![registry](https://raw.githubusercontent.com/deploys-app/console/screenshots/243-registry.png) | ![route](https://raw.githubusercontent.com/deploys-app/console/screenshots/243-route.png) | ![env-group](https://raw.githubusercontent.com/deploys-app/console/screenshots/243-env-group.png) |

### Remaining
**~15 files**: top-level `(auth)` chrome (`Navbar`, `Sidebar`, `SearchModal`, `ModalSelectProject`, `+layout.svelte`), `billing/*` (6), `github-setup`, `project/*` (2), and root `+layout.svelte`. One final batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)