### PR TITLE
github workflow: use EnvVarEditor for env input

### DIFF
--- a/src/lib/components/EnvVarEditor.svelte
+++ b/src/lib/components/EnvVarEditor.svelte
@@ -24,6 +24,14 @@
 		envText = toText(entries)
 	}
 
+	// Re-snapshot the text mirror when `entries` is replaced from outside (e.g. a
+	// parent form switching to a different record) so opening the text editor
+	// later shows current values, not stale ones. Skip while it's open so we
+	// never clobber in-progress typing.
+	$effect(() => {
+		if (!showText) envText = toText(entries)
+	})
+
 	// Parse the text editor back into rows, dropping blank lines.
 	function parseText () {
 		entries = envText

--- a/src/routes/(auth)/(project)/github/workflow/+page.svelte
+++ b/src/routes/(auth)/(project)/github/workflow/+page.svelte
@@ -3,6 +3,7 @@
 	import type { PageData } from './$types'
 	import api from '$lib/api'
 	import Select from '$lib/components/Select.svelte'
+	import EnvVarEditor from '$lib/components/EnvVarEditor.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import { denyTooltip } from '$lib/permission'
 	import { setupCopy } from '$lib/clipboard'
@@ -31,6 +32,11 @@
 			.replace(/^-+|-+$/g, '')
 	}
 
+	interface EnvVar {
+		k: string
+		v: string
+	}
+
 	interface GenState {
 		repository: string | undefined
 		location: string
@@ -43,13 +49,31 @@
 		spa: boolean
 		notFound: string
 		workingDirectory: string
-		env: string
+		env: EnvVar[]
 		envGroups: string[]
 		pullSecret: string
 		protocol: string
 		requireGoogleLogin: boolean
 		allowedEmails: string
 		allowedDomains: string
+	}
+
+	// The workflow config persists env as a newline `KEY=VALUE` string; the
+	// EnvVarEditor works in structured rows. Convert at those two boundaries,
+	// mirroring the editor's own parse so the round-trip stays consistent.
+	function parseEnv (text: string): EnvVar[] {
+		return text
+			.split('\n')
+			.filter((t) => t.length > 0)
+			.map((t) => t.split('='))
+			.map(([k, ...v]) => ({ k, v: v.join('=') }))
+	}
+
+	function envToText (entries: EnvVar[]): string {
+		return entries
+			.filter((e) => e.k.trim())
+			.map(({ k, v }) => `${k}=${v}`)
+			.join('\n')
 	}
 
 	// Default generator state for a repository with no saved config.
@@ -66,7 +90,7 @@
 			spa: false,
 			notFound: '404.html',
 			workingDirectory: '',
-			env: '',
+			env: [],
 			envGroups: [],
 			pullSecret: '',
 			protocol: 'http',
@@ -98,7 +122,7 @@
 			spa: cfg.spa ?? d.spa,
 			notFound: cfg.notFound || d.notFound,
 			workingDirectory: cfg.workingDirectory ?? d.workingDirectory,
-			env: cfg.env ?? d.env,
+			env: cfg.env != null ? parseEnv(cfg.env) : d.env,
 			envGroups: cfg.envGroups ? [...cfg.envGroups] : d.envGroups,
 			pullSecret: cfg.pullSecret ?? d.pullSecret,
 			protocol: cfg.protocol || d.protocol,
@@ -350,7 +374,10 @@
 
 		// env / envGroups are container-only — static has no pod.
 		if (gen.buildType === 'dockerfile') {
-			const envLines = gen.env.split('\n').map((l) => l.trim()).filter(Boolean)
+			const envLines = gen.env
+				.map(({ k, v }) => ({ k: k.trim(), v }))
+				.filter((e) => e.k)
+				.map((e) => `${e.k}=${e.v}`)
 			if (envLines.length) {
 				out.push('        env: |')
 				for (const l of envLines) out.push(`          ${l}`)
@@ -432,7 +459,7 @@ ${withBlock()}
 			spa: gen.spa,
 			notFound: gen.notFound,
 			workingDirectory: gen.workingDirectory,
-			env: gen.env,
+			env: envToText(gen.env),
 			envGroups: [...gen.envGroups],
 			pullSecret: gen.pullSecret,
 			requireGoogleLogin: gen.requireGoogleLogin,
@@ -617,11 +644,8 @@ ${withBlock()}
 					</div>
 
 					<div class="field">
-						<label for="gen-env">Environment variables</label>
-						<div class="textarea">
-							<textarea id="gen-env" class="font-mono" rows="4" bind:value={gen.env} placeholder="KEY=value&#10;ANOTHER=thing"></textarea>
-						</div>
-						<span class="helper">One <span class="font-mono">KEY=VALUE</span> per line.</span>
+						<span class="label">Environment variables</span>
+						<EnvVarEditor bind:entries={gen.env} />
 					</div>
 
 					<div class="field">


### PR DESCRIPTION
## What

The GitHub workflow generator's **Environment variables** input was a plain `KEY=VALUE` textarea. This swaps it for the shared `EnvVarEditor` (key/value rows + add/remove + a bulk-text toggle), so it matches the deploy form and the env-group create/edit form.

## How

- `gen.env` is now `EnvVar[]` internally. Two small converters bridge the boundaries:
  - `parseEnv` (saved config string → rows) on load,
  - `envToText` (rows → string) on save.
- The persisted `github.setWorkflowConfig` `env` value and the generated workflow YAML (`env: |` block) stay **byte-identical** — only the editing UI changed. Values containing `=` round-trip; blank-key rows are dropped.
- `EnvVarEditor` gains one small, guarded `$effect`: it re-snapshots its hidden bulk-text mirror when the bound `entries` are *replaced from outside*. This page is the first consumer to swap the whole env set in place (on repository switch, via a post-render `$effect`), so without this, opening the text editor after switching repos would show — and could write back — the previous repo's values. The effect is guarded by `!showText` so it never clobbers in-progress typing, leaving the deploy and env-group forms' behavior unchanged.

## Verification

- `bun check` — 0 errors, `bun lint` — clean.
- Rendered via `bun dev:mock` + Playwright against the `acme/web` mock fixture (saved config `NODE_ENV=production\nLOG_LEVEL=info`); confirmed the rows parse in and the YAML output is unchanged.

## Screenshots

Environment variables input — before (textarea) vs after (EnvVarEditor):

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/255-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/255-after.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)