### PR TITLE
chore: tier-2 dedup — list-loader, stable-id, route-target helpers

### DIFF
--- a/src/lib/cache/overrides.ts
+++ b/src/lib/cache/overrides.ts
@@ -4,6 +4,8 @@
 // Order = match order, with `priority` derived from index on every whole-zone
 // write — first match wins, lower priority first.
 
+import { makeGenId, withStableIds } from '$lib/form/ids'
+
 export interface OverrideForm {
 	id: string
 	description: string
@@ -66,25 +68,13 @@ export function overrideForm (override?: Api.CacheOverride): OverrideForm {
 /**
  * Generate a stable, unique override id that doesn't collide with `taken`.
  */
-export function genId (taken: string[]): string {
-	let id
-	do {
-		id = 'override-' + Math.random().toString(36).slice(2, 8)
-	} while (taken.includes(id))
-	return id
-}
+export const genId = makeGenId('override-')
 
 // Map API overrides to form rows: order by priority (lower matches first) so
 // the visible order is the match order, and give every row a unique id.
 export function normalizeOverrides (apiOverrides?: Api.CacheOverride[]): OverrideForm[] {
 	const sorted = [...(apiOverrides ?? [])].sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0))
-	const taken: string[] = []
-	return sorted.map((o) => {
-		const f = overrideForm(o)
-		if (!f.id || taken.includes(f.id)) f.id = genId(taken)
-		taken.push(f.id)
-		return f
-	})
+	return withStableIds(sorted, overrideForm, genId)
 }
 
 // Map form rows back to the API override shape. Priority follows row order —

--- a/src/lib/form/ids.ts
+++ b/src/lib/form/ids.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared helpers for form-row identity. WAF rules/limits and cache overrides
+ * all keep auto-generated, stable ids on their form rows so a row survives
+ * reordering and re-saving; these collapse the id-generation + id-stabilizing
+ * machinery that was duplicated across those modules.
+ */
+
+/**
+ * Build an id generator that yields collision-free ids with the given prefix
+ * (e.g. 'rule-', 'limit-', 'override-'), avoiding any id already in `taken`.
+ */
+export function makeGenId (prefix: string): (taken: string[]) => string {
+	return (taken) => {
+		let id
+		do {
+			id = prefix + Math.random().toString(36).slice(2, 8)
+		} while (taken.includes(id))
+		return id
+	}
+}
+
+/**
+ * Map API items to form rows, giving each a stable unique id: reuse the item's
+ * own id when present and not already taken, otherwise mint a fresh one.
+ */
+export function withStableIds<A, F extends { id: string }> (
+	items: A[] | undefined,
+	toForm: (item: A) => F,
+	genId: (taken: string[]) => string
+): F[] {
+	const taken: string[] = []
+	return (items ?? []).map((item) => {
+		const f = toForm(item)
+		if (!f.id || taken.includes(f.id)) f.id = genId(taken)
+		taken.push(f.id)
+		return f
+	})
+}

--- a/src/lib/loaders.ts
+++ b/src/lib/loaders.ts
@@ -1,0 +1,23 @@
+import api from '$lib/api'
+import type { LoadEvent } from '@sveltejs/kit'
+
+type ListData<K extends string, T> = { [P in K]: T[] } & { error?: Api.Error }
+
+/**
+ * Standard list-page loader. Fetches a project-scoped `*.list` RPC and returns
+ * its items under `key` plus the error envelope — the identical body that was
+ * repeated across every resource list page.
+ *
+ * Usage (in a `+page.ts`):
+ *   export const load = listLoad<Api.Disk, 'disks'>('disk.list', 'disks')
+ *
+ * `project` comes from the parent (project) layout's data. Pages that need
+ * extra fetches, args, or returned fields keep their own bespoke loader.
+ */
+export function listLoad<T, K extends string> (fn: string, key: K) {
+	return async ({ parent, fetch }: LoadEvent): Promise<ListData<K, T>> => {
+		const { project } = await parent() as { project: string }
+		const res = await api.invoke<Api.List<T>>(fn, { project }, fetch)
+		return { [key]: res.result?.items ?? [], error: res.error } as ListData<K, T>
+	}
+}

--- a/src/lib/route.ts
+++ b/src/lib/route.ts
@@ -1,0 +1,25 @@
+/**
+ * Per-target-prefix UI metadata for route targets, shared by the route
+ * list/manage and create/edit pages so the label/icon/placeholder/hint for each
+ * `<prefix>://` target type live in one place.
+ */
+export interface RouteTargetMeta {
+	label: string
+	icon: string // Font Awesome class
+	placeholder?: string
+	hint?: string
+}
+
+export const routeTargetMeta: Record<string, RouteTargetMeta> = {
+	'deployment://': { label: 'Deployment', icon: 'fa-cube' },
+	'redirect://': { label: 'Redirect', icon: 'fa-arrow-right-arrow-left', placeholder: 'https://example.com' },
+	'http://': {
+		label: 'External server (HTTP)',
+		icon: 'fa-server',
+		placeholder: '203.0.113.10:8080',
+		hint: 'Your server’s public IP address, with an optional port (defaults to 80). Private, loopback, and link-local addresses are not allowed.'
+	},
+	'ipfs://': { label: 'IPFS', icon: 'fa-cubes' },
+	'ipns://': { label: 'IPNS', icon: 'fa-cubes' },
+	'dnslink://': { label: 'DNSLink', icon: 'fa-link' }
+}

--- a/src/lib/waf/limits.ts
+++ b/src/lib/waf/limits.ts
@@ -2,6 +2,8 @@
 // ids are auto-generated and stable for the life of a limit (like rule ids),
 // but limits have no priority — order doesn't matter.
 
+import { makeGenId, withStableIds } from '$lib/form/ids'
+
 /**
  * One characteristic of the bucket key. Header/cookie carry a name; the rest
  * round-trip as a bare keyword ('ip', 'host', 'country', 'asn').
@@ -113,25 +115,13 @@ export function limitForm (limit?: Api.WafLimit): LimitForm {
 /**
  * Generate a stable, unique limit id that doesn't collide with `taken`.
  */
-export function genLimitId (taken: string[]): string {
-	let id
-	do {
-		id = 'limit-' + Math.random().toString(36).slice(2, 8)
-	} while (taken.includes(id))
-	return id
-}
+export const genLimitId = makeGenId('limit-')
 
 /**
  * Map API limits to form rows, giving every row a unique id.
  */
 export function normalizeLimits (apiLimits?: Api.WafLimit[]): LimitForm[] {
-	const taken: string[] = []
-	return (apiLimits ?? []).map((l) => {
-		const f = limitForm(l)
-		if (!f.id || taken.includes(f.id)) f.id = genLimitId(taken)
-		taken.push(f.id)
-		return f
-	})
+	return withStableIds(apiLimits, limitForm, genLimitId)
 }
 
 /**

--- a/src/lib/waf/rules.ts
+++ b/src/lib/waf/rules.ts
@@ -3,6 +3,8 @@
 // logs/metrics as rule_id), so they must survive reordering. Order = execution
 // order, with `priority` derived from index on every whole-zone write.
 
+import { makeGenId, withStableIds } from '$lib/form/ids'
+
 export interface RuleForm {
 	id: string
 	description: string
@@ -35,25 +37,13 @@ export function ruleForm (rule?: Api.WafRule): RuleForm {
 /**
  * Generate a stable, unique rule id that doesn't collide with `taken`.
  */
-export function genId (taken: string[]): string {
-	let id
-	do {
-		id = 'rule-' + Math.random().toString(36).slice(2, 8)
-	} while (taken.includes(id))
-	return id
-}
+export const genId = makeGenId('rule-')
 
 // Map API rules to form rows: order by priority (lower runs first) so the
 // visible order is the execution order, and give every row a unique id.
 export function normalizeRules (apiRules?: Api.WafRule[]): RuleForm[] {
 	const sorted = [...(apiRules ?? [])].sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0))
-	const taken: string[] = []
-	return sorted.map((r) => {
-		const f = ruleForm(r)
-		if (!f.id || taken.includes(f.id)) f.id = genId(taken)
-		taken.push(f.id)
-		return f
-	})
+	return withStableIds(sorted, ruleForm, genId)
 }
 
 // Map form rows back to the API rule shape. Priority follows row order — the

--- a/src/routes/(auth)/(project)/deployment/+page.ts
+++ b/src/routes/(auth)/(project)/deployment/+page.ts
@@ -1,12 +1,3 @@
-import api from '$lib/api'
-import type { PageLoad } from './$types'
+import { listLoad } from '$lib/loaders'
 
-export const load: PageLoad = async ({ parent, fetch }) => {
-	const { project } = await parent()
-
-	const res = await api.invoke<Api.List<Api.Deployment>>('deployment.list', { project }, fetch)
-	return {
-		deployments: res.result?.items ?? [],
-		error: res.error
-	}
-}
+export const load = listLoad<Api.Deployment, 'deployments'>('deployment.list', 'deployments')

--- a/src/routes/(auth)/(project)/disk/+page.ts
+++ b/src/routes/(auth)/(project)/disk/+page.ts
@@ -1,12 +1,3 @@
-import api from '$lib/api'
-import type { PageLoad } from './$types'
+import { listLoad } from '$lib/loaders'
 
-export const load: PageLoad = async ({ parent, fetch }) => {
-	const { project } = await parent()
-
-	const res = await api.invoke<Api.List<Api.Disk>>('disk.list', { project }, fetch)
-	return {
-		disks: res.result?.items ?? [],
-		error: res.error
-	}
-}
+export const load = listLoad<Api.Disk, 'disks'>('disk.list', 'disks')

--- a/src/routes/(auth)/(project)/domain/+page.ts
+++ b/src/routes/(auth)/(project)/domain/+page.ts
@@ -1,12 +1,3 @@
-import api from '$lib/api'
-import type { PageLoad } from './$types'
+import { listLoad } from '$lib/loaders'
 
-export const load: PageLoad = async ({ parent, fetch }) => {
-	const { project } = await parent()
-
-	const res = await api.invoke<Api.List<Api.Domain>>('domain.list', { project }, fetch)
-	return {
-		domains: res.result?.items ?? [],
-		error: res.error
-	}
-}
+export const load = listLoad<Api.Domain, 'domains'>('domain.list', 'domains')

--- a/src/routes/(auth)/(project)/email/+page.ts
+++ b/src/routes/(auth)/(project)/email/+page.ts
@@ -1,12 +1,3 @@
-import api from '$lib/api'
-import type { PageLoad } from './$types'
+import { listLoad } from '$lib/loaders'
 
-export const load: PageLoad = async ({ parent, fetch }) => {
-	const { project } = await parent()
-
-	const res = await api.invoke<Api.List<Api.EmailDomain>>('email.list', { project }, fetch)
-	return {
-		domains: res.result?.items ?? [],
-		error: res.error
-	}
-}
+export const load = listLoad<Api.EmailDomain, 'domains'>('email.list', 'domains')

--- a/src/routes/(auth)/(project)/env-group/+page.ts
+++ b/src/routes/(auth)/(project)/env-group/+page.ts
@@ -1,12 +1,3 @@
-import api from '$lib/api'
-import type { PageLoad } from './$types'
+import { listLoad } from '$lib/loaders'
 
-export const load: PageLoad = async ({ parent, fetch }) => {
-	const { project } = await parent()
-
-	const res = await api.invoke<Api.List<Api.EnvGroup>>('envGroup.list', { project }, fetch)
-	return {
-		envGroups: res.result?.items ?? [],
-		error: res.error
-	}
-}
+export const load = listLoad<Api.EnvGroup, 'envGroups'>('envGroup.list', 'envGroups')

--- a/src/routes/(auth)/(project)/pull-secret/+page.ts
+++ b/src/routes/(auth)/(project)/pull-secret/+page.ts
@@ -1,12 +1,3 @@
-import api from '$lib/api'
-import type { PageLoad } from './$types'
+import { listLoad } from '$lib/loaders'
 
-export const load: PageLoad = async ({ parent, fetch }) => {
-	const { project } = await parent()
-
-	const res = await api.invoke<Api.List<Api.PullSecret>>('pullSecret.list', { project }, fetch)
-	return {
-		pullSecrets: res.result?.items ?? [],
-		error: res.error
-	}
-}
+export const load = listLoad<Api.PullSecret, 'pullSecrets'>('pullSecret.list', 'pullSecrets')

--- a/src/routes/(auth)/(project)/registry/(list)/+page.ts
+++ b/src/routes/(auth)/(project)/registry/(list)/+page.ts
@@ -1,12 +1,3 @@
-import api from '$lib/api'
-import type { PageLoad } from './$types'
+import { listLoad } from '$lib/loaders'
 
-export const load: PageLoad = async ({ parent, fetch }) => {
-	const { project } = await parent()
-
-	const res = await api.invoke<Api.List<Api.Repository>>('registry.list', { project }, fetch)
-	return {
-		repositories: res.result?.items ?? [],
-		error: res.error
-	}
-}
+export const load = listLoad<Api.Repository, 'repositories'>('registry.list', 'repositories')

--- a/src/routes/(auth)/(project)/role/+page.ts
+++ b/src/routes/(auth)/(project)/role/+page.ts
@@ -1,12 +1,3 @@
-import api from '$lib/api'
-import type { PageLoad } from './$types'
+import { listLoad } from '$lib/loaders'
 
-export const load: PageLoad = async ({ parent, fetch }) => {
-	const { project } = await parent()
-
-	const res = await api.invoke<Api.List<Api.Role>>('role.list', { project }, fetch)
-	return {
-		roles: res.result?.items ?? [],
-		error: res.error
-	}
-}
+export const load = listLoad<Api.Role, 'roles'>('role.list', 'roles')

--- a/src/routes/(auth)/(project)/route/+page.ts
+++ b/src/routes/(auth)/(project)/route/+page.ts
@@ -1,12 +1,3 @@
-import api from '$lib/api'
-import type { PageLoad } from './$types'
+import { listLoad } from '$lib/loaders'
 
-export const load: PageLoad = async ({ parent, fetch }) => {
-	const { project } = await parent()
-
-	const res = await api.invoke<Api.List<Api.Route>>('route.list', { project }, fetch)
-	return {
-		routes: res.result?.items ?? [],
-		error: res.error
-	}
-}
+export const load = listLoad<Api.Route, 'routes'>('route.list', 'routes')

--- a/src/routes/(auth)/(project)/route/create/+page.svelte
+++ b/src/routes/(auth)/(project)/route/create/+page.svelte
@@ -4,6 +4,7 @@
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import { routeTargetMeta } from '$lib/route'
 	import type { PageData } from './$types'
 
 	const { data }: { data: PageData } = $props()
@@ -28,14 +29,8 @@
 		}
 	})
 
-	const targetPlaceholder = $derived(({
-		'redirect://': 'https://example.com',
-		'http://': '203.0.113.10:8080'
-	} as Record<string, string>)[form.targetPrefix] || '')
-
-	const targetHint = $derived(({
-		'http://': 'Your server’s public IP address, with an optional port (defaults to 80). Private, loopback, and link-local addresses are not allowed.'
-	} as Record<string, string>)[form.targetPrefix] || '')
+	const targetPlaceholder = $derived(routeTargetMeta[form.targetPrefix]?.placeholder ?? '')
+	const targetHint = $derived(routeTargetMeta[form.targetPrefix]?.hint ?? '')
 
 	let domains = $state<Api.Domain[]>([])
 	let deployments = $state<{ name: string, paused: boolean }[]>([])

--- a/src/routes/(auth)/(project)/route/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/route/edit/+page.svelte
@@ -5,6 +5,7 @@
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import { routeTargetMeta } from '$lib/route'
 	import type { PageData } from './$types'
 
 	const { data }: { data: PageData } = $props()
@@ -84,14 +85,8 @@
 		return base
 	})
 
-	const targetPlaceholder = $derived(({
-		'redirect://': 'https://example.com',
-		'http://': '203.0.113.10:8080'
-	} as Record<string, string>)[form.targetPrefix] || '')
-
-	const targetHint = $derived(({
-		'http://': 'Your server’s public IP address, with an optional port (defaults to 80). Private, loopback, and link-local addresses are not allowed.'
-	} as Record<string, string>)[form.targetPrefix] || '')
+	const targetPlaceholder = $derived(routeTargetMeta[form.targetPrefix]?.placeholder ?? '')
+	const targetHint = $derived(routeTargetMeta[form.targetPrefix]?.hint ?? '')
 
 	let deployments = $state<{ name: string, paused: boolean }[]>([])
 

--- a/src/routes/(auth)/(project)/route/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/route/manage/+page.svelte
@@ -7,6 +7,7 @@
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import { routeTargetMeta } from '$lib/route'
 	import type { PageData } from './$types'
 
 	const { data }: { data: PageData } = $props()
@@ -32,26 +33,8 @@
 	}
 
 	const parsed = $derived(splitTarget(route.target))
-	const typeLabel = $derived(
-		({
-			'deployment://': 'Deployment',
-			'redirect://': 'Redirect',
-			'http://': 'External server (HTTP)',
-			'ipfs://': 'IPFS',
-			'ipns://': 'IPNS',
-			'dnslink://': 'DNSLink'
-		} as Record<string, string>)[parsed.prefix] ?? parsed.prefix
-	)
-	const targetIcon = $derived(
-		({
-			'deployment://': 'fa-cube',
-			'redirect://': 'fa-arrow-right-arrow-left',
-			'http://': 'fa-server',
-			'ipfs://': 'fa-cubes',
-			'ipns://': 'fa-cubes',
-			'dnslink://': 'fa-link'
-		} as Record<string, string>)[parsed.prefix] ?? 'fa-cube'
-	)
+	const typeLabel = $derived(routeTargetMeta[parsed.prefix]?.label ?? parsed.prefix)
+	const targetIcon = $derived(routeTargetMeta[parsed.prefix]?.icon ?? 'fa-cube')
 
 	// deployment:// targets resolve to a deployment in the same location; link
 	// straight to its detail page so the route is navigable. Derive the name from

--- a/src/routes/(auth)/(project)/service-account/+page.ts
+++ b/src/routes/(auth)/(project)/service-account/+page.ts
@@ -1,12 +1,3 @@
-import api from '$lib/api'
-import type { PageLoad } from './$types'
+import { listLoad } from '$lib/loaders'
 
-export const load: PageLoad = async ({ parent, fetch }) => {
-	const { project } = await parent()
-
-	const res = await api.invoke<Api.List<Api.ServiceAccount>>('serviceAccount.list', { project }, fetch)
-	return {
-		serviceAccounts: res.result?.items ?? [],
-		error: res.error
-	}
-}
+export const load = listLoad<Api.ServiceAccount, 'serviceAccounts'>('serviceAccount.list', 'serviceAccounts')

--- a/src/routes/(auth)/(project)/workload-identity/+page.ts
+++ b/src/routes/(auth)/(project)/workload-identity/+page.ts
@@ -1,12 +1,3 @@
-import api from '$lib/api'
-import type { PageLoad } from './$types'
+import { listLoad } from '$lib/loaders'
 
-export const load: PageLoad = async ({ parent, fetch }) => {
-	const { project } = await parent()
-
-	const res = await api.invoke<Api.List<Api.WorkloadIdentity>>('workloadIdentity.list', { project }, fetch)
-	return {
-		workloadIdentities: res.result?.items ?? [],
-		error: res.error
-	}
-}
+export const load = listLoad<Api.WorkloadIdentity, 'workloadIdentities'>('workloadIdentity.list', 'workloadIdentities')


### PR DESCRIPTION
## What

The **Tier 2** consolidation items from the post-migration review. Behavior-preserving dedup — **no UI or behavior change**. (−199/+129 across 20 files.)

### 1. `listLoad<T, K>` — collapse the resource list loaders
`$lib/loaders.ts` adds a generic helper for the identical project-scoped `*.list` → `{ <key>: items, error }` body that was copy-pasted across **11 list pages**. Each loader is now 3 lines:
```ts
import { listLoad } from '$lib/loaders'
export const load = listLoad<Api.Disk, 'disks'>('disk.list', 'disks')
```
Per-page typing is preserved by the generic — `data.disks` stays `Api.Disk[]`. Pages with extra fetches/args/returned fields (cache, waf, dropbox, role/users, audit-log, …) keep their bespoke loaders.

### 2. `makeGenId` + `withStableIds` — collapse the id machinery
`$lib/form/ids.ts` extracts the identical id-generation loop and id-stabilizing map that were triplicated in `waf/rules`, `waf/limits`, and `cache/overrides`. Each module keeps its own `*Form`/`toApi*` (those genuinely differ) and just exports `genId`/`genLimitId` built from `makeGenId`.

### 3. `routeTargetMeta` — one route-target metadata map
`$lib/route.ts` holds a single per-prefix `{ label, icon, placeholder?, hint? }` map, replacing the overlapping inline maps — and their `as Record<string,string>` casts — in route `manage`/`create`/`edit` (this is the proper home for the cast cleanup deferred from Tier 1).

### Verification
- `bun check` → **0 errors / 0 warnings**, `bun lint` → clean, `bun build` → succeeds.
- No visual change. Routes list (driven by `listLoad`) and WAF manage (rules/limits via `normalizeRules`/`normalizeLimits` → `withStableIds`) render correctly:

| Routes (listLoad) | WAF manage (stable-id normalize) |
| --- | --- |
| ![routes](https://raw.githubusercontent.com/deploys-app/console/screenshots/247-routes.png) | ![waf-manage](https://raw.githubusercontent.com/deploys-app/console/screenshots/247-waf-manage.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)