### PR TITLE
scheduler: show pending invocation after Run now

### DIFF
--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -659,6 +659,7 @@ const schedulerJobs = [
 ]
 
 const schedulerInvocations = [
+	{ id: '4', startedAt: CREATED_AT, result: 'pending', httpStatus: 0, latencyMs: 0, error: '' },
 	{ id: '3', startedAt: CREATED_AT, result: 'success', httpStatus: 200, latencyMs: 142, error: '' },
 	{ id: '2', startedAt: CREATED_AT, result: 'success', httpStatus: 200, latencyMs: 158, error: '' },
 	{ id: '1', startedAt: CREATED_AT, result: 'failed', httpStatus: 500, latencyMs: 88, error: 'unexpected status 500' }
@@ -1317,7 +1318,7 @@ const handlers: Record<string, (args: any) => object> = {
 	'scheduler.delete': () => ok({}),
 	'scheduler.pause': () => ok({}),
 	'scheduler.resume': () => ok({}),
-	'scheduler.trigger': () => ok({ id: '99', startedAt: CREATED_AT, result: 'success', httpStatus: 200, latencyMs: 134, error: '' }),
+	'scheduler.trigger': () => ok({ id: '99', startedAt: CREATED_AT, result: 'pending', httpStatus: 0, latencyMs: 0, error: '' }),
 	'scheduler.logs': () => list(schedulerInvocations),
 
 	'email.list': () => list([{ domain: 'mail.acme.example.com', createdAt: CREATED_AT }]),

--- a/src/routes/(auth)/(project)/scheduler/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/scheduler/detail/+page.svelte
@@ -14,8 +14,17 @@
 	const job = $derived(data.job)
 	const invocations = $derived(data.invocations)
 	const headerEntries = $derived(Object.entries(job.headers ?? {}))
+	const hasPending = $derived(invocations.some((inv) => inv.result === 'pending'))
 
 	let busy = $state(false)
+
+	// A manual run records a pending invocation and executes asynchronously, so
+	// poll the list while anything is still pending and stop once it resolves.
+	$effect(() => {
+		if (!hasPending) return
+		const t = setTimeout(() => { invalidateAll() }, 3000)
+		return () => clearTimeout(t)
+	})
 
 	async function setPaused (paused: boolean) {
 		if (busy) return
@@ -42,12 +51,9 @@
 				modal.error({ error: resp.error })
 				return
 			}
-			const inv = resp.result
-			if (inv?.result === 'success') {
-				modal.success({ content: `Ran "${job.name}" — HTTP ${inv.httpStatus} in ${inv.latencyMs} ms` })
-			} else {
-				modal.error({ error: `Run failed: ${inv?.error || `HTTP ${inv?.httpStatus ?? ''}`}` })
-			}
+			// The run executes asynchronously — trigger only records a pending
+			// invocation. Reload the log so it shows up; the poll above refreshes it
+			// until it resolves to success/failed.
 			await invalidateAll()
 		} finally {
 			busy = false
@@ -190,14 +196,16 @@
 						<tr>
 							<td><span title={format.datetime(inv.startedAt)}>{format.fromNow(inv.startedAt)}</span></td>
 							<td>
-								{#if inv.result === 'success'}
+								{#if inv.result === 'pending'}
+									<span class="inline-flex items-center text-content/60"><StatusIcon status="pending" />Running</span>
+								{:else if inv.result === 'success'}
 									<span class="inline-flex items-center text-positive/80"><StatusIcon status="success" />Success</span>
 								{:else}
 									<span class="inline-flex items-center text-negative/80"><StatusIcon status="error" />Failed</span>
 								{/if}
 							</td>
 							<td>{inv.httpStatus > 0 ? inv.httpStatus : '—'}</td>
-							<td class="tabular-nums">{inv.latencyMs} ms</td>
+							<td class="tabular-nums">{inv.result === 'pending' ? '—' : `${inv.latencyMs} ms`}</td>
 							<td class="wrap-anywhere text-content/70">{inv.error || ''}</td>
 						</tr>
 					{:else}

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -736,7 +736,7 @@ declare namespace Api {
     export type SchedulerInvocation = {
         id: string
         startedAt: string
-        result: 'success' | 'failed'
+        result: 'pending' | 'success' | 'failed'
         httpStatus: number
         latencyMs: number
         error: string


### PR DESCRIPTION
## What

Pairs with the apiserver change that makes `scheduler.trigger` async: it now returns a **pending** invocation and runs the job in the background instead of blocking on the request.

- **Run now** no longer waits for the outcome or pops a success/error modal. It reloads the invocation log (`invalidateAll`) so the pending run shows up immediately.
- While any invocation is `pending`, a `$effect` polls the log every 3s and stops once everything resolves (cleanup clears the timer on navigation away).
- New **pending** render: a "Running" row with the spinner `StatusIcon` and `—` for status/latency.
- `SchedulerInvocation.result` type widened to `'pending' | 'success' | 'failed'`; mock fixtures updated to exercise the pending state.

## Screenshots

Scheduler detail — invocation log with a pending "Running" row at the top:

| Light | Dark |
| --- | --- |
| ![light](https://raw.githubusercontent.com/deploys-app/console/screenshots/252-light.png) | ![dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/252-dark.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)