### PR TITLE
deployment: hide Routes tab for auto-delete (TTL) deployments

### DIFF
--- a/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
@@ -15,7 +15,12 @@
 	// those tabs (the metrics tab stays but drops the pod-only charts).
 	// Routes only make sense for the deployment types that can be the target
 	// of a `deployment://` route — matches the filter in /route/create.
-	const canHaveRoutes = $derived(deployment.type === 'WebService' || deployment.type === 'Static')
+	// Auto-delete (TTL) deployments are excluded: routes cannot be set on them
+	// (the deploy form says as much), so the tab would only lead to dead ends.
+	// ttl: 0 = none, > 0 = expires after the duration, -1 = expired / pending deletion.
+	const canHaveRoutes = $derived(
+		(deployment.type === 'WebService' || deployment.type === 'Static') && deployment.ttl === 0
+	)
 	const tabs = $derived([
 		{ label: 'Metrics', path: '/deployment/metrics' },
 		{ label: 'Details', path: '/deployment/detail' },


### PR DESCRIPTION
## What

On the deployment detail page, hide the **Routes** tab when the deployment is an auto-delete (TTL) deployment.

## Why

Routes can't target an auto-delete deployment. `/route/create` already filters its deployment options to `(WebService | Static) && ttl === 0`, and the deploy form states *"Routes cannot be set on auto-delete deployments."* The Routes tab on the detail page didn't honor that, so for a TTL deployment it led to a create form the backend rejects.

This change extends `canHaveRoutes` to also require `ttl === 0`, mirroring the canonical filter in `/route/create`.

`ttl`: `0` = no auto-delete, `> 0` = expires after the duration, `-1` = expired / pending deletion. Only `ttl === 0` deployments can have routes.

## Screenshots

Tab strip — normal WebService (Routes shown) vs auto-delete deployment (Routes hidden):

| WebService (ttl 0) | Auto-delete (ttl > 0) |
| --- | --- |
| ![normal](https://raw.githubusercontent.com/deploys-app/console/screenshots/261-normal.png) | ![ttl](https://raw.githubusercontent.com/deploys-app/console/screenshots/261-ttl.png) |

## Verification

- `bun lint` — clean
- `bun check` — 0 errors
- Rendered both states in mock mode and confirmed the tab list: `web` → `Metrics, Details, Revisions, Routes, Logs, Events`; TTL deployment → `Metrics, Details, Revisions, Logs, Events`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYMGjvqWELm2ctgKamiMSS
