### PR TITLE
deployment: add Routes tab on detail page

### DIFF
--- a/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
@@ -13,10 +13,14 @@
 
 	// A Static deployment runs no pods, so it has no logs or k8s events — hide
 	// those tabs (the metrics tab stays but drops the pod-only charts).
+	// Routes only make sense for the deployment types that can be the target
+	// of a `deployment://` route — matches the filter in /route/create.
+	const canHaveRoutes = $derived(deployment.type === 'WebService' || deployment.type === 'Static')
 	const tabs = $derived([
 		{ label: 'Metrics', path: '/deployment/metrics' },
 		{ label: 'Details', path: '/deployment/detail' },
 		{ label: 'Revisions', path: '/deployment/revision' },
+		...(canHaveRoutes ? [{ label: 'Routes', path: '/deployment/routes' }] : []),
 		...(deployment.type === 'Static'
 			? []
 			: [

--- a/src/routes/(auth)/(project)/deployment/(detail)/routes/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/routes/+page.svelte
@@ -1,0 +1,377 @@
+<script lang="ts">
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import { denyTooltip, getPermissionContext } from '$lib/permission'
+	import type { PageData } from './$types'
+
+	const { can } = getPermissionContext()
+
+	const { data }: { data: PageData } = $props()
+
+	const project = $derived(data.project)
+	const deployment = $derived(data.deployment)
+	const routes = $derived(data.routes)
+	const domains = $derived(data.domains)
+	const error = $derived(data.error)
+
+	type Mode = 'create' | 'edit'
+
+	let formOpen = $state(false)
+	let formMode = $state<Mode>('create')
+	let saving = $state(false)
+
+	// editing identity — populated when opening in edit mode so we can
+	// pass the original (location, domain, path) tuple to the API even if
+	// the inputs are read-only.
+	let editingDomain = $state('')
+	let editingPath = $state('')
+
+	const form = $state({
+		domain: '', // base domain (when wildcard, the "*.example.com" parent)
+		subdomain: '', // only used when the selected base domain is wildcard
+		path: '/',
+		auth: 'none' as 'none' | 'basic' | 'forward',
+		basicAuth: { user: '', password: '' },
+		forwardAuth: { target: '', requestHeaders: '', responseHeaders: '' }
+	})
+
+	const selectedDomain = $derived(domains.find((d) => d.domain === form.domain))
+
+	function resetForm () {
+		form.domain = ''
+		form.subdomain = ''
+		form.path = '/'
+		form.auth = 'none'
+		form.basicAuth = { user: '', password: '' }
+		form.forwardAuth = { target: '', requestHeaders: '', responseHeaders: '' }
+		editingDomain = ''
+		editingPath = ''
+	}
+
+	function openCreate () {
+		resetForm()
+		formMode = 'create'
+		formOpen = true
+	}
+
+	function openEdit (r: Api.Route) {
+		resetForm()
+		formMode = 'edit'
+		// Wildcard routes serialize as `sub.parent`; the picker can't split this
+		// back into base + subdomain without help, so we just lock the field as a
+		// flat string in edit mode (identity is read-only anyway).
+		form.domain = r.domain
+		form.path = r.path
+		editingDomain = r.domain
+		editingPath = r.path
+
+		const cfg = r.config ?? {}
+		if (cfg.basicAuth) {
+			form.auth = 'basic'
+			form.basicAuth.user = cfg.basicAuth.user
+			form.basicAuth.password = cfg.basicAuth.password
+		} else if (cfg.forwardAuth) {
+			form.auth = 'forward'
+			form.forwardAuth.target = cfg.forwardAuth.target
+			form.forwardAuth.requestHeaders = (cfg.forwardAuth.authRequestHeaders ?? []).join('\n')
+			form.forwardAuth.responseHeaders = (cfg.forwardAuth.authResponseHeaders ?? []).join('\n')
+		}
+
+		formOpen = true
+	}
+
+	function closeForm () {
+		if (saving) return
+		formOpen = false
+	}
+
+	function onBackdrop (e: MouseEvent) {
+		if (e.target === e.currentTarget) closeForm()
+	}
+
+	function splitLines (s: string): string[] {
+		return s.split('\n').map((x) => x.trim()).filter((x) => x !== '')
+	}
+
+	async function save (e: SubmitEvent) {
+		e.preventDefault()
+		if (saving) return
+
+		let domain = form.domain
+		let path = form.path
+		if (formMode === 'edit') {
+			domain = editingDomain
+			path = editingPath
+		} else {
+			if (!selectedDomain) return
+			const sub = form.subdomain.trim()
+			if (selectedDomain.wildcard && sub !== '') {
+				domain = `${sub}.${domain}`
+			}
+		}
+
+		const config = {
+			basicAuth: form.auth === 'basic'
+				? { user: form.basicAuth.user, password: form.basicAuth.password }
+				: null,
+			forwardAuth: form.auth === 'forward'
+				? {
+					target: form.forwardAuth.target,
+					authRequestHeaders: splitLines(form.forwardAuth.requestHeaders),
+					authResponseHeaders: splitLines(form.forwardAuth.responseHeaders)
+				}
+				: null
+		}
+
+		saving = true
+		try {
+			// route.createV2 upserts on (location, domain, path) — same call serves
+			// create and edit.
+			const resp = await api.invoke('route.createV2', {
+				project,
+				location: deployment.location,
+				domain,
+				path,
+				target: `deployment://${deployment.name}`,
+				config
+			}, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+			await api.invalidate('route.list')
+			formOpen = false
+		} finally {
+			saving = false
+		}
+	}
+
+	function deleteRoute (r: Api.Route) {
+		modal.confirm({
+			title: `Delete route ${r.domain}${r.path} in ${r.location}?`,
+			yes: 'Delete',
+			callback: async () => {
+				const resp = await api.invoke('route.delete', {
+					project,
+					location: r.location,
+					domain: r.domain,
+					path: r.path
+				}, fetch)
+				if (!resp.ok) {
+					modal.error({ error: resp.error })
+					return
+				}
+				await api.invalidate('route.list')
+			}
+		})
+	}
+</script>
+
+<div class="page-head">
+	<div>
+		<h4><strong>Routes</strong></h4>
+		<p class="page-sub">{routes.length} {routes.length === 1 ? 'route' : 'routes'} pointing to this deployment</p>
+	</div>
+	<GuardedButton permission="route.create" class="button is-icon-left" onclick={openCreate}>
+		<i class="fa-solid fa-plus"></i>
+		Create
+	</GuardedButton>
+</div>
+
+<div class="panel is-level-300">
+	<div class="table-container">
+		<table class="table is-variant-compact">
+			<thead>
+				<tr>
+					<th>Route</th>
+					<th>Auth</th>
+					<th class="is-collapse is-align-right"></th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each routes as it (`${it.domain}${it.path}-${it.location}`)}
+					<tr>
+						<td>
+							<a class="link cell-name" href={`https://${it.domain}${it.path}`} target="_blank" rel="noreferrer">
+								https://{it.domain}{it.path}
+							</a>
+						</td>
+						<td>
+							{#if it.config?.basicAuth}
+								<span class="auth-chip"><i class="fa-solid fa-lock"></i> Basic</span>
+							{:else if it.config?.forwardAuth}
+								<span class="auth-chip"><i class="fa-solid fa-shield-halved"></i> Forward</span>
+							{:else}
+								<span class="cell-muted">Public</span>
+							{/if}
+						</td>
+						<td>
+							<div class="flex gap-1 justify-end">
+								<a class="icon-button" aria-label="Open route in new tab"
+								   href={`https://${it.domain}${it.path}`}
+								   target="_blank" rel="noreferrer">
+									<i class="fa-solid fa-arrow-up-right-from-square"></i>
+								</a>
+								<span class="inline-flex" title={can('route.create') ? null : denyTooltip('route.create')}>
+									<button class="icon-button" type="button" aria-label="Edit"
+										disabled={!can('route.create')}
+										onclick={() => openEdit(it)}>
+										<i class="fa-solid fa-pencil"></i>
+									</button>
+								</span>
+								<span class="inline-flex" title={can('route.delete') ? null : denyTooltip('route.delete')}>
+									<button class="icon-button" type="button" aria-label="Delete"
+										disabled={!can('route.delete')}
+										onclick={() => deleteRoute(it)}>
+										<i class="fa-solid fa-trash-alt"></i>
+									</button>
+								</span>
+							</div>
+						</td>
+					</tr>
+				{/each}
+				<NoDataRow span={3} list={routes} message="No routes point to this deployment" />
+				<ErrorRow span={3} {error} />
+			</tbody>
+		</table>
+	</div>
+</div>
+
+<div class="modal" onclick={onBackdrop} class:is-active={formOpen} aria-hidden={!formOpen}>
+	<div class="modal-panel">
+		<div class="modal-close" onclick={closeForm} onkeypress={closeForm} tabindex="0" role="button">✕</div>
+		<h4><strong>{formMode === 'create' ? 'Create route' : 'Edit route'}</strong></h4>
+		<p class="page-sub mt-1">
+			{formMode === 'create' ? 'Forward traffic from a domain path to' : 'Update authentication for the route on'}
+			<span class="font-mono">{deployment.name}</span>
+			in <span class="font-mono">{deployment.location}</span>.
+		</p>
+
+		<form class="grid gap-4 mt-5" onsubmit={save}>
+			{#if formMode === 'create'}
+				<div class="field">
+					<label for="rt-domain">Domain</label>
+					<Select
+						id="rt-domain"
+						bind:value={form.domain}
+						required
+						placeholder={domains.length ? 'Select Domain' : 'No verified domains in this location'}
+						disabled={domains.length === 0}
+						options={domains.map((it) => ({ value: it.domain, label: (it.wildcard ? '*.' : '') + it.domain }))} />
+				</div>
+
+				{#if selectedDomain?.wildcard}
+					<div class="field">
+						<label for="rt-subdomain">Subdomain</label>
+						<div class="input -has-icon-right">
+							<input id="rt-subdomain" bind:value={form.subdomain}>
+							<input class="icon -is-right px-2 w-auto" value={`.${form.domain}`} size={form.domain.length} readonly disabled>
+						</div>
+					</div>
+				{/if}
+
+				<div class="field">
+					<label for="rt-path">Path</label>
+					<div class="input">
+						<input id="rt-path" bind:value={form.path}>
+					</div>
+				</div>
+			{:else}
+				<div class="field">
+					<label for="rt-domain-ro">Domain</label>
+					<div class="input">
+						<input id="rt-domain-ro" class="font-mono" value={editingDomain} readonly>
+					</div>
+				</div>
+				<div class="field">
+					<label for="rt-path-ro">Path</label>
+					<div class="input">
+						<input id="rt-path-ro" class="font-mono" value={editingPath} readonly>
+					</div>
+				</div>
+			{/if}
+
+			<div class="field">
+				<label for="rt-auth">Protect with</label>
+				<Select
+					id="rt-auth"
+					bind:value={form.auth}
+					placeholder="Select"
+					options={[
+						{ value: 'none', label: 'None' },
+						{ value: 'basic', label: 'Basic Auth' },
+						{ value: 'forward', label: 'Forward Auth' }
+					]} />
+			</div>
+
+			{#if form.auth === 'basic'}
+				<div class="field">
+					<label for="rt-basic-user">User</label>
+					<div class="input">
+						<input id="rt-basic-user" bind:value={form.basicAuth.user} required>
+					</div>
+				</div>
+				<div class="field">
+					<label for="rt-basic-password">Password</label>
+					<div class="input">
+						<input id="rt-basic-password" type="password" bind:value={form.basicAuth.password} required>
+					</div>
+				</div>
+			{:else if form.auth === 'forward'}
+				<div class="field">
+					<label for="rt-fwd-target">Target</label>
+					<div class="input">
+						<input id="rt-fwd-target" bind:value={form.forwardAuth.target} placeholder="https://auth.example.com/verify" required>
+					</div>
+				</div>
+				<div class="field">
+					<label for="rt-fwd-req">Request headers</label>
+					<div class="textarea">
+						<textarea id="rt-fwd-req" rows="3"
+							bind:value={form.forwardAuth.requestHeaders}
+							placeholder="One header name per line"></textarea>
+					</div>
+				</div>
+				<div class="field">
+					<label for="rt-fwd-res">Response headers</label>
+					<div class="textarea">
+						<textarea id="rt-fwd-res" rows="3"
+							bind:value={form.forwardAuth.responseHeaders}
+							placeholder="One header name per line"></textarea>
+					</div>
+				</div>
+			{/if}
+
+			<div class="flex gap-3 mt-2">
+				<GuardedButton permission="route.create" type="submit" loading={saving}>Save</GuardedButton>
+				<button type="button" class="button is-variant-tertiary" disabled={saving} onclick={closeForm}>Cancel</button>
+			</div>
+		</form>
+	</div>
+</div>
+
+<style>
+	.modal-panel {
+		width: 100%;
+		max-width: 36rem;
+		max-height: calc(100dvh - 3rem);
+		overflow-y: auto;
+	}
+
+	.auth-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		padding: 0.1rem 0.5rem;
+		border-radius: 999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		background: hsl(var(--hsl-warning) / 0.12);
+		color: hsl(var(--hsl-warning));
+		border: 1px solid hsl(var(--hsl-warning) / 0.3);
+	}
+</style>

--- a/src/routes/(auth)/(project)/deployment/(detail)/routes/+page.ts
+++ b/src/routes/(auth)/(project)/deployment/(detail)/routes/+page.ts
@@ -1,0 +1,24 @@
+import api from '$lib/api'
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async ({ parent, fetch }) => {
+	const { project, deployment } = await parent()
+
+	const [routesResp, domainsResp] = await Promise.all([
+		api.invoke<Api.List<Api.Route>>('route.list', { project }, fetch),
+		api.invoke<Api.List<Api.Domain>>('domain.list', { project, location: deployment.location }, fetch)
+	])
+
+	const target = `deployment://${deployment.name}`
+	const routes = (routesResp.result?.items ?? [])
+		.filter((r) => r.location === deployment.location && r.target === target)
+
+	const domains = (domainsResp.result?.items ?? [])
+		.filter((d) => d.status === 'success')
+
+	return {
+		routes,
+		domains,
+		error: routesResp.error
+	}
+}

--- a/tests/deployment-routes.spec.js
+++ b/tests/deployment-routes.spec.js
@@ -1,0 +1,371 @@
+import { test, expect, setMocks, getRequestLog } from './helpers.js'
+import {
+	defaultLocation,
+	sampleDeployment,
+	sampleDomain,
+	sampleRoute,
+	sampleStaticDeployment
+} from './fixtures/mocks.js'
+
+const detailUrl = '/deployment/detail?project=test-project&location=gke&name=web'
+const routesUrl = '/deployment/routes?project=test-project&location=gke&name=web'
+const staticRoutesUrl = '/deployment/routes?project=test-project&location=gke&name=website'
+
+/**
+ * Tests that drive clicks against this page must wait for Svelte 5 to finish
+ * hydrating — otherwise a fast Playwright `.click()` lands before the
+ * delegated handler is wired up and silently goes nowhere.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} url
+ */
+async function gotoHydrated (page, url) {
+	await page.goto(url)
+	await page.waitForLoadState('networkidle')
+}
+
+test.describe('deployment detail — Routes tab', () => {
+	test('shows the Routes tab for a WebService deployment', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleDeployment },
+			'location.get': { ok: true, result: defaultLocation }
+		})
+
+		await gotoHydrated(page, detailUrl)
+
+		const tabs = page.locator('.tabs')
+		await expect(tabs.getByRole('link', { name: 'Routes' })).toBeVisible()
+	})
+
+	test('shows the Routes tab for a Static deployment', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleStaticDeployment },
+			'location.get': { ok: true, result: defaultLocation }
+		})
+
+		await gotoHydrated(page, '/deployment/detail?project=test-project&location=gke&name=website')
+
+		const tabs = page.locator('.tabs')
+		await expect(tabs.getByRole('link', { name: 'Routes' })).toBeVisible()
+	})
+
+	test('hides the Routes tab for a TCPService deployment', async ({ page }) => {
+		await setMocks({
+			'deployment.get': {
+				ok: true,
+				result: { ...sampleDeployment, type: 'TCPService' }
+			},
+			'location.get': { ok: true, result: defaultLocation }
+		})
+
+		await gotoHydrated(page, detailUrl)
+
+		const tabs = page.locator('.tabs')
+		await expect(tabs.getByRole('link', { name: 'Routes' })).toHaveCount(0)
+	})
+})
+
+test.describe('deployment detail — Routes tab list', () => {
+	test('lists only the routes that point to this deployment in this location', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleDeployment },
+			'location.get': { ok: true, result: defaultLocation },
+			'route.list': {
+				ok: true,
+				result: {
+					items: [
+						sampleRoute, // gke + deployment://web — matches
+						{ ...sampleRoute, domain: 'api.example.com', path: '/v1' }, // matches too
+						{ ...sampleRoute, target: 'deployment://other', domain: 'other.example.com' }, // wrong target
+						{ ...sampleRoute, location: 'sin', domain: 'sin.example.com' }, // wrong location
+						{ ...sampleRoute, target: 'redirect://https://elsewhere.test', domain: 'redir.example.com' } // wrong scheme
+					]
+				}
+			}
+		})
+
+		await gotoHydrated(page, routesUrl)
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Routes', exact: true })).toBeVisible()
+		await expect(main.getByText('2 routes pointing to this deployment')).toBeVisible()
+
+		const rows = main.locator('table tbody tr')
+		await expect(rows).toHaveCount(2)
+		await expect(main.getByText('https://example.com/', { exact: true })).toBeVisible()
+		await expect(main.getByText('https://api.example.com/v1', { exact: true })).toBeVisible()
+		await expect(main.getByText('https://other.example.com/')).toHaveCount(0)
+		await expect(main.getByText('https://sin.example.com/')).toHaveCount(0)
+		await expect(main.getByText('https://redir.example.com/')).toHaveCount(0)
+	})
+
+	test('shows the empty state when no route points to the deployment', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleDeployment },
+			'location.get': { ok: true, result: defaultLocation }
+		})
+
+		await gotoHydrated(page, routesUrl)
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('No routes point to this deployment')).toBeVisible()
+	})
+
+	test('shows the open-in-new-tab link with the live URL', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleDeployment },
+			'location.get': { ok: true, result: defaultLocation },
+			'route.list': { ok: true, result: { items: [sampleRoute] } }
+		})
+
+		await gotoHydrated(page, routesUrl)
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('link', { name: 'Open route in new tab' }))
+			.toHaveAttribute('href', 'https://example.com/')
+	})
+})
+
+test.describe('deployment detail — Routes tab create', () => {
+	test('creates a route pre-scoped to the deployment', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleDeployment },
+			'location.get': { ok: true, result: defaultLocation },
+			'domain.list': { ok: true, result: { items: [sampleDomain] } },
+			'route.createV2': { ok: true, result: {} }
+		})
+
+		await gotoHydrated(page, routesUrl)
+
+		await page.locator('.page-head').getByRole('button', { name: 'Create' }).click()
+
+		const modal = page.locator('.modal.is-active')
+		await expect(modal.getByRole('heading', { name: 'Create route' })).toBeVisible()
+		// The blurb names the target deployment + location so the user knows the
+		// route's location/target are locked.
+		await expect(modal.getByText('web')).toBeVisible()
+		await expect(modal.getByText('gke', { exact: true })).toBeVisible()
+
+		await modal.locator('#rt-domain').click()
+		await page.getByRole('option', { name: 'example.com' }).click()
+		await modal.locator('#rt-path').fill('/app')
+
+		await modal.getByRole('button', { name: 'Save' }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/route.createV2')
+		}).toBeTruthy()
+
+		const req = (await getRequestLog()).find((r) => r.path === '/route.createV2')
+		if (!req) throw new Error('expected a route.createV2 request')
+		const body = JSON.parse(req.body)
+		// Location + target are derived from the deployment, not the form.
+		expect(body).toMatchObject({
+			project: 'test-project',
+			location: 'gke',
+			domain: 'example.com',
+			path: '/app',
+			target: 'deployment://web'
+		})
+		expect(body.config.basicAuth).toBeNull()
+		expect(body.config.forwardAuth).toBeNull()
+	})
+
+	test('creates a basic-auth-protected route', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleDeployment },
+			'location.get': { ok: true, result: defaultLocation },
+			'domain.list': { ok: true, result: { items: [sampleDomain] } },
+			'route.createV2': { ok: true, result: {} }
+		})
+
+		await gotoHydrated(page, routesUrl)
+
+		await page.locator('.page-head').getByRole('button', { name: 'Create' }).click()
+
+		const modal = page.locator('.modal.is-active')
+		await modal.locator('#rt-domain').click()
+		await page.getByRole('option', { name: 'example.com' }).click()
+		await modal.locator('#rt-path').fill('/admin')
+
+		await modal.locator('#rt-auth').click()
+		await page.getByRole('option', { name: 'Basic Auth' }).click()
+		await modal.locator('#rt-basic-user').fill('admin')
+		await modal.locator('#rt-basic-password').fill('s3cret')
+
+		await modal.getByRole('button', { name: 'Save' }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/route.createV2')
+		}).toBeTruthy()
+
+		const req = (await getRequestLog()).find((r) => r.path === '/route.createV2')
+		if (!req) throw new Error('expected a route.createV2 request')
+		const body = JSON.parse(req.body)
+		expect(body.config.basicAuth).toEqual({ user: 'admin', password: 's3cret' })
+		expect(body.config.forwardAuth).toBeNull()
+	})
+
+	test('appends a subdomain when the selected domain is a wildcard', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleDeployment },
+			'location.get': { ok: true, result: defaultLocation },
+			'domain.list': {
+				ok: true,
+				result: {
+					items: [{ ...sampleDomain, domain: 'apps.example.com', wildcard: true }]
+				}
+			},
+			'route.createV2': { ok: true, result: {} }
+		})
+
+		await gotoHydrated(page, routesUrl)
+
+		await page.locator('.page-head').getByRole('button', { name: 'Create' }).click()
+
+		const modal = page.locator('.modal.is-active')
+		await modal.locator('#rt-domain').click()
+		await page.getByRole('option', { name: '*.apps.example.com' }).click()
+		await modal.locator('#rt-subdomain').fill('billing')
+		await modal.locator('#rt-path').fill('/')
+
+		await modal.getByRole('button', { name: 'Save' }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/route.createV2')
+		}).toBeTruthy()
+
+		const req = (await getRequestLog()).find((r) => r.path === '/route.createV2')
+		if (!req) throw new Error('expected a route.createV2 request')
+		const body = JSON.parse(req.body)
+		expect(body.domain).toBe('billing.apps.example.com')
+	})
+})
+
+test.describe('deployment detail — Routes tab edit', () => {
+	test('opens the edit modal with the identity locked and auth pre-filled', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleDeployment },
+			'location.get': { ok: true, result: defaultLocation },
+			'route.list': {
+				ok: true,
+				result: {
+					items: [{
+						...sampleRoute,
+						config: { basicAuth: { user: 'admin', password: 'secret' } }
+					}]
+				}
+			}
+		})
+
+		await gotoHydrated(page, routesUrl)
+
+		await page.getByRole('button', { name: 'Edit' }).click()
+
+		const modal = page.locator('.modal.is-active')
+		await expect(modal.getByRole('heading', { name: 'Edit route' })).toBeVisible()
+		// Identity fields are locked; auth state is rehydrated.
+		await expect(modal.locator('#rt-domain-ro')).toHaveValue('example.com')
+		await expect(modal.locator('#rt-domain-ro')).toHaveAttribute('readonly', '')
+		await expect(modal.locator('#rt-path-ro')).toHaveValue('/')
+		await expect(modal.locator('#rt-basic-user')).toHaveValue('admin')
+	})
+
+	test('saves an auth-config-only update against the existing identity', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleDeployment },
+			'location.get': { ok: true, result: defaultLocation },
+			'route.list': { ok: true, result: { items: [sampleRoute] } },
+			'route.createV2': { ok: true, result: {} }
+		})
+
+		await gotoHydrated(page, routesUrl)
+
+		await page.getByRole('button', { name: 'Edit' }).click()
+
+		const modal = page.locator('.modal.is-active')
+		await modal.locator('#rt-auth').click()
+		await page.getByRole('option', { name: 'Forward Auth' }).click()
+		await modal.locator('#rt-fwd-target').fill('https://auth.example.com/verify')
+		await modal.locator('#rt-fwd-req').fill('X-User')
+
+		await modal.getByRole('button', { name: 'Save' }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/route.createV2')
+		}).toBeTruthy()
+
+		const req = (await getRequestLog()).find((r) => r.path === '/route.createV2')
+		if (!req) throw new Error('expected a route.createV2 request')
+		const body = JSON.parse(req.body)
+		// The existing identity (location, domain, path, target) goes back
+		// untouched, with only the auth config changed.
+		expect(body).toMatchObject({
+			project: 'test-project',
+			location: 'gke',
+			domain: 'example.com',
+			path: '/',
+			target: 'deployment://web'
+		})
+		expect(body.config.basicAuth).toBeNull()
+		expect(body.config.forwardAuth).toEqual({
+			target: 'https://auth.example.com/verify',
+			authRequestHeaders: ['X-User'],
+			authResponseHeaders: []
+		})
+	})
+})
+
+test.describe('deployment detail — Routes tab delete', () => {
+	test('confirms then calls route.delete with the row identity', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleDeployment },
+			'location.get': { ok: true, result: defaultLocation },
+			'route.list': { ok: true, result: { items: [sampleRoute] } },
+			'route.delete': { ok: true, result: {} }
+		})
+
+		await gotoHydrated(page, routesUrl)
+
+		await page.getByRole('button', { name: 'Delete' }).click()
+		await page.locator('.swal2-confirm').click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/route.delete')
+		}).toBeTruthy()
+
+		const req = (await getRequestLog()).find((r) => r.path === '/route.delete')
+		if (!req) throw new Error('expected a route.delete request')
+		expect(JSON.parse(req.body)).toMatchObject({
+			project: 'test-project',
+			location: 'gke',
+			domain: 'example.com',
+			path: '/'
+		})
+	})
+})
+
+test.describe('deployment detail — Routes tab works for Static too', () => {
+	test('lists routes pointing to a Static deployment', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleStaticDeployment },
+			'location.get': { ok: true, result: defaultLocation },
+			'route.list': {
+				ok: true,
+				result: {
+					items: [{ ...sampleRoute, target: 'deployment://website' }]
+				}
+			}
+		})
+
+		await gotoHydrated(page, staticRoutesUrl)
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('1 route pointing to this deployment')).toBeVisible()
+		await expect(main.getByText('https://example.com/', { exact: true })).toBeVisible()
+	})
+})


### PR DESCRIPTION
## Summary

Adds a **Routes** tab to the deployment detail page so the routes pointing at the current deployment are visible (and manageable) without leaving the page.

- The tab shows up for **WebService** and **Static** deployments — the same types that can be the target of a `deployment://` route (matches the filter in `/route/create`).
- The list is `route.list` filtered client-side to `location === deployment.location && target === 'deployment://<name>'`.
- **Create** opens an inline modal pre-scoped to this deployment: the user only picks a domain, optional subdomain (for wildcard domains), path and an auth mode (None / Basic / Forward). Location + target are hard-coded.
- **Edit** opens the same modal with domain + path read-only (route identity) — useful for flipping auth on/off without trekking to `/route/edit`.
- **Delete** uses the same `modal.confirm` + `route.delete` pattern as the standalone routes page.

All three actions go through `GuardedButton` so the existing `route.create` / `route.delete` permission gates apply.

## Screenshots

Routes tab on the deployment detail page (table + actions):

![list](https://raw.githubusercontent.com/deploys-app/console/screenshots/258-list.png)

Create modal — pre-scoped to this deployment:

| ![create](https://raw.githubusercontent.com/deploys-app/console/screenshots/258-create.png) | ![create-forward](https://raw.githubusercontent.com/deploys-app/console/screenshots/258-create-forward-auth.png) |
| --- | --- |

Edit modal — identity (domain, path) locked, auth editable:

![edit](https://raw.githubusercontent.com/deploys-app/console/screenshots/258-edit.png)

## Test plan

- [x] `bun lint` — clean
- [x] `bun check` — clean
- [x] Manual: routes for a `WebService` deployment render in the new tab
- [ ] Manual: `Static` deployment — tab shows existing routes
- [ ] Manual: `TCPService` / `CronJob` / `InternalTCPService` — tab is hidden
- [x] Manual: Create modal opens with deployment pre-scoped
- [x] Manual: Forward Auth fields appear when selected
- [x] Manual: Edit modal locks domain/path
- [ ] Manual: Create → save → row appears
- [ ] Manual: Edit → toggle auth → save → chip updates
- [ ] Manual: Delete → confirm → row disappears
