### PR TITLE
dropbox: let users pick upload TTL via dropdown

### DIFF
--- a/src/routes/(auth)/(project)/dropbox/+page.svelte
+++ b/src/routes/(auth)/(project)/dropbox/+page.svelte
@@ -3,6 +3,7 @@
 	import { onMount } from 'svelte'
 	import api from '$lib/api'
 	import * as format from '$lib/format'
+	import Select from '$lib/components/Select.svelte'
 	import type { PageData } from './$types'
 
 	const { data }: { data: PageData } = $props()
@@ -18,6 +19,18 @@
 	let justCopied = $state('')
 
 	let selectedFile = $state<File | null>(null)
+
+	// Download lifetime in days (1-7); the dropbox service defaults to 1.
+	const ttlOptions = [
+		{ value: '1', label: '1 day' },
+		{ value: '2', label: '2 days' },
+		{ value: '3', label: '3 days' },
+		{ value: '4', label: '4 days' },
+		{ value: '5', label: '5 days' },
+		{ value: '6', label: '6 days' },
+		{ value: '7', label: '7 days' }
+	]
+	let ttl = $state('1')
 
 	onMount(() => {
 		const clip = new ClipboardJS('.copy-url')
@@ -79,7 +92,7 @@
 		uploading = true
 		error = ''
 		try {
-			const resp = await fetch(`/api/dropbox?project=${project}&filename=${encodeURIComponent(file.name)}`, {
+			const resp = await fetch(`/api/dropbox?project=${project}&filename=${encodeURIComponent(file.name)}&ttl=${ttl}`, {
 				method: 'POST',
 				body: file
 			})
@@ -331,7 +344,11 @@
 			</div>
 		{/if}
 
-		<div class="flex gap-4 justify-end">
+		<div class="flex gap-4 justify-between items-end flex-wrap">
+			<div class="field mb-0 w-36">
+				<label class="label" for="dropbox-ttl">Expires after</label>
+				<Select id="dropbox-ttl" bind:value={ttl} options={ttlOptions} disabled={uploading} />
+			</div>
 			<button
 				class="button"
 				class:is-loading={uploading}

--- a/src/routes/api/dropbox/+server.ts
+++ b/src/routes/api/dropbox/+server.ts
@@ -4,6 +4,7 @@ export const POST: RequestHandler = async ({ locals, request, url }) => {
 	const token = locals.token
 	const project = url.searchParams.get('project')
 	const filename = url.searchParams.get('filename') ?? ''
+	const ttl = url.searchParams.get('ttl') ?? ''
 
 	if (!token || !project) {
 		return new Response(JSON.stringify({
@@ -26,6 +27,9 @@ export const POST: RequestHandler = async ({ locals, request, url }) => {
 	}
 	if (filename) {
 		headers['param-filename'] = filename
+	}
+	if (ttl) {
+		headers['param-ttl'] = ttl
 	}
 
 	const resp = await fetch('https://dropbox.deploys.app/', {


### PR DESCRIPTION
## What

Adds an **Expires after** dropdown to the dropbox upload form so users can choose how long an uploaded file stays downloadable (1–7 days) instead of always getting the 1-day default.

## How

- **`+page.svelte`** — new `Select` (reusing `$lib/components/Select.svelte`) bound to a `ttl` state, options 1–7 days, default `1`. The value is appended to the upload request as `&ttl=`.
- **`api/dropbox/+server.ts`** — reads the `ttl` query param and forwards it to `dropbox.deploys.app` as the `param-ttl` header, mirroring the existing `param-filename` handling.

The dropbox service already supported TTL (`param-ttl` / `ttl`, 1–7, default 1 — see `dropbox/handler.go`); this only wires the console UI and proxy. Out-of-range values clamp to 1 server-side, and the dropdown only emits valid values.

## Verification

- `bun lint` and `bun check` both pass with zero errors.
- Rendered locally with `bun dev:mock` and screenshotted (closed + open states below).

| Dropdown (collapsed) | Dropdown (open) |
| --- | --- |
| ![closed](https://raw.githubusercontent.com/deploys-app/console/screenshots/254-closed.png) | ![open](https://raw.githubusercontent.com/deploys-app/console/screenshots/254-open.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)