### PR TITLE
Show audit log channel in the activity feed

### DIFF
--- a/src/lib/components/ChannelBadge.svelte
+++ b/src/lib/components/ChannelBadge.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	interface Props {
+		channel: Api.AuditChannel
+	}
+
+	const { channel }: Props = $props()
+
+	const badge = $derived.by(() => {
+		switch (channel) {
+		case 'api': return { cls: 'is-api', label: 'API' }
+		case 'console': return { cls: 'is-console', label: 'Console' }
+		case 'cli': return { cls: 'is-cli', label: 'CLI' }
+		case 'mcp': return { cls: 'is-mcp', label: 'MCP' }
+		default: return null // legacy rows recorded before the channel column
+		}
+	})
+</script>
+
+<style>
+	.channel-badge {
+		display: inline-block;
+		padding: 0.1rem 0.5rem;
+		border-radius: 999px;
+		font-size: 0.75rem;
+		line-height: 1.25;
+		background: hsl(var(--hsl-content) / 0.08);
+		color: hsl(var(--hsl-content) / 0.75);
+	}
+
+	.channel-badge.is-api {
+		color: hsl(var(--hsl-info));
+		background: hsl(var(--hsl-info) / 0.12);
+	}
+
+	.channel-badge.is-console {
+		color: hsl(var(--hsl-primary));
+		background: hsl(var(--hsl-primary) / 0.12);
+	}
+
+	.channel-badge.is-cli {
+		color: hsl(var(--hsl-accent));
+		background: hsl(var(--hsl-accent) / 0.12);
+	}
+
+	.channel-badge.is-mcp {
+		color: hsl(var(--hsl-warning));
+		background: hsl(var(--hsl-warning) / 0.14);
+	}
+
+	.channel-muted {
+		color: hsl(var(--hsl-content) / 0.4);
+	}
+</style>
+
+{#if badge}
+	<span class="channel-badge {badge.cls}">{badge.label}</span>
+{:else}
+	<span class="channel-muted">—</span>
+{/if}

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -740,6 +740,9 @@ const auditLogItems = (() => {
 		{ resource: { type: 'PullSecret', id: 'ghcr', name: 'ghcr' }, action: 'pullSecret.create', detail: 'Added pull secret' },
 		{ resource: { type: 'EnvGroup', id: 'web-env', name: 'web-env' }, action: 'envGroup.update', detail: 'Updated env group' }
 	]
+	// cycle through the channels (plus one legacy '' row) so the badge column
+	// and the channel filter have varied data offline.
+	const channels = ['console', 'cli', 'mcp', 'api', 'console', '']
 	const t0 = new Date(CREATED_AT).getTime()
 	const items = []
 	for (let i = 0; i < 137; i++) {
@@ -748,6 +751,7 @@ const auditLogItems = (() => {
 			id: 1042 - i,
 			resource: { ...s.resource, locationId: LOCATION_ID },
 			actor: { email: USER_EMAIL, type: 'User' },
+			channel: channels[i % channels.length],
 			action: s.action,
 			outcome: i % 11 === 0 ? 'failure' : 'success',
 			detail: `${s.detail} (#${1042 - i})`,
@@ -1046,6 +1050,7 @@ const handlers: Record<string, (args: any) => object> = {
 		}
 		if (args?.resourceType) arr = arr.filter((it) => it.resource.type.toLowerCase() === String(args.resourceType).toLowerCase())
 		if (args?.actor) arr = arr.filter((it) => it.actor.email === args.actor)
+		if (args?.channel) arr = arr.filter((it) => it.channel === args.channel)
 		if (args?.outcome) arr = arr.filter((it) => it.outcome === args.outcome)
 		return list(arr.slice(0, args?.limit ?? arr.length))
 	},

--- a/src/routes/(auth)/(project)/audit-log/+page.svelte
+++ b/src/routes/(auth)/(project)/audit-log/+page.svelte
@@ -9,6 +9,7 @@
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import OutcomeBadge from '$lib/components/OutcomeBadge.svelte'
+	import ChannelBadge from '$lib/components/ChannelBadge.svelte'
 	import Select from '$lib/components/Select.svelte'
 	import * as format from '$lib/format'
 
@@ -31,6 +32,13 @@
 		{ value: 'serviceAccount', label: 'Service Account' }
 	]
 
+	const CHANNELS = [
+		{ value: 'api', label: 'API' },
+		{ value: 'console', label: 'Console' },
+		{ value: 'cli', label: 'CLI' },
+		{ value: 'mcp', label: 'MCP' }
+	]
+
 	function parseDate (v: string): Date | null {
 		if (!v) return null
 		const d = new Date(v)
@@ -40,6 +48,7 @@
 	const form = $state(untrack(() => ({
 		resourceType: data.filters.resourceType,
 		actor: data.filters.actor,
+		channel: data.filters.channel,
 		outcome: data.filters.outcome,
 		startDate: parseDate(data.filters.after),
 		endDate: parseDate(data.filters.before)
@@ -104,6 +113,7 @@
 				project,
 				resourceType: data.filters.resourceType,
 				actor: data.filters.actor,
+				channel: data.filters.channel,
 				outcome: data.filters.outcome,
 				after: toRFC3339(data.filters.after),
 				before: cursor,
@@ -155,6 +165,7 @@
 			q.set('project', project)
 			if (form.resourceType) q.set('resourceType', form.resourceType)
 			if (form.actor) q.set('actor', form.actor)
+			if (form.channel) q.set('channel', form.channel)
 			if (form.outcome) q.set('outcome', form.outcome)
 			if (form.startDate) q.set('after', new Date(form.startDate).toISOString())
 			if (form.endDate) q.set('before', new Date(form.endDate).toISOString())
@@ -170,6 +181,7 @@
 		try {
 			form.resourceType = ''
 			form.actor = ''
+			form.channel = ''
 			form.outcome = ''
 			form.startDate = null
 			form.endDate = null
@@ -426,6 +438,13 @@
 					</button>
 				</DatePicker>
 			</div>
+			<div class="field">
+				<label class="label" for="filter-channel">Channel</label>
+				<Select
+					id="filter-channel"
+					bind:value={form.channel}
+					options={[{ value: '', label: 'All' }, ...CHANNELS]} />
+			</div>
 		</div>
 		<div class="actor-row">
 			<div class="field">
@@ -451,6 +470,7 @@
 					<th>Time</th>
 					<th>Outcome</th>
 					<th>Actor</th>
+					<th>Channel</th>
 					<th>Action</th>
 					<th>Resource</th>
 					<th>Detail</th>
@@ -467,6 +487,7 @@
 								<span class="actor-tag">service account</span>
 							{/if}
 						</td>
+						<td><ChannelBadge channel={it.channel} /></td>
 						<td><span class="action-cell">{it.action}</span></td>
 						<td>
 							{#if it.resource.type}
@@ -486,11 +507,11 @@
 						</td>
 					</tr>
 				{/each}
-				<NoDataRow span={6} list={items} />
-				<ErrorRow span={6} {error} />
+				<NoDataRow span={7} list={items} />
+				<ErrorRow span={7} {error} />
 				{#if hasMore || loadingMore || loadMoreError}
 					<tr class="loadmore-row">
-						<td colspan="6">
+						<td colspan="7">
 							<div bind:this={sentinel} class="loadmore-sentinel">
 								{#if loadingMore}
 									<i class="fa-solid fa-circle-notch fa-spin"></i>

--- a/src/routes/(auth)/(project)/audit-log/+page.ts
+++ b/src/routes/(auth)/(project)/audit-log/+page.ts
@@ -16,6 +16,7 @@ export const load: PageLoad = async ({ url, parent, fetch }) => {
 	const filters = {
 		resourceType: url.searchParams.get('resourceType') ?? '',
 		actor: url.searchParams.get('actor') ?? '',
+		channel: url.searchParams.get('channel') ?? '',
 		outcome: url.searchParams.get('outcome') ?? '',
 		after: url.searchParams.get('after') ?? '',
 		before: url.searchParams.get('before') ?? ''
@@ -25,6 +26,7 @@ export const load: PageLoad = async ({ url, parent, fetch }) => {
 		project,
 		resourceType: filters.resourceType,
 		actor: filters.actor,
+		channel: filters.channel,
 		outcome: filters.outcome,
 		after: toRFC3339(filters.after),
 		before: toRFC3339(filters.before),

--- a/src/routes/api/[fn]/+server.ts
+++ b/src/routes/api/[fn]/+server.ts
@@ -34,7 +34,8 @@ export const POST: RequestHandler = async ({ locals, params, request }) => {
 		headers: {
 			accept: 'application/json',
 			'content-type': request.headers.get('content-type') ?? 'application/json',
-			authorization: `bearer ${token}`
+			authorization: `bearer ${token}`,
+			'x-deploys-channel': 'console'
 		}
 	})
 	return new Response(resp.body, {

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -481,6 +481,10 @@ declare namespace Api {
 
     export type AuditOutcome = 'success' | 'failure'
 
+    // The client surface a write action came through. Empty string on legacy
+    // rows recorded before the channel column existed.
+    export type AuditChannel = 'api' | 'console' | 'cli' | 'mcp' | ''
+
     export type AuditLogActor = {
         email: string
         type: AuditActorType
@@ -497,6 +501,7 @@ declare namespace Api {
         id: number
         resource: AuditLogResource
         actor: AuditLogActor
+        channel: AuditChannel
         action: string
         outcome: AuditOutcome
         detail: string


### PR DESCRIPTION
## What

Surfaces the new audit **channel** dimension in the console:

1. **Proxy header** — `src/routes/api/[fn]/+server.ts` now sends `X-Deploys-Channel: console` on every API request, so all console-originated writes are recorded under the `console` channel by the apiserver.
2. **Activity page** — a color-coded **Channel** badge column (`ChannelBadge.svelte`) and a **Channel** filter (api / console / cli / mcp). Legacy rows recorded before the channel column render as a muted dash.

Mock fixtures (`mock.ts`) now carry varied channels (including one legacy blank) so the column and filter work under `bun dev:mock`.

Depends on the audit channel contract (deploys-app/api#82, merged) and the apiserver column (deploys-app/apiserver#148).

## Verification

`bun lint` and `bun check` both pass with zero errors.

## Screenshots

Before / after — the new **Channel** column and filter:

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/250-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/250-after.png) |

Channel filter applied (`channel=mcp`) and dark mode:

| Filter = MCP | Dark |
| --- | --- |
| ![filter](https://raw.githubusercontent.com/deploys-app/console/screenshots/250-filter.png) | ![dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/250-dark.png) |

## Rollout note

⚠️ **Do not merge until the apiserver migration (deploys-app/apiserver#148) is applied in prod.** The header is harmlessly ignored until the `channel` column exists, but the Channel column will show dashes until apiserver is recording the value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)