### PR TITLE
registry: add Garbage collect button

### DIFF
--- a/src/lib/components/RegistryGcModal.svelte
+++ b/src/lib/components/RegistryGcModal.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import * as format from '$lib/format'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+
+	interface Props {
+		project: string
+	}
+
+	const { project }: Props = $props()
+
+	let isActive = $state(false)
+	let loading = $state(false)
+	let submitting = $state(false)
+	let result = $state<Api.RegistryGcResult | null>(null)
+
+	const nothingToCollect = $derived(
+		result !== null && result.removedManifests === 0 && result.removedTags === 0
+	)
+
+	// open runs a dry-run first so the modal previews exactly what would be
+	// removed; the actual delete only happens when the user confirms.
+	export async function open (): Promise<void> {
+		isActive = true
+		loading = true
+		result = null
+
+		const resp = await api.invoke<Api.RegistryGcResult>('registry.gc', { project, dryRun: true }, fetch)
+		loading = false
+		if (!resp.ok) {
+			isActive = false
+			modal.error({ error: resp.error })
+			return
+		}
+		result = resp.result ?? null
+	}
+
+	function close () {
+		if (submitting) return
+		isActive = false
+	}
+
+	async function collect () {
+		submitting = true
+		const resp = await api.invoke<Api.RegistryGcResult>('registry.gc', { project, dryRun: false }, fetch)
+		submitting = false
+		if (!resp.ok) {
+			modal.error({ error: resp.error })
+			return
+		}
+		isActive = false
+		await api.invalidate('registry.list')
+		modal.success({
+			content: `Removed ${resp.result?.removedManifests ?? 0} manifest(s) and ${resp.result?.removedTags ?? 0} tag(s).`
+		})
+	}
+</script>
+
+<div class="modal" onclick={close} class:is-active={isActive} aria-hidden={!isActive}>
+	<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+	<div class="modal-panel" onclick={(e) => e.stopPropagation()}>
+		<div class="modal-close" onclick={close} onkeypress={close} tabindex="0" role="button">✕</div>
+		<h4><strong>Garbage collect registry</strong></h4>
+		<p class="page-sub mt-1">
+			Removes manifests no deployment references — across the current revision and
+			all history. Recently pushed images are kept.
+		</p>
+
+		{#if loading}
+			<p class="mt-4">Calculating…</p>
+		{:else if result}
+			<div class="summary mt-4">
+				<div><strong>{format.count(result.removedManifests)}</strong> manifests</div>
+				<div><strong>{format.count(result.removedTags)}</strong> tags</div>
+				<div><strong>{format.storage(result.reclaimedSize)}</strong> reclaimable</div>
+			</div>
+
+			{#if !nothingToCollect}
+				<div class="table-container mt-4">
+					<table class="table is-variant-compact">
+						<thead>
+							<tr>
+								<th>Repository</th>
+								<th class="is-align-right">Manifests</th>
+								<th class="is-align-right">Tags</th>
+								<th class="is-align-right">Reclaimable</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each result.repositories as repo (repo.repository)}
+								<tr>
+									<td class="wrap-anywhere">{repo.repository}</td>
+									<td class="is-align-right">{format.count(repo.manifests.length)}</td>
+									<td class="is-align-right">{format.count(repo.tags.length)}</td>
+									<td class="is-align-right">{format.storage(repo.size)}</td>
+								</tr>
+							{/each}
+							<NoDataRow span={4} list={result.repositories} />
+						</tbody>
+					</table>
+				</div>
+			{:else}
+				<p class="mt-4">Nothing to collect — every image is still in use or recently pushed.</p>
+			{/if}
+
+			<div class="actions mt-6">
+				<button class="button is-variant-tertiary" onclick={close} disabled={submitting}>Cancel</button>
+				{#if !nothingToCollect}
+					<button class="button is-variant-negative" class:is-loading={submitting} onclick={collect} disabled={submitting}>
+						Garbage collect
+					</button>
+				{/if}
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.modal-panel {
+		width: 100%;
+		max-width: 48rem;
+	}
+
+	.table-container {
+		max-height: 360px;
+		overflow: auto;
+	}
+
+	.summary {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 1.5rem;
+	}
+
+	.actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 1rem;
+	}
+</style>

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -1540,7 +1540,17 @@ const handlers: Record<string, (args: any) => object> = {
 	'registry.getManifests': (args) => ok({ name: args?.repository ?? repositories[0].name, items: repositoryManifests }),
 	'registry.delete': () => ok({}),
 	'registry.deleteManifest': () => ok({}),
-	'registry.untag': () => ok({})
+	'registry.untag': () => ok({}),
+	'registry.gc': (args) => ok({
+		dryRun: !!args?.dryRun,
+		removedManifests: 3,
+		removedTags: 2,
+		reclaimedSize: 61440000,
+		repositories: [
+			{ repository: 'acme/web', manifests: ['sha256:aaaa', 'sha256:bbbb'], tags: ['old-staging'], size: 40960000 },
+			{ repository: 'acme/worker', manifests: ['sha256:cccc'], tags: ['v0.9.0'], size: 20480000 }
+		]
+	})
 }
 
 /**

--- a/src/routes/(auth)/(project)/registry/(list)/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/(list)/+page.svelte
@@ -3,6 +3,7 @@
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import RegistryGcModal from '$lib/components/RegistryGcModal.svelte'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 
@@ -11,6 +12,8 @@
 	const project = $derived(data.project)
 	const repositories = $derived(data.repositories)
 	const error = $derived(data.error)
+
+	let gcModal = $state<RegistryGcModal>()
 
 	function deleteRepository (name: string) {
 		modal.confirm({
@@ -33,11 +36,19 @@
 		<h4><strong>Registry</strong></h4>
 		<p class="page-sub">Container image registry</p>
 	</div>
-	<a class="button is-variant-secondary is-icon-left" href={`/registry/usage?project=${project}`}>
-		<i class="fa-solid fa-chart-line"></i>
-		Usage
-	</a>
+	<div class="flex gap-3">
+		<GuardedButton permission="registry.push" class="button is-variant-secondary is-icon-left" onclick={() => gcModal?.open()}>
+			<i class="fa-solid fa-broom"></i>
+			Garbage collect
+		</GuardedButton>
+		<a class="button is-variant-secondary is-icon-left" href={`/registry/usage?project=${project}`}>
+			<i class="fa-solid fa-chart-line"></i>
+			Usage
+		</a>
+	</div>
 </div>
+
+<RegistryGcModal bind:this={gcModal} {project} />
 <div class="panel is-level-300">
 	<div class="table-container">
 		<table class="table is-variant-compact">

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -494,6 +494,21 @@ declare namespace Api {
         List<RepositoryManifest>
         & { name: string }
 
+    export type RegistryGcRepository = {
+        repository: string
+        manifests: string[]
+        tags: string[]
+        size: number
+    }
+
+    export type RegistryGcResult = {
+        dryRun: boolean
+        removedManifests: number
+        removedTags: number
+        reclaimedSize: number
+        repositories: RegistryGcRepository[]
+    }
+
     export type AuditActorType = 'User' | 'ServiceAccount'
 
     export type AuditOutcome = 'success' | 'failure'


### PR DESCRIPTION
Adds a project-scoped **Garbage collect** action to the registry list page, gated by `registry.push`.

`RegistryGcModal` first calls `registry.gc` with `dryRun: true` to preview what would be removed — total manifests / tags / reclaimable size, plus a per-repository breakdown — then deletes on confirm and refreshes the repository list. Adds the `Api.RegistryGcResult` type and a `registry.gc` mock fixture.

Part of the registry.gc rollout: api#88 + apiserver#162 (both merged), plus deploys / mcp / docs.

## Screenshots

| List page (new button) | GC modal (dry-run preview) |
| --- | --- |
| ![list](https://raw.githubusercontent.com/deploys-app/console/screenshots/259-list.png) | ![modal](https://raw.githubusercontent.com/deploys-app/console/screenshots/259-modal.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)