### PR TITLE
Surface domain certificate status

### DIFF
--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -304,6 +304,35 @@ const domains = [
 			cname: ['rcf2.deploys.app.']
 		},
 		status: 'success',
+		certStatus: 'created',
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL
+	},
+	{
+		project: 'acme',
+		location: LOCATION_ID,
+		domain: 'stuck.example.com',
+		wildcard: false,
+		verification: {
+			ownership: { type: 'TXT', name: '_deploys.stuck.example.com', value: 'verify=mock', errors: [] },
+			ssl: {
+				pending: true,
+				dcv: { name: '_acme-challenge.stuck.example.com', value: 'mock-dcv' },
+				records: [],
+				errors: []
+			},
+			dns: { verifiedAt: CREATED_AT, lastCheckedAt: CREATED_AT, errors: [] }
+		},
+		dnsConfig: {
+			ipv4: ['203.0.113.10'],
+			ipv6: ['2001:db8::10'],
+			cname: ['rcf2.deploys.app.']
+		},
+		status: 'success',
+		// DNS verified but the cert never issued — pending since long ago, so the
+		// console shows the "taking longer than expected" banner + Issuing chip.
+		certStatus: 'pendingCreate',
+		certPendingSince: CREATED_AT,
 		createdAt: CREATED_AT,
 		createdBy: USER_EMAIL
 	}
@@ -1219,7 +1248,10 @@ const handlers: Record<string, (args: any) => object> = {
 	}),
 
 	'domain.list': () => list(domains),
-	'domain.get': (args) => ok({ ...domains[0], domain: args?.domain ?? 'acme.example.com', location: args?.location ?? LOCATION_ID }),
+	'domain.get': (args) => {
+		const d = domains.find((x) => x.domain === args?.domain) ?? { ...domains[0], domain: args?.domain ?? 'acme.example.com' }
+		return ok({ ...d, location: args?.location ?? LOCATION_ID })
+	},
 	'domain.create': () => ok({}),
 	'domain.delete': () => ok({}),
 	'domain.purgeCache': () => ok({}),

--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -43,11 +43,30 @@
 	const hasSsl = $derived(sslRecords.length > 0 || !!ssl?.dcv?.name)
 	const hasAnyRecord = $derived(showConnect || hasOwnership || hasSsl)
 
+	// ─── Certificate status ───
+	// A cert normally issues in a minute or two; if it sits in pendingCreate for
+	// over an hour something is wrong (Let's Encrypt rate-limit, a CAA record, or
+	// a missing DCV CNAME) and it's heading toward the 24h reclaim — surface it.
+	const certPendingLong = $derived(
+		domain.certStatus === 'pendingCreate' &&
+		!!domain.certPendingSince &&
+		Date.now() - new Date(domain.certPendingSince).getTime() > 60 * 60 * 1000
+	)
+	const cert = $derived.by(() => {
+		switch (domain.certStatus) {
+		case 'created': return { show: true, tone: 'positive', icon: 'fa-solid fa-lock', label: 'Active' }
+		case 'pendingCreate': return { show: true, tone: certPendingLong ? 'warning' : 'info', icon: 'fa-solid fa-certificate', label: 'Issuing' }
+		case 'pendingDelete': return { show: true, tone: 'muted', icon: 'fa-solid fa-lock-open', label: 'Removing' }
+		default: return { show: false, tone: 'muted', icon: '', label: '' }
+		}
+	})
+
 	// ─── Status banner ───
 	const banner = $derived.by(() => {
 		if (domain.status === 'error') return { tone: 'negative', icon: 'fa-solid fa-circle-exclamation', title: 'DNS verification failed' }
 		if (domain.status !== 'success') return { tone: 'warning', icon: 'fa-solid fa-clock', title: domain.wildcard ? 'Waiting for ownership record' : 'Waiting for DNS' }
 		if (hasDnsErrors) return { tone: 'warning', icon: 'fa-solid fa-triangle-exclamation', title: 'DNS needs attention' }
+		if (certPendingLong) return { tone: 'warning', icon: 'fa-solid fa-certificate', title: 'Certificate is taking longer than expected' }
 		return { tone: 'positive', icon: 'fa-solid fa-circle-check', title: 'Domain is active' }
 	})
 	const showDnsMeta = $derived(domain.verification?.dns?.verifiedAt || domain.verification?.dns?.lastCheckedAt)
@@ -273,6 +292,13 @@
 		font-variant-numeric: tabular-nums;
 		font-weight: 600;
 	}
+
+	/* Certificate-status tones for the overview rail value. */
+	.stat__value.cert-positive { color: hsl(var(--hsl-positive)); }
+	.stat__value.cert-warning { color: hsl(var(--hsl-warning)); }
+	.stat__value.cert-info { color: hsl(var(--hsl-info)); }
+	.stat__value.cert-muted { color: hsl(var(--hsl-content) / 0.55); }
+	.stat__value i { font-size: 0.85em; margin-right: 0.15rem; }
 
 	.stat__unit { color: var(--rail-fg-muted); }
 
@@ -555,6 +581,12 @@
 				<span class="stat__unit">Status</span>
 				<span class="stat__value">{headerStatus}</span>
 			</span>
+			{#if cert.show}
+				<span class="stat">
+					<span class="stat__unit">Certificate</span>
+					<span class="stat__value cert-{cert.tone}"><i class={cert.icon}></i> {cert.label}</span>
+				</span>
+			{/if}
 		</div>
 	</header>
 
@@ -592,6 +624,15 @@
 						<p>
 							The domain is verified, but our latest DNS check reported problems.
 							Review the errors below and confirm your records still match.
+						</p>
+					{:else if certPendingLong}
+						<p>
+							The domain is verified, but its TLS certificate hasn't finished
+							issuing. This usually means a Let's Encrypt rate-limit, a
+							<code>CAA</code> record blocking Let's Encrypt, or a missing
+							<code>_acme-challenge</code> record — check the <strong>TLS
+							certificate</strong> records below. If it can't issue within 24 hours
+							we reclaim it and keep re-trying automatically.
 						</p>
 					{:else}
 						<p>Your domain is verified and serving traffic.</p>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -169,6 +169,8 @@ declare namespace Api {
             cname: string[]
         }
         status: 'pending' | 'success' | 'error' | 'verify'
+        certStatus: 'none' | 'pendingCreate' | 'created' | 'pendingDelete'
+        certPendingSince?: string
         createdAt: string
         createdBy: string
     }


### PR DESCRIPTION
## What

Adds TLS certificate visibility to the domain detail page — the user-facing layer of the cert-cleanup feature:

- A **"Certificate" chip** in the overview rail: **Active** (issued), **Issuing** (pendingCreate), **Removing** (pendingDelete). It turns warning-toned once a cert has been issuing too long.
- A **warning banner** when a cert has been issuing for **over an hour** ("Certificate is taking longer than expected") — explaining the likely cause (Let's Encrypt rate-limit, a `CAA` record, or a missing `_acme-challenge` CNAME) and that it's reclaimed + retried if it can't issue within 24 hours.

Reads the new `domain.certStatus` / `domain.certPendingSince`. **Absent-safe:** when the backend doesn't yet send them, the chip hides and the banner is unchanged, so the page renders exactly as today.

## Dependencies

Runtime-depends on [api#86](https://github.com/deploys-app/api/pull/86) (the fields) + [apiserver#158](https://github.com/deploys-app/apiserver/pull/158) (mints them). Independently mergeable (absent-safe); the chip/banner light up once those deploy.

## Mock / screenshots

Adds a `stuck.example.com` fixture (long-pending cert) and makes `domain.get` select by name, so both states are explorable offline (`bun dev:mock`). `bun lint` + `bun check` clean.

## Screenshots

**Stuck cert** — "Issuing" chip (warning) + "taking longer than expected" banner:

![stuck dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/253-stuck-dark.png)

**Healthy** — "Active" certificate chip:

![active dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/253-active-dark.png)

**Stuck cert (light):**

![stuck light](https://raw.githubusercontent.com/deploys-app/console/screenshots/253-stuck-light.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)