### PR TITLE
Add Scheduler UI

### DIFF
--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -32,5 +32,6 @@ export const projectMenu: ProjectMenuItem[] = [
 	{ id: 'dropbox', title: 'Dropbox', icon: 'fa-box-open', link: '/dropbox' },
 	{ id: 'registry', title: 'Registry', icon: 'fa-warehouse-full', link: '/registry' },
 	{ id: 'github', title: 'GitHub', icon: 'fa-code-branch', link: '/github', preview: true },
+	{ id: 'scheduler', title: 'Scheduler', icon: 'fa-clock', link: '/scheduler', preview: true },
 	{ id: 'audit-log', title: 'Audit Logs', icon: 'fa-clipboard-list', link: '/audit-log' }
 ]

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -609,6 +609,61 @@ const envGroups = [
 	}
 ]
 
+const schedulerJobs = [
+	{
+		project: 'acme',
+		name: 'daily-health-check',
+		schedule: '0 9 * * *',
+		timezone: 'Asia/Bangkok',
+		method: 'POST',
+		url: 'https://api.example.com/health',
+		headers: { 'Content-Type': 'application/json' },
+		body: '{"check":true}',
+		auth: { type: 'bearer' },
+		insecureSkipVerify: false,
+		paused: false,
+		lastResult: 'success',
+		lastRunAt: CREATED_AT,
+		lastLatencyMs: 142,
+		lastHttpStatus: 200,
+		lastError: '',
+		nextRunAt: CREATED_AT,
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL,
+		updatedAt: CREATED_AT,
+		updatedBy: USER_EMAIL
+	},
+	{
+		project: 'acme',
+		name: 'cache-warmer',
+		schedule: '*/15 * * * *',
+		timezone: 'UTC',
+		method: 'GET',
+		url: 'https://example.com/warm',
+		headers: {},
+		body: '',
+		auth: { type: 'none' },
+		insecureSkipVerify: false,
+		paused: true,
+		lastResult: 'failed',
+		lastRunAt: CREATED_AT,
+		lastLatencyMs: 30021,
+		lastHttpStatus: 0,
+		lastError: 'context deadline exceeded',
+		nextRunAt: null,
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL,
+		updatedAt: CREATED_AT,
+		updatedBy: USER_EMAIL
+	}
+]
+
+const schedulerInvocations = [
+	{ id: '3', startedAt: CREATED_AT, result: 'success', httpStatus: 200, latencyMs: 142, error: '' },
+	{ id: '2', startedAt: CREATED_AT, result: 'success', httpStatus: 200, latencyMs: 158, error: '' },
+	{ id: '1', startedAt: CREATED_AT, result: 'failed', httpStatus: 500, latencyMs: 88, error: 'unexpected status 500' }
+]
+
 const roles = [
 	{
 		role: 'viewer',
@@ -1249,6 +1304,16 @@ const handlers: Record<string, (args: any) => object> = {
 	'envGroup.create': () => ok({}),
 	'envGroup.update': () => ok({}),
 	'envGroup.delete': () => ok({}),
+
+	'scheduler.list': () => list(schedulerJobs),
+	'scheduler.get': (args) => ok(schedulerJobs.find((j) => j.name === args?.name) ?? { ...schedulerJobs[0], name: args?.name ?? 'daily-health-check' }),
+	'scheduler.create': () => ok({}),
+	'scheduler.update': () => ok({}),
+	'scheduler.delete': () => ok({}),
+	'scheduler.pause': () => ok({}),
+	'scheduler.resume': () => ok({}),
+	'scheduler.trigger': () => ok({ id: '99', startedAt: CREATED_AT, result: 'success', httpStatus: 200, latencyMs: 134, error: '' }),
+	'scheduler.logs': () => list(schedulerInvocations),
 
 	'email.list': () => list([{ domain: 'mail.acme.example.com', createdAt: CREATED_AT }]),
 

--- a/src/routes/(auth)/(project)/scheduler/+layout.ts
+++ b/src/routes/(auth)/(project)/scheduler/+layout.ts
@@ -1,0 +1,8 @@
+import type { LayoutLoad } from './$types'
+
+export const load: LayoutLoad = () => {
+	return {
+		menu: 'scheduler',
+		overrideRedirect: '/scheduler'
+	}
+}

--- a/src/routes/(auth)/(project)/scheduler/+page.svelte
+++ b/src/routes/(auth)/(project)/scheduler/+page.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+	import type { PageData } from './$types'
+	import ListTable from '$lib/components/ListTable.svelte'
+	import StatusIcon from '$lib/components/StatusIcon.svelte'
+	import * as format from '$lib/format'
+	import { denyTooltip, getPermissionContext } from '$lib/permission'
+
+	const { can } = getPermissionContext()
+
+	const { data }: { data: PageData } = $props()
+
+	const project = $derived(data.project)
+	const jobs = $derived(data.jobs)
+	const error = $derived(data.error)
+
+	// Map a job's denormalized last result to a StatusIcon status. A paused job
+	// shows a neutral marker; a never-run job shows nothing yet.
+	function statusOf (job: Api.SchedulerJob): string {
+		if (job.lastResult === 'success') return 'success'
+		if (job.lastResult === 'failed') return 'error'
+		return ''
+	}
+</script>
+
+<ListTable
+	title="Scheduler"
+	items={jobs}
+	{error}
+	noun="job"
+	createPermission="scheduler.create"
+	createHref="/scheduler/create?project={project}"
+	createLabel="Create job"
+	columns={['Name', 'Schedule', 'Method', 'Last run', 'Status']}
+	actions
+	key={(it) => it.name}>
+	{#snippet row(it)}
+		<td>
+			<a class="link cell-name" href="/scheduler/detail?project={project}&name={it.name}">
+				{it.name}
+			</a>
+		</td>
+		<td><span class="font-mono text-sm">{it.schedule}</span></td>
+		<td><span class="method-badge" data-method={it.method}>{it.method}</span></td>
+		<td>
+			{#if it.lastRunAt}
+				<span class="cell-time" title={format.datetime(it.lastRunAt)}>{format.fromNow(it.lastRunAt)}</span>
+			{:else}
+				<span class="text-content/40">Never</span>
+			{/if}
+		</td>
+		<td>
+			{#if it.paused}
+				<span class="inline-flex items-center gap-2 text-content/60"><i class="fa-solid fa-pause"></i> Paused</span>
+			{:else if it.lastResult === 'success'}
+				<span class="inline-flex items-center text-positive/80"><StatusIcon status={statusOf(it)} />Success</span>
+			{:else if it.lastResult === 'failed'}
+				<span class="inline-flex items-center text-negative/80"><StatusIcon status={statusOf(it)} />Failed</span>
+			{:else}
+				<span class="text-content/40">—</span>
+			{/if}
+		</td>
+		<td>
+			<span class="inline-flex" title={can('scheduler.update') ? null : denyTooltip('scheduler.update')}>
+				<a
+					href={can('scheduler.update') ? `/scheduler/create?project=${project}&name=${it.name}` : null}
+					aria-label="Edit"
+					aria-disabled={can('scheduler.update') ? null : 'true'}>
+					<div class="icon-button">
+						<i class="fa-solid fa-pen"></i>
+					</div>
+				</a>
+			</span>
+		</td>
+	{/snippet}
+</ListTable>
+
+<style>
+	.method-badge {
+		display: inline-flex;
+		padding: 0.0625rem 0.5rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		font-family: var(--ffml-mono, monospace);
+		color: hsl(var(--hsl-content) / 0.75);
+		background-color: hsl(var(--hsl-content) / 0.08);
+	}
+
+	.method-badge[data-method='GET'],
+	.method-badge[data-method='HEAD'] {
+		color: hsl(var(--hsl-primary));
+		background-color: hsl(var(--hsl-primary) / 0.12);
+	}
+
+	.method-badge[data-method='POST'],
+	.method-badge[data-method='PUT'],
+	.method-badge[data-method='PATCH'] {
+		color: hsl(var(--hsl-warning));
+		background-color: hsl(var(--hsl-warning) / 0.12);
+	}
+
+	.method-badge[data-method='DELETE'] {
+		color: hsl(var(--hsl-negative));
+		background-color: hsl(var(--hsl-negative) / 0.12);
+	}
+</style>

--- a/src/routes/(auth)/(project)/scheduler/+page.ts
+++ b/src/routes/(auth)/(project)/scheduler/+page.ts
@@ -1,0 +1,3 @@
+import { listLoad } from '$lib/loaders'
+
+export const load = listLoad<Api.SchedulerJob, 'jobs'>('scheduler.list', 'jobs')

--- a/src/routes/(auth)/(project)/scheduler/create/+page.svelte
+++ b/src/routes/(auth)/(project)/scheduler/create/+page.svelte
@@ -1,0 +1,260 @@
+<script lang="ts">
+	import { untrack } from 'svelte'
+	import { goto } from '$app/navigation'
+	import type { PageData } from './$types'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import EnvVarEditor from '$lib/components/EnvVarEditor.svelte'
+
+	const { data }: { data: PageData } = $props()
+
+	const project = $derived(data.project)
+	const job = $derived(data.job)
+	const isEdit = $derived(!!data.job)
+
+	const methodOptions = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']
+		.map((m) => ({ value: m, label: m }))
+
+	const authTypeOptions = [
+		{ value: 'none', label: 'None' },
+		{ value: 'basic', label: 'Basic auth' },
+		{ value: 'bearer', label: 'Bearer token' }
+	]
+
+	// IANA timezones for the searchable Timezone dropdown. Intl.supportedValuesOf
+	// is the canonical list (Node 18+ / modern browsers); UTC is pinned first and
+	// the editable Select still accepts any typed value (the server validates).
+	const timezoneOptions = (() => {
+		let zones: string[]
+		try {
+			zones = Intl.supportedValuesOf('timeZone')
+		} catch {
+			zones = []
+		}
+		return ['UTC', ...zones.filter((z) => z !== 'UTC')].map((z) => ({ value: z, label: z }))
+	})()
+
+	const form = $state(untrack(() => ({
+		name: job?.name ?? '',
+		schedule: job?.schedule ?? '',
+		timezone: job?.timezone ?? '',
+		method: job?.method ?? 'GET',
+		url: job?.url ?? '',
+		headers: Object.entries(job?.headers ?? {}).map(([k, v]) => ({ k, v })),
+		body: job?.body ?? '',
+		authType: job?.auth?.type === 'basic' || job?.auth?.type === 'bearer' ? job.auth.type : 'none',
+		authUsername: job?.auth?.username ?? '',
+		// Secret is write-only: never prefilled. On edit, leaving it blank keeps
+		// the stored one.
+		authSecret: '',
+		insecureSkipVerify: job?.insecureSkipVerify ?? false,
+		paused: job?.paused ?? false
+	})))
+
+	// The stored auth type (basic/bearer carry a write-only secret). A secret is
+	// required when creating, or when editing changes the auth type — switching
+	// type needs a fresh secret since the stored one belonged to the old type.
+	const originalAuthType = $derived(
+		job?.auth?.type === 'basic' || job?.auth?.type === 'bearer' ? job.auth.type : 'none'
+	)
+	const secretRequired = $derived(
+		(form.authType === 'basic' || form.authType === 'bearer') &&
+		(!isEdit || form.authType !== originalAuthType)
+	)
+
+	let saving = $state(false)
+
+	async function save (e: SubmitEvent) {
+		e.preventDefault()
+		if (saving) return
+
+		const headers = form.headers.reduce<Record<string, string>>((p, x) => {
+			if (x.k) p[x.k] = x.v
+			return p
+		}, {})
+
+		const auth: Api.SchedulerAuth = { type: form.authType as Api.SchedulerAuth['type'] }
+		if (form.authType === 'basic') auth.username = form.authUsername
+		if ((form.authType === 'basic' || form.authType === 'bearer') && form.authSecret) {
+			auth.secret = form.authSecret
+		}
+
+		saving = true
+		try {
+			const fn = isEdit ? 'scheduler.update' : 'scheduler.create'
+			const args: Record<string, unknown> = {
+				project,
+				name: form.name,
+				schedule: form.schedule,
+				timezone: form.timezone,
+				method: form.method,
+				url: form.url,
+				headers,
+				body: form.body,
+				auth,
+				insecureSkipVerify: form.insecureSkipVerify
+			}
+			if (!isEdit) args.paused = form.paused
+
+			const resp = await api.invoke(fn, args, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+			await goto(`/scheduler/detail?project=${project}&name=${encodeURIComponent(form.name)}`)
+		} finally {
+			saving = false
+		}
+	}
+
+	function cancel () {
+		goto(`/scheduler?project=${project}`)
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/scheduler?project=${project}`} class="link"><h6>Scheduler</h6></a>
+	</div>
+	{#if isEdit && job}
+		<div class="breadcrumb-item">
+			<a href={`/scheduler/detail?project=${project}&name=${encodeURIComponent(job.name)}`} class="link"><h6>{job.name}</h6></a>
+		</div>
+		<div class="breadcrumb-item"><h6>Edit</h6></div>
+	{:else}
+		<div class="breadcrumb-item"><h6>Create</h6></div>
+	{/if}
+</div>
+
+<br>
+
+<div class="page-head">
+	<div>
+		<h4><strong>{isEdit ? 'Edit scheduled job' : 'Create scheduled job'}</strong></h4>
+		<p class="page-sub">Call an HTTP endpoint on a cron schedule.</p>
+	</div>
+</div>
+
+<div class="panel is-level-300 grid gap-4">
+	<form class="grid gap-4 w-full" onsubmit={save}>
+		<div class="field">
+			<label for="input-name">Name</label>
+			<div class="input">
+				<input id="input-name" placeholder="daily-health-check" bind:value={form.name} required readonly={isEdit}>
+			</div>
+		</div>
+
+		<div class="grid gap-4 sm:grid-cols-2">
+			<div class="field">
+				<label for="input-schedule">Schedule</label>
+				<div class="input">
+					<input id="input-schedule" class="font-mono" placeholder="*/5 * * * *" bind:value={form.schedule} required>
+				</div>
+				<p class="text-content/50 text-sm mt-1">5-field cron, or a macro like <code>@hourly</code> / <code>@every 30m</code>.</p>
+			</div>
+			<div class="field">
+				<label for="input-timezone">Timezone</label>
+				<Select id="input-timezone" editable bind:value={form.timezone} placeholder="UTC" options={timezoneOptions} />
+				<p class="text-content/50 text-sm mt-1">IANA name (e.g. <code>Asia/Bangkok</code>). Type to search; defaults to UTC.</p>
+			</div>
+		</div>
+
+		<br>
+		<hr>
+		<br>
+
+		<h6><strong>Request</strong></h6>
+
+		<div class="grid gap-4 sm:grid-cols-[10rem_1fr]">
+			<div class="field">
+				<label for="input-method">Method</label>
+				<Select id="input-method" bind:value={form.method} options={methodOptions} />
+			</div>
+			<div class="field">
+				<label for="input-url">URL</label>
+				<div class="input">
+					<input id="input-url" type="url" placeholder="https://example.com/webhook" bind:value={form.url} required>
+				</div>
+			</div>
+		</div>
+
+		<div class="field">
+			<span class="label">Headers</span>
+			<EnvVarEditor bind:entries={form.headers} />
+			<p class="text-content/50 text-sm mt-1">
+				A default <code>User-Agent: deploys-scheduler/1.0</code> is sent unless you set your own here.
+			</p>
+		</div>
+
+		<div class="field">
+			<label for="input-body">Body</label>
+			<div class="textarea">
+				<textarea id="input-body" class="font-mono" rows="4" placeholder={'{"key": "value"}'} bind:value={form.body}></textarea>
+			</div>
+		</div>
+
+		<br>
+		<hr>
+		<br>
+
+		<h6><strong>Authentication</strong></h6>
+
+		<div class="field">
+			<label for="input-auth-type">Type</label>
+			<Select id="input-auth-type" bind:value={form.authType} options={authTypeOptions} />
+		</div>
+
+		{#if form.authType === 'basic'}
+			<div class="grid gap-4 sm:grid-cols-2">
+				<div class="field">
+					<label for="input-auth-user">Username</label>
+					<div class="input">
+						<input id="input-auth-user" bind:value={form.authUsername} autocomplete="off" required>
+					</div>
+				</div>
+				<div class="field">
+					<label for="input-auth-secret">Password</label>
+					<div class="input">
+						<input id="input-auth-secret" type="password" bind:value={form.authSecret}
+							placeholder={isEdit && !secretRequired ? 'Unchanged' : ''} autocomplete="off" required={secretRequired}>
+					</div>
+				</div>
+			</div>
+		{:else if form.authType === 'bearer'}
+			<div class="field">
+				<label for="input-auth-secret">Token</label>
+				<div class="input">
+					<input id="input-auth-secret" type="password" bind:value={form.authSecret}
+						placeholder={isEdit && !secretRequired ? 'Unchanged' : ''} autocomplete="off" required={secretRequired}>
+				</div>
+			</div>
+		{/if}
+
+		<br>
+		<hr>
+		<br>
+
+		<label class="checkbox">
+			<input type="checkbox" bind:checked={form.insecureSkipVerify}>
+			Skip TLS verification for HTTPS targets (self-signed certificates)
+		</label>
+
+		{#if !isEdit}
+			<label class="checkbox">
+				<input type="checkbox" bind:checked={form.paused}>
+				Create paused (do not run until resumed)
+			</label>
+		{/if}
+
+		<hr>
+
+		<div class="flex gap-3">
+			<GuardedButton permission={isEdit ? 'scheduler.update' : 'scheduler.create'} type="submit" loading={saving}>
+				{isEdit ? 'Save' : 'Create'}
+			</GuardedButton>
+			<button type="button" class="button is-variant-secondary" onclick={cancel}>Cancel</button>
+		</div>
+	</form>
+</div>

--- a/src/routes/(auth)/(project)/scheduler/create/+page.ts
+++ b/src/routes/(auth)/(project)/scheduler/create/+page.ts
@@ -1,0 +1,24 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async ({ url, parent, fetch }) => {
+	const { project } = await parent()
+	const name = url.searchParams.get('name')
+
+	let job: Api.SchedulerJob | null = null
+	if (name) {
+		const res = await api.invoke<Api.SchedulerJob>('scheduler.get', { project, name }, fetch)
+		if (!res.ok) {
+			if (res.error?.notFound) redirect(302, `/scheduler?project=${project}`)
+			error(500, res.error?.message)
+		}
+		if (!res.result) redirect(302, `/scheduler?project=${project}`)
+		job = res.result
+	}
+
+	return {
+		menu: 'scheduler',
+		job
+	}
+}

--- a/src/routes/(auth)/(project)/scheduler/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/scheduler/detail/+page.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+	import { goto, invalidateAll } from '$app/navigation'
+	import type { PageData } from './$types'
+	import * as format from '$lib/format'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import DangerZone from '$lib/components/DangerZone.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import StatusIcon from '$lib/components/StatusIcon.svelte'
+
+	const { data }: { data: PageData } = $props()
+
+	const project = $derived(data.project)
+	const job = $derived(data.job)
+	const invocations = $derived(data.invocations)
+	const headerEntries = $derived(Object.entries(job.headers ?? {}))
+
+	let busy = $state(false)
+
+	async function setPaused (paused: boolean) {
+		if (busy) return
+		busy = true
+		try {
+			const fn = paused ? 'scheduler.pause' : 'scheduler.resume'
+			const resp = await api.invoke(fn, { project, name: job.name }, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+			await invalidateAll()
+		} finally {
+			busy = false
+		}
+	}
+
+	async function trigger () {
+		if (busy) return
+		busy = true
+		try {
+			const resp = await api.invoke<Api.SchedulerInvocation>('scheduler.trigger', { project, name: job.name }, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+			const inv = resp.result
+			if (inv?.result === 'success') {
+				modal.success({ content: `Ran "${job.name}" — HTTP ${inv.httpStatus} in ${inv.latencyMs} ms` })
+			} else {
+				modal.error({ error: `Run failed: ${inv?.error || `HTTP ${inv?.httpStatus ?? ''}`}` })
+			}
+			await invalidateAll()
+		} finally {
+			busy = false
+		}
+	}
+
+	function deleteItem () {
+		modal.confirm({
+			title: `Delete "${job.name}"?`,
+			yes: 'Delete',
+			callback: async () => {
+				const resp = await api.invoke('scheduler.delete', { project, name: job.name }, fetch)
+				if (!resp.ok) {
+					modal.error({ error: resp.error })
+					return
+				}
+				await goto(`/scheduler?project=${project}`)
+			}
+		})
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/scheduler?project=${project}`} class="link"><h6>Scheduler</h6></a>
+	</div>
+	<div class="breadcrumb-item min-w-0">
+		<h6 class="min-w-0 wrap-anywhere">{job.name}</h6>
+	</div>
+</div>
+
+<br>
+
+<div class="page-head">
+	<div class="min-w-0">
+		<h4 class="min-w-0 wrap-anywhere"><strong>{job.name}</strong></h4>
+		<p class="page-sub">
+			{#if job.paused}
+				<span class="text-content/60"><i class="fa-solid fa-pause"></i> Paused</span>
+			{:else}
+				<span class="font-mono">{job.schedule}</span>
+				{#if job.nextRunAt}· next run {format.fromNow(job.nextRunAt)}{/if}
+			{/if}
+		</p>
+	</div>
+	<div class="flex gap-3 flex-wrap">
+		<GuardedButton permission="scheduler.run" class="button is-variant-secondary is-icon-left" type="button"
+			loading={busy} onclick={trigger}>
+			<i class="fa-solid fa-play"></i>
+			Run now
+		</GuardedButton>
+		{#if job.paused}
+			<GuardedButton permission="scheduler.update" class="button is-variant-secondary is-icon-left" type="button"
+				loading={busy} onclick={() => setPaused(false)}>
+				<i class="fa-solid fa-play"></i>
+				Resume
+			</GuardedButton>
+		{:else}
+			<GuardedButton permission="scheduler.update" class="button is-variant-secondary is-icon-left" type="button"
+				loading={busy} onclick={() => setPaused(true)}>
+				<i class="fa-solid fa-pause"></i>
+				Pause
+			</GuardedButton>
+		{/if}
+		<GuardedButton permission="scheduler.update" class="button is-variant-secondary is-icon-left"
+			href={`/scheduler/create?project=${project}&name=${encodeURIComponent(job.name)}`}>
+			<i class="fa-solid fa-pen"></i>
+			Edit
+		</GuardedButton>
+	</div>
+</div>
+
+<div class="panel is-level-300 grid gap-6">
+	<div class="grid gap-4 w-full">
+		<div class="grid gap-4 sm:grid-cols-2">
+			<div class="field">
+				<label for="d-schedule">Schedule</label>
+				<div class="input"><input id="d-schedule" value={job.schedule} readonly disabled></div>
+			</div>
+			<div class="field">
+				<label for="d-timezone">Timezone</label>
+				<div class="input"><input id="d-timezone" value={job.timezone} readonly disabled></div>
+			</div>
+		</div>
+
+		<div class="field">
+			<label for="d-url">Request</label>
+			<div class="input"><input id="d-url" value={`${job.method} ${job.url}`} readonly disabled></div>
+		</div>
+
+		<div class="grid gap-4 sm:grid-cols-2">
+			<div class="field">
+				<label for="d-auth">Authentication</label>
+				<div class="input">
+					<input id="d-auth" value={!job.auth || job.auth.type === '' || job.auth.type === 'none' ? 'None' : (job.auth.type === 'basic' ? `Basic (${job.auth.username})` : 'Bearer token')} readonly disabled>
+				</div>
+			</div>
+			<div class="field">
+				<label for="d-tls">TLS verification</label>
+				<div class="input"><input id="d-tls" value={job.insecureSkipVerify ? 'Disabled (insecure)' : 'Enabled'} readonly disabled></div>
+			</div>
+		</div>
+
+		{#if headerEntries.length}
+			<div class="field">
+				<span class="label">Headers</span>
+				<div class="table-container">
+					<table class="table is-variant-compact">
+						<thead><tr><th class="is-collapse" style="min-width: 256px">Key</th><th>Value</th></tr></thead>
+						<tbody>
+							{#each headerEntries as [k, v] (k)}
+								<tr><td class="font-mono">{k}</td><td class="font-mono wrap-anywhere">{v}</td></tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			</div>
+		{/if}
+
+		<hr>
+
+		<div>
+			<h6><strong>Invocation log</strong></h6>
+			<p class="text-content/50 text-sm mt-1">The most recent runs of this job.</p>
+		</div>
+
+		<div class="table-container">
+			<table class="table is-variant-compact">
+				<thead>
+					<tr>
+						<th>Time</th>
+						<th>Result</th>
+						<th>Status</th>
+						<th>Latency</th>
+						<th>Error</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each invocations as inv (inv.id)}
+						<tr>
+							<td><span title={format.datetime(inv.startedAt)}>{format.fromNow(inv.startedAt)}</span></td>
+							<td>
+								{#if inv.result === 'success'}
+									<span class="inline-flex items-center text-positive/80"><StatusIcon status="success" />Success</span>
+								{:else}
+									<span class="inline-flex items-center text-negative/80"><StatusIcon status="error" />Failed</span>
+								{/if}
+							</td>
+							<td>{inv.httpStatus > 0 ? inv.httpStatus : '—'}</td>
+							<td class="tabular-nums">{inv.latencyMs} ms</td>
+							<td class="wrap-anywhere text-content/70">{inv.error || ''}</td>
+						</tr>
+					{:else}
+						<tr><td colspan="5" class="text-center text-content/50">No runs yet. Use “Run now” to trigger one.</td></tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+
+		<DangerZone description="Permanently delete this scheduled job and its invocation history.">
+			<GuardedButton permission="scheduler.delete" class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</GuardedButton>
+		</DangerZone>
+	</div>
+</div>

--- a/src/routes/(auth)/(project)/scheduler/detail/+page.ts
+++ b/src/routes/(auth)/(project)/scheduler/detail/+page.ts
@@ -1,0 +1,26 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async ({ url, parent, fetch }) => {
+	const { project } = await parent()
+	const name = url.searchParams.get('name')
+	if (!name) redirect(302, `/scheduler?project=${project}`)
+
+	const res = await api.invoke<Api.SchedulerJob>('scheduler.get', { project, name }, fetch)
+	if (!res.ok) {
+		if (res.error?.notFound) redirect(302, `/scheduler?project=${project}`)
+		error(500, res.error?.message)
+	}
+	if (!res.result) redirect(302, `/scheduler?project=${project}`)
+
+	// Recent invocations. A failure here shouldn't break the detail page, so the
+	// items default to empty.
+	const logs = await api.invoke<Api.SchedulerLogsResult>('scheduler.logs', { project, name, limit: 50 }, fetch)
+
+	return {
+		menu: 'scheduler',
+		job: res.result,
+		invocations: logs.result?.items ?? []
+	}
+}

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -694,6 +694,55 @@ declare namespace Api {
         items: CacheZone[]
     }
 
+    // Scheduler — cron-driven outbound HTTP requests (project-scoped,
+    // location-less). The auth secret is write-only: never present in responses.
+    export type SchedulerAuth = {
+        type: '' | 'none' | 'basic' | 'bearer'
+        username?: string
+        // accepted on create/update, never returned by get/list.
+        secret?: string
+    }
+
+    export type SchedulerJob = {
+        project: string
+        name: string
+        schedule: string
+        timezone: string
+        method: string
+        url: string
+        headers?: Record<string, string>
+        body?: string
+        auth: SchedulerAuth
+        insecureSkipVerify: boolean
+        paused: boolean
+        // denormalized last-run state. lastResult is '' before the first run.
+        lastResult: '' | 'success' | 'failed'
+        lastRunAt?: string | null
+        lastLatencyMs: number
+        lastHttpStatus: number
+        lastError: string
+        nextRunAt?: string | null
+        createdAt: string
+        createdBy: string
+        updatedAt: string
+        updatedBy: string
+    }
+
+    export type SchedulerInvocation = {
+        id: string
+        startedAt: string
+        result: 'success' | 'failed'
+        httpStatus: number
+        latencyMs: number
+        error: string
+    }
+
+    export type SchedulerLogsResult = {
+        project: string
+        name: string
+        items: SchedulerInvocation[]
+    }
+
     // cache.metrics reuses WafMetricsTimeRange.
     export type CacheMetricsSeries = {
         overrideId: string


### PR DESCRIPTION
Adds the `scheduler.*` resource UI under `(auth)/(project)/scheduler`:

- **List** — `ListTable` with method badges and a last-status/paused column.
- **Create / edit** — cron schedule + a **searchable IANA-timezone dropdown**, method/url, headers (via `EnvVarEditor`), body, typed auth with conditional fields, TLS-skip and create-paused toggles. The auth secret is write-only: blank-on-edit keeps the stored one, and is required on create or when an edit changes the auth type.
- **Detail** — read-only config + headers, the invocation log table, and Run-now / Pause-Resume / Edit / Delete actions, all permission-gated via `GuardedButton`.

Also adds `Api.Scheduler*` types, the nav entry (preview), and mock fixtures. `bun check` + `bun lint` are clean; all pages verified under `dev:mock` (light + dark).

Depends on the API shipped in deploys-app/api#81 (merged) / apiserver#147.

## Screenshots

**List**

| Light | Dark |
| --- | --- |
| ![list](https://raw.githubusercontent.com/deploys-app/console/screenshots/249-list.png) | ![list dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/249-list-dark.png) |

**Detail + invocation log**

| Light | Dark |
| --- | --- |
| ![detail](https://raw.githubusercontent.com/deploys-app/console/screenshots/249-detail.png) | ![detail dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/249-detail-dark.png) |

**Create form** (with the searchable timezone dropdown)

| Form | Timezone search |
| --- | --- |
| ![create](https://raw.githubusercontent.com/deploys-app/console/screenshots/249-create.png) | ![timezone search](https://raw.githubusercontent.com/deploys-app/console/screenshots/249-tz-search.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)