### PR TITLE
Disable iOS auto-zoom on form controls

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -14,7 +14,9 @@
 	<title>Console | Deploys.app</title>
 	<link rel="icon" type="image/webp" href="/favicon.webp">
 	<link rel="icon" type="image/png" href="/favicon.png">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<!-- maximum-scale=1 stops iOS Safari from auto-zooming when a form control
+	     with a sub-16px font-size is focused. -->
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 	%sveltekit.head%
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -738,18 +738,6 @@
 		resize: vertical;
 	}
 
-	/* iOS Safari zooms the page when a focused form control has a font-size
-	 * below 16px. Bump to 16px on coarse-pointer (touch) devices to suppress
-	 * that auto-zoom, while keeping the tighter 14px on desktop. */
-	@media (pointer: coarse) {
-		.input > input,
-		.input > select,
-		.select > select,
-		.textarea > textarea {
-			font-size: 16px;
-		}
-	}
-
 	/* Readonly/disabled tint applied at the wrapper so it covers the
 	 * whole row (including the padding gap around the native control).
 	 * `:has` is well-supported across modern browsers. */

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -738,6 +738,18 @@
 		resize: vertical;
 	}
 
+	/* iOS Safari zooms the page when a focused form control has a font-size
+	 * below 16px. Bump to 16px on coarse-pointer (touch) devices to suppress
+	 * that auto-zoom, while keeping the tighter 14px on desktop. */
+	@media (pointer: coarse) {
+		.input > input,
+		.input > select,
+		.select > select,
+		.textarea > textarea {
+			font-size: 16px;
+		}
+	}
+
 	/* Readonly/disabled tint applied at the wrapper so it covers the
 	 * whole row (including the padding gap around the native control).
 	 * `:has` is well-supported across modern browsers. */


### PR DESCRIPTION
## Summary

iOS Safari auto-zooms the page whenever a focused form control (`input` / `select` / `textarea`) has a `font-size` below 16px. The console's form controls are styled at `0.875rem` (14px), so tapping into any field on an iPhone triggers an annoying zoom-in.

This disables that auto-zoom globally by adding `maximum-scale=1` to the viewport meta tag in `src/app.html`.

## Changes

- `src/app.html`: add `maximum-scale=1` to the viewport `<meta>` tag.

## Notes

- `bun lint` and `bun check` both pass with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6NLDKBPXCApA8FqaiF7M4