### PR TITLE
notification channels UI

### DIFF
--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -33,5 +33,6 @@ export const projectMenu: ProjectMenuItem[] = [
 	{ id: 'registry', title: 'Registry', icon: 'fa-warehouse-full', link: '/registry' },
 	{ id: 'github', title: 'GitHub', icon: 'fa-code-branch', link: '/github', preview: true },
 	{ id: 'scheduler', title: 'Scheduler', icon: 'fa-clock', link: '/scheduler', preview: true },
+	{ id: 'notification', title: 'Notifications', icon: 'fa-bell', link: '/notification', preview: true },
 	{ id: 'audit-log', title: 'Audit Logs', icon: 'fa-clipboard-list', link: '/audit-log' }
 ]

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -717,6 +717,38 @@ const schedulerInvocations = [
 	{ id: '1', startedAt: CREATED_AT, result: 'failed', httpStatus: 500, latencyMs: 88, error: 'unexpected status 500' }
 ]
 
+const notificationChannels = [
+	{
+		project: 'acme',
+		name: 'ops-webhook',
+		config: { type: 'webhook', url: 'https://hooks.example.com/deploys', insecureSkipVerify: false },
+		subscription: { resourceTypes: ['deployment'], actions: ['deploy', 'delete'], outcomes: [] },
+		disabled: false,
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL,
+		updatedAt: CREATED_AT,
+		updatedBy: USER_EMAIL
+	},
+	{
+		project: 'acme',
+		name: 'team-discord',
+		config: { type: 'discord', url: 'https://discord.com/api/webhooks/123/abc', insecureSkipVerify: false },
+		subscription: { resourceTypes: [], actions: [], outcomes: ['failure'] },
+		disabled: true,
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL,
+		updatedAt: CREATED_AT,
+		updatedBy: USER_EMAIL
+	}
+]
+
+const notificationDeliveries = [
+	{ id: '4', startedAt: CREATED_AT, result: 'success', httpStatus: 200, latencyMs: 84, error: '' },
+	{ id: '3', startedAt: CREATED_AT, result: 'retry', httpStatus: 503, latencyMs: 120, error: 'unexpected status 503' },
+	{ id: '2', startedAt: CREATED_AT, result: 'success', httpStatus: 204, latencyMs: 61, error: '' },
+	{ id: '1', startedAt: CREATED_AT, result: 'failed', httpStatus: 0, latencyMs: 30002, error: 'context deadline exceeded' }
+]
+
 const roles = [
 	{
 		role: 'viewer',
@@ -1378,6 +1410,14 @@ const handlers: Record<string, (args: any) => object> = {
 	'scheduler.resume': () => ok({}),
 	'scheduler.trigger': () => ok({ id: '99', startedAt: CREATED_AT, result: 'pending', httpStatus: 0, latencyMs: 0, error: '' }),
 	'scheduler.logs': () => list(schedulerInvocations),
+
+	'notification.list': () => list(notificationChannels),
+	'notification.get': (args) => ok(notificationChannels.find((c) => c.name === args?.name) ?? { ...notificationChannels[0], name: args?.name ?? 'ops-webhook' }),
+	'notification.create': () => ok({}),
+	'notification.update': () => ok({}),
+	'notification.delete': () => ok({}),
+	'notification.test': () => ok({ id: '', startedAt: CREATED_AT, result: 'success', httpStatus: 200, latencyMs: 73, error: '' }),
+	'notification.deliveries': () => list(notificationDeliveries),
 
 	'email.list': () => list([{ domain: 'mail.acme.example.com', createdAt: CREATED_AT }]),
 

--- a/src/routes/(auth)/(project)/notification/+layout.ts
+++ b/src/routes/(auth)/(project)/notification/+layout.ts
@@ -1,0 +1,8 @@
+import type { LayoutLoad } from './$types'
+
+export const load: LayoutLoad = () => {
+	return {
+		menu: 'notification',
+		overrideRedirect: '/notification'
+	}
+}

--- a/src/routes/(auth)/(project)/notification/+page.svelte
+++ b/src/routes/(auth)/(project)/notification/+page.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import type { PageData } from './$types'
+	import ListTable from '$lib/components/ListTable.svelte'
+	import { denyTooltip, getPermissionContext } from '$lib/permission'
+
+	const { can } = getPermissionContext()
+
+	const { data }: { data: PageData } = $props()
+
+	const project = $derived(data.project)
+	const channels = $derived(data.channels)
+	const error = $derived(data.error)
+</script>
+
+<ListTable
+	title="Notifications"
+	items={channels}
+	{error}
+	noun="notification channel"
+	createPermission="notification.create"
+	createHref="/notification/create?project={project}"
+	createLabel="Create channel"
+	columns={['Name', 'Type', 'Target', 'Status']}
+	actions
+	key={(it) => it.name}>
+	{#snippet row(it)}
+		<td>
+			<a class="link cell-name" href="/notification/detail?project={project}&name={it.name}">
+				{it.name}
+			</a>
+		</td>
+		<td><span class="type-badge" data-type={it.config.type}>{it.config.type}</span></td>
+		<td><span class="font-mono text-sm text-content/70 wrap-anywhere">{it.config.url}</span></td>
+		<td>
+			{#if it.disabled}
+				<span class="inline-flex items-center gap-2 text-content/60"><i class="fa-solid fa-ban"></i> Disabled</span>
+			{:else}
+				<span class="inline-flex items-center gap-2 text-positive/80"><i class="fa-solid fa-circle text-[0.5rem]"></i> Enabled</span>
+			{/if}
+		</td>
+		<td>
+			<span class="inline-flex" title={can('notification.update') ? null : denyTooltip('notification.update')}>
+				<a
+					href={can('notification.update') ? `/notification/detail?project=${project}&name=${it.name}` : null}
+					aria-label="Edit"
+					aria-disabled={can('notification.update') ? null : 'true'}>
+					<div class="icon-button">
+						<i class="fa-solid fa-pen"></i>
+					</div>
+				</a>
+			</span>
+		</td>
+	{/snippet}
+</ListTable>
+
+<style>
+	.type-badge {
+		display: inline-flex;
+		padding: 0.0625rem 0.5rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.75);
+		background-color: hsl(var(--hsl-content) / 0.08);
+	}
+
+	.type-badge[data-type='webhook'] {
+		color: hsl(var(--hsl-primary));
+		background-color: hsl(var(--hsl-primary) / 0.12);
+	}
+
+	.type-badge[data-type='discord'] {
+		color: hsl(var(--hsl-accent, var(--hsl-primary)));
+		background-color: hsl(var(--hsl-accent, var(--hsl-primary)) / 0.12);
+	}
+</style>

--- a/src/routes/(auth)/(project)/notification/+page.ts
+++ b/src/routes/(auth)/(project)/notification/+page.ts
@@ -1,0 +1,3 @@
+import { listLoad } from '$lib/loaders'
+
+export const load = listLoad<Api.NotificationItem, 'channels'>('notification.list', 'channels')

--- a/src/routes/(auth)/(project)/notification/create/+page.svelte
+++ b/src/routes/(auth)/(project)/notification/create/+page.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+	import { untrack } from 'svelte'
+	import { goto } from '$app/navigation'
+	import type { PageData } from './$types'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
+	import TagInput from '$lib/components/TagInput.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+
+	const { data }: { data: PageData } = $props()
+
+	const project = $derived(data.project)
+	const channel = $derived(data.channel)
+	const isEdit = $derived(!!data.channel)
+
+	const typeOptions = [
+		{ value: 'webhook', label: 'Webhook' },
+		{ value: 'discord', label: 'Discord' }
+	]
+
+	const form = $state(untrack(() => ({
+		name: channel?.name ?? '',
+		type: (channel?.config?.type ?? 'webhook') as string,
+		url: channel?.config?.url ?? '',
+		// Secret is write-only: never prefilled. On edit, leaving it blank keeps the
+		// stored one.
+		secret: '',
+		insecureSkipVerify: channel?.config?.insecureSkipVerify ?? false,
+		resourceTypes: channel?.subscription?.resourceTypes ?? [],
+		actions: channel?.subscription?.actions ?? [],
+		outcomes: channel?.subscription?.outcomes ?? [],
+		disabled: channel?.disabled ?? false
+	})))
+
+	// A webhook needs a signing secret. It is required when creating, or when an
+	// edit switches a non-webhook channel to webhook — the stored secret (if any)
+	// belonged to the old type, so a fresh one is needed.
+	const originalType = $derived(channel?.config?.type ?? 'webhook')
+	const secretRequired = $derived(form.type === 'webhook' && (!isEdit || originalType !== 'webhook'))
+
+	let saving = $state(false)
+
+	async function save (e: SubmitEvent) {
+		e.preventDefault()
+		if (saving) return
+
+		const config: Api.NotificationConfig = {
+			type: form.type as Api.NotificationConfig['type'],
+			url: form.url,
+			insecureSkipVerify: form.insecureSkipVerify
+		}
+		// Webhook signing secret is write-only — send only when entered (on edit an
+		// empty value keeps the stored one). Discord carries no secret.
+		if (form.type === 'webhook' && form.secret) config.secret = form.secret
+
+		saving = true
+		try {
+			const fn = isEdit ? 'notification.update' : 'notification.create'
+			const args: Record<string, unknown> = {
+				project,
+				name: form.name,
+				config,
+				subscription: {
+					resourceTypes: form.resourceTypes,
+					actions: form.actions,
+					outcomes: form.outcomes
+				},
+				disabled: form.disabled
+			}
+
+			const resp = await api.invoke(fn, args, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+			await goto(`/notification/detail?project=${project}&name=${encodeURIComponent(form.name)}`)
+		} finally {
+			saving = false
+		}
+	}
+
+	function cancel () {
+		goto(`/notification?project=${project}`)
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/notification?project=${project}`} class="link"><h6>Notifications</h6></a>
+	</div>
+	{#if isEdit && channel}
+		<div class="breadcrumb-item">
+			<a href={`/notification/detail?project=${project}&name=${encodeURIComponent(channel.name)}`} class="link"><h6>{channel.name}</h6></a>
+		</div>
+		<div class="breadcrumb-item"><h6>Edit</h6></div>
+	{:else}
+		<div class="breadcrumb-item"><h6>Create</h6></div>
+	{/if}
+</div>
+
+<br>
+
+<div class="page-head">
+	<div>
+		<h4><strong>{isEdit ? 'Edit notification channel' : 'Create notification channel'}</strong></h4>
+		<p class="page-sub">Deliver a notification whenever a matching change happens in this project.</p>
+	</div>
+</div>
+
+<div class="panel is-level-300 grid gap-4">
+	<form class="grid gap-4 w-full" onsubmit={save}>
+		<div class="field">
+			<label for="input-name">Name</label>
+			<div class="input">
+				<input id="input-name" placeholder="ops-webhook" bind:value={form.name} required readonly={isEdit}>
+			</div>
+		</div>
+
+		<br>
+		<hr>
+		<br>
+
+		<h6><strong>Channel</strong></h6>
+
+		<div class="grid gap-4 sm:grid-cols-[10rem_1fr]">
+			<div class="field">
+				<label for="input-type">Type</label>
+				<Select id="input-type" bind:value={form.type} options={typeOptions} />
+			</div>
+			<div class="field">
+				<label for="input-url">URL</label>
+				<div class="input">
+					<input id="input-url" type="url" placeholder="https://example.com/webhook" bind:value={form.url} required>
+				</div>
+				{#if form.type === 'discord'}
+					<p class="text-content/50 text-sm mt-1">The Discord channel's incoming webhook URL.</p>
+				{/if}
+			</div>
+		</div>
+
+		{#if form.type === 'webhook'}
+			<div class="field">
+				<label for="input-secret">Signing secret</label>
+				<div class="input">
+					<input id="input-secret" type="password" bind:value={form.secret}
+						placeholder={isEdit && !secretRequired ? 'Unchanged' : ''} autocomplete="off" required={secretRequired}>
+				</div>
+				<p class="text-content/50 text-sm mt-1">
+					Deliveries are signed <code>X-Deploys-Signature: sha256=&lt;hmac&gt;</code> with this secret so your endpoint can verify them.
+				</p>
+			</div>
+		{/if}
+
+		<br>
+		<hr>
+		<br>
+
+		<div>
+			<h6><strong>Subscription</strong></h6>
+			<p class="text-content/50 text-sm mt-1">Which changes this channel receives. Leave an axis empty to match all.</p>
+		</div>
+
+		<div class="field">
+			<label for="input-resourceTypes">Resource types</label>
+			<TagInput id="input-resourceTypes" bind:tags={form.resourceTypes} placeholder="deployment, route, domain …" />
+		</div>
+		<div class="field">
+			<label for="input-actions">Actions</label>
+			<TagInput id="input-actions" bind:tags={form.actions} placeholder="create, update, delete, deploy …" />
+		</div>
+		<div class="field">
+			<label for="input-outcomes">Outcomes</label>
+			<TagInput id="input-outcomes" bind:tags={form.outcomes} placeholder="success, failure" />
+		</div>
+
+		<br>
+		<hr>
+		<br>
+
+		{#if form.type === 'webhook'}
+			<label class="checkbox">
+				<input type="checkbox" bind:checked={form.insecureSkipVerify}>
+				Skip TLS verification for HTTPS targets (self-signed certificates)
+			</label>
+		{/if}
+
+		<label class="checkbox">
+			<input type="checkbox" bind:checked={form.disabled}>
+			Disabled (do not deliver until re-enabled)
+		</label>
+
+		<hr>
+
+		<div class="flex gap-3">
+			<GuardedButton permission={isEdit ? 'notification.update' : 'notification.create'} type="submit" loading={saving}>
+				{isEdit ? 'Save' : 'Create'}
+			</GuardedButton>
+			<button type="button" class="button is-variant-secondary" onclick={cancel}>Cancel</button>
+		</div>
+	</form>
+</div>

--- a/src/routes/(auth)/(project)/notification/create/+page.ts
+++ b/src/routes/(auth)/(project)/notification/create/+page.ts
@@ -1,0 +1,24 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async ({ url, parent, fetch }) => {
+	const { project } = await parent()
+	const name = url.searchParams.get('name')
+
+	let channel: Api.NotificationItem | null = null
+	if (name) {
+		const res = await api.invoke<Api.NotificationItem>('notification.get', { project, name }, fetch)
+		if (!res.ok) {
+			if (res.error?.notFound) redirect(302, `/notification?project=${project}`)
+			error(500, res.error?.message)
+		}
+		if (!res.result) redirect(302, `/notification?project=${project}`)
+		channel = res.result
+	}
+
+	return {
+		menu: 'notification',
+		channel
+	}
+}

--- a/src/routes/(auth)/(project)/notification/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/notification/detail/+page.svelte
@@ -1,0 +1,244 @@
+<script lang="ts">
+	import { goto } from '$app/navigation'
+	import type { PageData } from './$types'
+	import * as format from '$lib/format'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import DangerZone from '$lib/components/DangerZone.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+
+	const { data }: { data: PageData } = $props()
+
+	const project = $derived(data.project)
+	const channel = $derived(data.channel)
+	const deliveries = $derived(data.deliveries)
+
+	const sub = $derived(channel.subscription)
+	const noFilter = $derived(!sub.resourceTypes.length && !sub.actions.length && !sub.outcomes.length)
+
+	let busy = $state(false)
+	let testResult = $state<Api.NotificationDelivery | null>(null)
+
+	async function sendTest () {
+		if (busy) return
+		busy = true
+		testResult = null
+		try {
+			const resp = await api.invoke<Api.NotificationDelivery>('notification.test', { project, name: channel.name }, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+			testResult = resp.result ?? null
+		} finally {
+			busy = false
+		}
+	}
+
+	function deleteItem () {
+		modal.confirm({
+			title: `Delete "${channel.name}"?`,
+			yes: 'Delete',
+			callback: async () => {
+				const resp = await api.invoke('notification.delete', { project, name: channel.name }, fetch)
+				if (!resp.ok) {
+					modal.error({ error: resp.error })
+					return
+				}
+				await goto(`/notification?project=${project}`)
+			}
+		})
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/notification?project=${project}`} class="link"><h6>Notifications</h6></a>
+	</div>
+	<div class="breadcrumb-item min-w-0">
+		<h6 class="min-w-0 wrap-anywhere">{channel.name}</h6>
+	</div>
+</div>
+
+<br>
+
+<div class="page-head">
+	<div class="min-w-0">
+		<h4 class="min-w-0 wrap-anywhere"><strong>{channel.name}</strong></h4>
+		<p class="page-sub">
+			<span class="type-badge" data-type={channel.config.type}>{channel.config.type}</span>
+			{#if channel.disabled}
+				<span class="text-content/60 ml-2"><i class="fa-solid fa-ban"></i> Disabled</span>
+			{:else}
+				<span class="text-positive/80 ml-2"><i class="fa-solid fa-circle text-[0.5rem]"></i> Enabled</span>
+			{/if}
+		</p>
+	</div>
+	<div class="flex gap-3 flex-wrap">
+		<GuardedButton permission="notification.test" class="button is-variant-secondary is-icon-left" type="button"
+			loading={busy} onclick={sendTest}>
+			<i class="fa-solid fa-paper-plane"></i>
+			Send test
+		</GuardedButton>
+		<GuardedButton permission="notification.update" class="button is-variant-secondary is-icon-left"
+			href={`/notification/create?project=${project}&name=${encodeURIComponent(channel.name)}`}>
+			<i class="fa-solid fa-pen"></i>
+			Edit
+		</GuardedButton>
+	</div>
+</div>
+
+{#if testResult}
+	<div class="test-result" class:is-ok={testResult.result === 'success'} class:is-fail={testResult.result !== 'success'}>
+		{#if testResult.result === 'success'}
+			<i class="fa-solid fa-circle-check"></i>
+			<span>Test delivered — HTTP {testResult.httpStatus}, {testResult.latencyMs} ms.</span>
+		{:else}
+			<i class="fa-solid fa-circle-xmark"></i>
+			<span>Test failed{testResult.httpStatus > 0 ? ` — HTTP ${testResult.httpStatus}` : ''}{testResult.error ? `: ${testResult.error}` : ''}.</span>
+		{/if}
+	</div>
+{/if}
+
+<div class="panel is-level-300 grid gap-6">
+	<div class="grid gap-4 w-full">
+		<div class="grid gap-4 sm:grid-cols-[10rem_1fr]">
+			<div class="field">
+				<label for="d-type">Type</label>
+				<div class="input"><input id="d-type" value={channel.config.type} readonly disabled></div>
+			</div>
+			<div class="field">
+				<label for="d-url">URL</label>
+				<div class="input"><input id="d-url" value={channel.config.url} readonly disabled></div>
+			</div>
+		</div>
+
+		{#if channel.config.type === 'webhook'}
+			<div class="field">
+				<label for="d-tls">TLS verification</label>
+				<div class="input"><input id="d-tls" value={channel.config.insecureSkipVerify ? 'Disabled (insecure)' : 'Enabled'} readonly disabled></div>
+			</div>
+		{/if}
+
+		<div class="field">
+			<span class="label">Subscription</span>
+			{#if noFilter}
+				<p class="text-content/70">All changes (no filter).</p>
+			{:else}
+				<div class="grid gap-2">
+					<div class="sub-row"><span class="sub-key">Resource types</span><span class="sub-val">{sub.resourceTypes.length ? sub.resourceTypes.join(', ') : 'Any'}</span></div>
+					<div class="sub-row"><span class="sub-key">Actions</span><span class="sub-val">{sub.actions.length ? sub.actions.join(', ') : 'Any'}</span></div>
+					<div class="sub-row"><span class="sub-key">Outcomes</span><span class="sub-val">{sub.outcomes.length ? sub.outcomes.join(', ') : 'Any'}</span></div>
+				</div>
+			{/if}
+		</div>
+
+		<hr>
+
+		<div>
+			<h6><strong>Delivery log</strong></h6>
+			<p class="text-content/50 text-sm mt-1">The most recent change deliveries for this project.</p>
+		</div>
+
+		<div class="table-container">
+			<table class="table is-variant-compact">
+				<thead>
+					<tr>
+						<th>Time</th>
+						<th>Result</th>
+						<th>Status</th>
+						<th>Latency</th>
+						<th>Error</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each deliveries as d (d.id)}
+						<tr>
+							<td><span title={format.datetime(d.startedAt)}>{format.fromNow(d.startedAt)}</span></td>
+							<td>
+								{#if d.result === 'success'}
+									<span class="inline-flex items-center gap-2 text-positive/80"><i class="fa-solid fa-circle-check"></i> Success</span>
+								{:else if d.result === 'retry'}
+									<span class="inline-flex items-center gap-2 text-warning/80"><i class="fa-solid fa-rotate"></i> Retry</span>
+								{:else if d.result === 'pending'}
+									<span class="inline-flex items-center gap-2 text-content/60"><i class="fa-solid fa-clock"></i> Pending</span>
+								{:else}
+									<span class="inline-flex items-center gap-2 text-negative/80"><i class="fa-solid fa-circle-xmark"></i> Failed</span>
+								{/if}
+							</td>
+							<td>{d.httpStatus > 0 ? d.httpStatus : '—'}</td>
+							<td class="tabular-nums">{d.result === 'pending' ? '—' : `${d.latencyMs} ms`}</td>
+							<td class="wrap-anywhere text-content/70">{d.error || ''}</td>
+						</tr>
+					{:else}
+						<tr><td colspan="5" class="text-center text-content/50">No deliveries yet.</td></tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+
+		<DangerZone description="Permanently delete this notification channel.">
+			<GuardedButton permission="notification.delete" class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</GuardedButton>
+		</DangerZone>
+	</div>
+</div>
+
+<style>
+	.type-badge {
+		display: inline-flex;
+		padding: 0.0625rem 0.5rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.75);
+		background-color: hsl(var(--hsl-content) / 0.08);
+	}
+
+	.type-badge[data-type='webhook'] {
+		color: hsl(var(--hsl-primary));
+		background-color: hsl(var(--hsl-primary) / 0.12);
+	}
+
+	.type-badge[data-type='discord'] {
+		color: hsl(var(--hsl-accent, var(--hsl-primary)));
+		background-color: hsl(var(--hsl-accent, var(--hsl-primary)) / 0.12);
+	}
+
+	.test-result {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		margin: 1rem 0;
+		padding: 0.75rem 1rem;
+		border-radius: 0.5rem;
+		font-size: 0.875rem;
+	}
+
+	.test-result.is-ok {
+		color: hsl(var(--hsl-positive));
+		background-color: hsl(var(--hsl-positive) / 0.1);
+	}
+
+	.test-result.is-fail {
+		color: hsl(var(--hsl-negative));
+		background-color: hsl(var(--hsl-negative) / 0.1);
+	}
+
+	.sub-row {
+		display: grid;
+		grid-template-columns: 9rem 1fr;
+		gap: 0.5rem;
+		align-items: baseline;
+	}
+
+	.sub-key {
+		color: hsl(var(--hsl-content) / 0.6);
+		font-size: 0.8125rem;
+	}
+
+	.sub-val {
+		font-family: var(--ffml-mono, monospace);
+		font-size: 0.8125rem;
+		word-break: break-word;
+	}
+</style>

--- a/src/routes/(auth)/(project)/notification/detail/+page.ts
+++ b/src/routes/(auth)/(project)/notification/detail/+page.ts
@@ -1,0 +1,26 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async ({ url, parent, fetch }) => {
+	const { project } = await parent()
+	const name = url.searchParams.get('name')
+	if (!name) redirect(302, `/notification?project=${project}`)
+
+	const res = await api.invoke<Api.NotificationItem>('notification.get', { project, name }, fetch)
+	if (!res.ok) {
+		if (res.error?.notFound) redirect(302, `/notification?project=${project}`)
+		error(500, res.error?.message)
+	}
+	if (!res.result) redirect(302, `/notification?project=${project}`)
+
+	// Recent deliveries. A failure here shouldn't break the detail page, so the
+	// items default to empty.
+	const deliveries = await api.invoke<Api.NotificationDeliveriesResult>('notification.deliveries', { project, name, limit: 50 }, fetch)
+
+	return {
+		menu: 'notification',
+		channel: res.result,
+		deliveries: deliveries.result?.items ?? []
+	}
+}

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -765,6 +765,49 @@ declare namespace Api {
         items: SchedulerInvocation[]
     }
 
+    // Notification — change-notification channels (project-scoped, location-less).
+    // The webhook signing secret is write-only: never present in responses.
+    export type NotificationConfig = {
+        type: 'webhook' | 'discord'
+        url: string
+        // accepted on create/update (webhook only), never returned by get/list.
+        secret?: string
+        insecureSkipVerify: boolean
+    }
+
+    export type NotificationSubscription = {
+        resourceTypes: string[]
+        actions: string[]
+        outcomes: string[]
+    }
+
+    export type NotificationItem = {
+        project: string
+        name: string
+        config: NotificationConfig
+        subscription: NotificationSubscription
+        disabled: boolean
+        createdAt: string
+        createdBy: string
+        updatedAt: string
+        updatedBy: string
+    }
+
+    export type NotificationDelivery = {
+        id: string
+        startedAt: string
+        result: 'pending' | 'success' | 'retry' | 'failed'
+        httpStatus: number
+        latencyMs: number
+        error: string
+    }
+
+    export type NotificationDeliveriesResult = {
+        project: string
+        name: string
+        items: NotificationDelivery[]
+    }
+
     // cache.metrics reuses WafMetricsTimeRange.
     export type CacheMetricsSeries = {
         overrideId: string


### PR DESCRIPTION
PR6 of the **notification-channels** feature — the console UI, consuming the merged `notification.*` RPCs (api#87, apiserver#159). Mirrors the scheduler pages.

## What

- **Routes** under `(auth)/(project)/notification/`: list, create/edit form, detail. Data via `listLoad` + `api.invoke('notification.*')`, permission-gated with `GuardedButton`/`can()`.
- **List** — channels table (name, type badge, target, enabled/disabled status), gated create button, edit action.
- **Create/edit** — name; type (webhook/discord); URL; **write-only signing secret** (webhook only, never prefilled — empty on edit keeps the stored one, required when switching to webhook); subscription chips for resourceTypes/actions/outcomes (empty = all) via `TagInput`; TLS-skip + disabled toggles.
- **Detail** — read-only config + subscription, a **Send test** button that delivers a synthetic change and shows the classified result inline, the recent **delivery log** (success/retry/failed/pending), and a delete danger zone.
- `nav.ts` Notifications entry (`fa-bell`, preview); `api.d.ts` types; `mock.ts` fixtures + handlers for `bun dev:mock`.

`bun check` and `bun lint` pass.

## Screenshots

**List**

![list](https://raw.githubusercontent.com/deploys-app/console/screenshots/256-list.png)

**Create / edit**

![create](https://raw.githubusercontent.com/deploys-app/console/screenshots/256-create.png)

**Detail + delivery log**

![detail](https://raw.githubusercontent.com/deploys-app/console/screenshots/256-detail.png)

**Send test result**

![test](https://raw.githubusercontent.com/deploys-app/console/screenshots/256-test.png)