### PR TITLE
Surface error pods on the deployment views

### DIFF
--- a/src/lib/deployment/DeploymentPodErrors.svelte
+++ b/src/lib/deployment/DeploymentPodErrors.svelte
@@ -1,0 +1,247 @@
+<script lang="ts">
+	import { browser } from '$app/environment'
+	import { onDestroy } from 'svelte'
+	import { podErrorReason, podErrorDetail, dominantReason } from '$lib/deployment/podError'
+	import { podPrefixStripper } from '$lib/deployment/podName'
+
+	interface Props {
+		// Pre-signed log-service /errors URL (Api.Deployment.errorsUrl).
+		url: string
+		status: Api.DeploymentStatus
+		action: Api.DeploymentAction
+		type: Api.DeploymentType
+		internalAddress?: string
+		// compact = one-line masthead strip; otherwise the full Events-tab card.
+		compact?: boolean
+	}
+
+	const { url, status, action, type, internalAddress, compact = false }: Props = $props()
+
+	// Only deployments that are supposed to keep standing pods can meaningfully
+	// have "no running pod": Static is edge-served (no pods, no errorsUrl) and a
+	// paused deployment is intentionally at zero — neither should poll. Mirrors
+	// DeploymentStatusIcon's needsPodStatus gate.
+	const needsErrors = $derived(
+		browser && !!url && type !== 'Static' && action !== 'pause' &&
+		(status === 'success' || status === 'error' || status === 'pending')
+	)
+
+	let pods = $state<Api.PodError[]>([])
+	const stripPods = $derived(podPrefixStripper({ internalAddress }))
+
+	const totalRestarts = $derived(pods.reduce((n, p) => n + (p.restartCount || 0), 0))
+	const reason = $derived(dominantReason(pods))
+
+	let timer: ReturnType<typeof setTimeout> | null = null
+	let destroyed = false
+
+	function clearTimer () {
+		if (timer) {
+			clearTimeout(timer)
+			timer = null
+		}
+	}
+
+	async function poll () {
+		clearTimer()
+		if (destroyed) return
+
+		try {
+			const res = await fetch(url)
+			if (res.status === 403) {
+				// token expired — stop polling
+				return
+			}
+			pods = (await res.json()) ?? []
+		} catch (err) {
+			console.error(err)
+		} finally {
+			if (!destroyed && needsErrors) {
+				// jitter so many rows don't refetch in lockstep
+				timer = setTimeout(poll, 10000 + Math.random() * 3000)
+			}
+		}
+	}
+
+	// Drop stale pods if the deployment we point at changes.
+	$effect(() => {
+		url
+		pods = []
+	})
+
+	// Run the poll loop only while it's needed; restart on target change.
+	$effect(() => {
+		const active = needsErrors
+		url
+		clearTimer()
+		if (active) {
+			poll()
+		}
+		return clearTimer
+	})
+
+	onDestroy(() => {
+		destroyed = true
+		clearTimer()
+	})
+</script>
+
+<style>
+	/* compact: a single line under the masthead meta */
+	.strip {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+		padding: 0.5rem 0.65rem;
+		border-radius: 8px;
+		background: hsl(var(--hsl-negative) / 0.08);
+		border: 1px solid hsl(var(--hsl-negative) / 0.2);
+		color: hsl(var(--hsl-negative));
+		font-family: var(--ffml-primary);
+		font-size: 0.8125rem;
+	}
+
+	.strip__reason {
+		font-weight: 700;
+	}
+
+	.strip__meta {
+		color: hsl(var(--hsl-content) / 0.7);
+	}
+
+	.strip__sep {
+		color: hsl(var(--hsl-content) / 0.3);
+	}
+
+	/* full card: Pod Health, sits atop the Events tab */
+	.card {
+		display: flex;
+		flex-direction: column;
+		background: hsl(var(--hsl-base-100));
+		border: 1px solid hsl(var(--hsl-negative) / 0.25);
+		border-radius: 10px;
+		overflow: hidden;
+		margin-bottom: 1.25rem;
+	}
+
+	.card__head {
+		display: flex;
+		align-items: center;
+		gap: 0.55rem;
+		padding: 0.55rem 1rem;
+		background: hsl(var(--hsl-negative) / 0.08);
+		border-bottom: 1px solid hsl(var(--hsl-negative) / 0.18);
+		color: hsl(var(--hsl-negative));
+		font-family: var(--ffml-primary);
+	}
+
+	.card__title {
+		margin: 0;
+		font-size: 0.9rem;
+		font-weight: 600;
+	}
+
+	.card__sub {
+		color: hsl(var(--hsl-content) / 0.6);
+		font-size: 0.8125rem;
+		font-weight: 500;
+	}
+
+	.card__list {
+		list-style: none;
+		margin: 0;
+		padding: 0.25rem 0;
+		font-family: var(--ffml-mono);
+		font-size: 0.8125rem;
+	}
+
+	.row {
+		display: grid;
+		grid-template-columns:
+			[pod]    minmax(7rem, 14rem)
+			[reason] 11rem
+			[detail] auto
+			[msg]    1fr;
+		align-items: baseline;
+		column-gap: 0.75rem;
+		padding: 0.3rem 1rem;
+		line-height: 1.5;
+	}
+
+	.row:hover {
+		background: hsl(var(--hsl-content) / 0.04);
+	}
+
+	.row__pod {
+		grid-column: pod;
+		color: hsl(var(--hsl-content) / 0.7);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.row__reason {
+		grid-column: reason;
+		font-family: var(--ffml-primary);
+		font-weight: 600;
+		color: hsl(var(--hsl-negative));
+		white-space: nowrap;
+	}
+
+	.row__detail {
+		grid-column: detail;
+		color: hsl(var(--hsl-content) / 0.6);
+		white-space: nowrap;
+	}
+
+	.row__msg {
+		grid-column: msg;
+		color: hsl(var(--hsl-content) / 0.85);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		min-width: 0;
+	}
+
+	@media (max-width: 768px) {
+		.row {
+			grid-template-columns: 1fr;
+			row-gap: 0.1rem;
+		}
+		.row__msg { white-space: normal; }
+	}
+</style>
+
+{#if pods.length > 0}
+	{#if compact}
+		<div class="strip" role="status">
+			<i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+			<span class="strip__reason">{reason}</span>
+			<span class="strip__sep">·</span>
+			<span class="strip__meta">{pods.length} pod{pods.length === 1 ? '' : 's'} not ready</span>
+			{#if totalRestarts > 0}
+				<span class="strip__sep">·</span>
+				<span class="strip__meta">{totalRestarts} restart{totalRestarts === 1 ? '' : 's'}</span>
+			{/if}
+		</div>
+	{:else}
+		<section class="card">
+			<header class="card__head">
+				<i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+				<h6 class="card__title">Pod Health</h6>
+				<span class="card__sub">{pods.length} pod{pods.length === 1 ? '' : 's'} not ready</span>
+			</header>
+			<ul class="card__list">
+				{#each pods as p (p.name)}
+					<li class="row">
+						<span class="row__pod" title={p.name}>{stripPods(p.name)}</span>
+						<span class="row__reason">{podErrorReason(p)}</span>
+						<span class="row__detail">{podErrorDetail(p)}</span>
+						<span class="row__msg" title={p.message}>{stripPods(p.message)}</span>
+					</li>
+				{/each}
+			</ul>
+		</section>
+	{/if}
+{/if}

--- a/src/lib/deployment/podError.ts
+++ b/src/lib/deployment/podError.ts
@@ -1,0 +1,48 @@
+// Helpers for interpreting the raw k8s failure reasons the log service's
+// /errors endpoint returns. The endpoint emits reasons verbatim (no
+// classification enum) so newly-added k8s reasons keep flowing through
+// untouched — the console turns them into something human here.
+
+/**
+ * A short label for a pod's current failure, e.g. `CrashLoopBackOff` /
+ * `ImagePullBackOff`. Prefers the live waiting/terminated reason, then the
+ * previous termination, and finally falls back to the phase.
+ */
+export function podErrorReason (p: Api.PodError): string {
+	if (p.waitingReason) return p.waitingReason
+	if (p.terminatedReason) return p.terminatedReason
+	if (p.lastTerminatedReason) return p.lastTerminatedReason
+	if (p.phase === 'Pending') return 'Pending'
+	if (p.phase === 'Running') return 'Not ready'
+	return p.phase || 'Unknown'
+}
+
+/**
+ * A one-line detail for a pod: restart count and exit code where meaningful.
+ * Exit 0 is treated as "no signal" (the reason already carries the meaning).
+ */
+export function podErrorDetail (p: Api.PodError): string {
+	const parts: string[] = []
+	if (p.restartCount > 0) parts.push(`${p.restartCount} restart${p.restartCount === 1 ? '' : 's'}`)
+	const exit = p.terminatedExitCode || p.lastTerminatedExitCode
+	if (exit) parts.push(`exit ${exit}`)
+	return parts.join(' · ')
+}
+
+/** The most common failure reason across a set of error pods (for a summary). */
+export function dominantReason (pods: Api.PodError[]): string {
+	const counts = new Map<string, number>()
+	for (const p of pods) {
+		const r = podErrorReason(p)
+		counts.set(r, (counts.get(r) ?? 0) + 1)
+	}
+	let best = ''
+	let bestN = 0
+	for (const [r, n] of counts) {
+		if (n > bestN) {
+			best = r
+			bestN = n
+		}
+	}
+	return best
+}

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -15,6 +15,12 @@ const HEALTHY_STATUS_URL =
 	'data:application/json,' +
 	encodeURIComponent(JSON.stringify({ count: 1, ready: 1, succeeded: 0, failed: 0 }))
 
+// An unhealthy pod status (no ready pod) for the erroring deployment fixture,
+// so its status icon resolves to the warning state offline.
+const UNHEALTHY_STATUS_URL =
+	'data:application/json,' +
+	encodeURIComponent(JSON.stringify({ count: 2, ready: 0, succeeded: 0, failed: 1 }))
+
 const ok = <T>(result: T = ({} as T)): { ok: true, result: T } => ({ ok: true, result })
 
 const err = (message: string): { ok: false, error: { message: string } } => ({ ok: false, error: { message } })
@@ -160,6 +166,9 @@ function deployment (project = 'acme') {
 		eventUrl: '/api/mock-events?t=mock',
 		podsUrl: '',
 		statusUrl: HEALTHY_STATUS_URL,
+		// Healthy deployments report no error pods; '' means the UI never fetches.
+		// The erroring 'api' fixture below overrides this with a live mock feed.
+		errorsUrl: '',
 		address: '203.0.113.10',
 		// `<kubeName>-<projectID>` (the in-cluster service name); id-named here so
 		// the logs/events pages exercise pod-name prefix stripping.
@@ -205,8 +214,22 @@ function staticDeployment (project = 'acme', releaseSha = STATIC_RELEASE_SHA) {
 	}
 }
 
+// An erroring WebService: crash-looping, no ready pod. errorsUrl points at the
+// mock /errors feed so the masthead strip + Events Pod Health card render
+// offline; UNHEALTHY_STATUS_URL drives the warning status icon.
+function erroringDeployment (project = 'acme') {
+	return {
+		...deployment(project),
+		name: 'api',
+		status: 'error',
+		statusUrl: UNHEALTHY_STATUS_URL,
+		errorsUrl: '/api/mock-errors?t=mock'
+	}
+}
+
 const deployments = [
 	deployment('acme'),
+	erroringDeployment('acme'),
 	staticDeployment('acme'),
 	{
 		...deployment('acme'),
@@ -1126,6 +1149,9 @@ const handlers: Record<string, (args: any) => object> = {
 			if (!revision || revision >= base.revision) return ok(base)
 			const sha = `${revision}`.repeat(64).slice(0, 64)
 			return ok({ ...base, revision, site: `site://deploys-static/${args?.project ?? 'acme'}/website@${sha}`, siteManifestDigest: sha })
+		}
+		if (args?.name === 'api') {
+			return ok({ ...erroringDeployment(args?.project), location: args?.location ?? LOCATION_ID })
 		}
 		const base = { ...deployment(args?.project), name: args?.name ?? 'web', location: args?.location ?? LOCATION_ID }
 		const revision = Number(args?.revision ?? 0)

--- a/src/routes/(auth)/(project)/deployment/(detail)/events/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/events/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte'
 	import { podPrefixStripper } from '$lib/deployment/podName'
+	import DeploymentPodErrors from '$lib/deployment/DeploymentPodErrors.svelte'
 	import type { PageData } from './$types'
 
 	interface DeploymentEvent {
@@ -410,6 +411,13 @@
 		}
 	}
 </style>
+
+<DeploymentPodErrors
+	url={deployment.errorsUrl}
+	status={deployment.status}
+	action={deployment.action}
+	type={deployment.type}
+	internalAddress={deployment.internalAddress} />
 
 <div class="events-shell">
 	<header class="events-rail">

--- a/src/routes/(auth)/(project)/deployment/_components/Header.svelte
+++ b/src/routes/(auth)/(project)/deployment/_components/Header.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import DeploymentStatusIcon from '$lib/components/DeploymentStatusIcon.svelte'
+	import DeploymentPodErrors from '$lib/deployment/DeploymentPodErrors.svelte'
 	import { page } from '$app/stores'
 	import api from '$lib/api'
 	import * as modal from '$lib/modal'
@@ -400,4 +401,12 @@
 			<span class="meta__value">#{deployment.revision}</span>
 		</span>
 	</div>
+
+	<DeploymentPodErrors
+		compact
+		url={deployment.errorsUrl}
+		status={deployment.status}
+		action={deployment.action}
+		type={deployment.type}
+		internalAddress={deployment.internalAddress} />
 </div>

--- a/src/routes/api/mock-errors/+server.ts
+++ b/src/routes/api/mock-errors/+server.ts
@@ -1,0 +1,43 @@
+// Mock error-pod feed for offline development. Only active when MOCK_API is
+// set — otherwise the route 404s. Returns the same JSON shape the real log
+// service's /errors endpoint emits: an array of Api.PodError. The deployment
+// fixture points an *erroring* deployment's errorsUrl here so the masthead
+// strip and the Events-tab Pod Health card are exercisable offline.
+//
+// Pod names use full id-named pod names (`d128-77-<rsHash>-<podHash>`) so the
+// UI exercises pod-name prefix stripping.
+
+import type { RequestHandler } from './$types'
+import { env } from '$env/dynamic/private'
+
+const POD_ERRORS = [
+	{
+		name: 'd128-77-7d8f9b6c5-x2k9p',
+		phase: 'Running',
+		ready: false,
+		restartCount: 7,
+		waitingReason: 'CrashLoopBackOff',
+		lastTerminatedReason: 'Error',
+		lastTerminatedExitCode: 1,
+		message: 'back-off 5m0s restarting failed container app'
+	},
+	{
+		name: 'd128-77-7d8f9b6c5-q8m2t',
+		phase: 'Pending',
+		ready: false,
+		restartCount: 0,
+		waitingReason: 'ImagePullBackOff',
+		message: 'Back-off pulling image "registry.deploys.app/acme/web:latest"'
+	}
+]
+
+export const GET: RequestHandler = async () => {
+	if (!env.MOCK_API) return new Response('not found', { status: 404 })
+
+	return new Response(JSON.stringify(POD_ERRORS), {
+		headers: {
+			'content-type': 'application/json',
+			'cache-control': 'no-store'
+		}
+	})
+}

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -80,6 +80,20 @@ declare namespace Api {
         failed: number
     }
 
+    export type PodError = {
+        name: string
+        phase: string
+        ready: boolean
+        restartCount: number
+        waitingReason?: string
+        waitingMessage?: string
+        terminatedReason?: string
+        terminatedExitCode?: number
+        lastTerminatedReason?: string
+        lastTerminatedExitCode?: number
+        message?: string
+    }
+
     export type RouteConfig = {
         basicAuth?: {
             user: string
@@ -345,6 +359,7 @@ declare namespace Api {
         eventUrl: string
         podsUrl: string
         statusUrl: string
+        errorsUrl: string
         address: string
         internalAddress: string
         status: DeploymentStatus


### PR DESCRIPTION
## What

Final part of the **auto-mark-deployment-as-Error** feature (error-pod data layer) — the user-facing surface. When a deployment has no ready pod, the console now explains *why* instead of just showing a red pill.

Two surfaces, sharing one component (`DeploymentPodErrors.svelte`):

1. **Compact strip** under the masthead meta (in the always-visible `Header.svelte`) — dominant failure reason + count of not-ready pods + total restarts. Visible on every detail tab.
2. **"Pod Health" card** atop the **Events** tab — one row per not-ready pod with its reason, restart/exit detail, and message (pod-name prefix stripped via the existing `podPrefixStripper`).

Both fetch the new `errorsUrl` **directly from the browser** — the same pattern `DeploymentStatusIcon` uses for `statusUrl` — poll every ~10 s (jittered) while the deployment is one that should have standing pods, and stop on `403`. They render **nothing** when there are no error pods, so healthy / static / paused deployments are unaffected (and never poll).

k8s reasons are rendered **raw** via `src/lib/deployment/podError.ts` helpers — no classification enum — so newly-added k8s waiting/terminated reasons keep flowing through untouched.

## Dependencies

Runtime-depends on the data layer: [api#83](https://github.com/deploys-app/api/pull/83) (`ErrorsURL` field) + [apiserver#151](https://github.com/deploys-app/apiserver/pull/151) (mints `errorsUrl`) + [log#3](https://github.com/deploys-app/log/pull/3) (`/errors` endpoint). The field is additive and absent-safe, so this is independently mergeable, but the panels stay empty until the data-layer chain deploys.

## Mock / screenshots

Adds an erroring `api` deployment fixture + a `/api/mock-errors` feed so the error UI is explorable and screenshottable offline (`bun dev:mock`).

`bun lint` and `bun check` both clean.

## Screenshots

**Events tab** — masthead Error pill + error strip, then the Pod Health card, then the live events feed:

![events dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/251-events-dark.png)

**Events tab (light):**

![events light](https://raw.githubusercontent.com/deploys-app/console/screenshots/251-events-light.png)

**Detail tab** — the masthead strip stays visible across tabs:

![detail dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/251-detail-dark.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)