### PR TITLE
registry: show manifest, tag counts and size in repository table

### DIFF
--- a/src/lib/format/index.ts
+++ b/src/lib/format/index.ts
@@ -29,7 +29,7 @@ export function memory (v: string): string {
 }
 
 export function storage (v: number): string {
-	return (v / 1024 / 1024 / 1024).toLocaleString(undefined, { maximumFractionDigits: 2 }) + ' GiB'
+	return ((v ?? 0) / 1024 / 1024 / 1024).toLocaleString(undefined, { maximumFractionDigits: 2 }) + ' GiB'
 }
 
 const compactNumber = new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 })

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -902,8 +902,8 @@ const auditLogItems = (() => {
 })()
 
 const repositories = [
-	{ name: 'acme/web', size: 184320000, createdAt: CREATED_AT },
-	{ name: 'acme/worker', size: 92160000, createdAt: CREATED_AT }
+	{ name: 'acme/web', size: 184320000, manifests: 12, tags: 8, createdAt: CREATED_AT },
+	{ name: 'acme/worker', size: 92160000, manifests: 5, tags: 3, createdAt: CREATED_AT }
 ]
 
 const repositoryTags = [

--- a/src/routes/(auth)/(project)/registry/(list)/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/(list)/+page.svelte
@@ -5,6 +5,7 @@
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import RegistryGcModal from '$lib/components/RegistryGcModal.svelte'
 	import * as modal from '$lib/modal'
+	import * as format from '$lib/format'
 	import api from '$lib/api'
 
 	const { data }: { data: PageData } = $props()
@@ -55,6 +56,9 @@
 			<thead>
 				<tr>
 					<th>Repository</th>
+					<th class="is-collapse is-align-right">Manifests</th>
+					<th class="is-collapse is-align-right">Tags</th>
+					<th class="is-collapse is-align-right">Size</th>
 					<th class="is-collapse is-align-right"></th>
 				</tr>
 			</thead>
@@ -67,6 +71,9 @@
 								{repo.name}
 							</a>
 						</td>
+						<td class="is-align-right">{format.count(repo.manifests)}</td>
+						<td class="is-align-right">{format.count(repo.tags)}</td>
+						<td class="is-align-right">{format.storage(repo.size)}</td>
 						<td>
 							<GuardedButton permission="registry.push" class="icon-button" aria-label="Remove" onclick={() => deleteRepository(repo.name)}>
 								<i class="fa-solid fa-trash-alt"></i>
@@ -74,8 +81,8 @@
 						</td>
 					</tr>
 				{/each}
-				<NoDataRow span={2} list={repositories} />
-				<ErrorRow span={2} {error} />
+				<NoDataRow span={5} list={repositories} />
+				<ErrorRow span={5} {error} />
 			</tbody>
 		</table>
 	</div>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -467,6 +467,8 @@ declare namespace Api {
     export type Repository = {
         name: string
         size: number
+        manifests: number
+        tags: number
         createdAt: string
     }
 

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -353,6 +353,8 @@ export const sampleInvoice = {
 export const sampleRepository = {
 	name: 'web',
 	size: 12345678,
+	manifests: 4,
+	tags: 6,
 	createdAt: now
 }
 

--- a/tests/registry.spec.js
+++ b/tests/registry.spec.js
@@ -16,6 +16,14 @@ test.describe('registry', () => {
 		await expect(main.getByRole('heading', { name: 'Registry' })).toBeVisible()
 		await expect(main.getByRole('link', { name: 'web' })).toBeVisible()
 		await expect(main.getByRole('link', { name: 'api' })).toBeVisible()
+
+		// manifest / tag counts and size are shown per repository
+		await expect(main.getByRole('columnheader', { name: 'Manifests' })).toBeVisible()
+		await expect(main.getByRole('columnheader', { name: 'Tags' })).toBeVisible()
+		await expect(main.getByRole('columnheader', { name: 'Size' })).toBeVisible()
+		const webRow = main.getByRole('row').filter({ has: page.getByRole('link', { name: 'web', exact: true }) })
+		await expect(webRow.getByRole('cell', { name: '4', exact: true })).toBeVisible()
+		await expect(webRow.getByRole('cell', { name: '6', exact: true })).toBeVisible()
 	})
 
 	test('empty state when no repositories', async ({ page }) => {


### PR DESCRIPTION
## What

Add **Manifests**, **Tags**, and **Size** columns to the registry repository table, populated from the new `registry.list` fields.

- Counts use `format.count` (compact, e.g. `1.2K`); size uses `format.storage` (GiB), matching the repository detail header.
- Numeric columns are right-aligned and collapse to content width.
- `Api.Repository` gains `manifests` / `tags`; mock + Playwright fixtures updated; the `registry` spec asserts the new columns/values.

## Depends on

- deploys-app/api#91 (adds the fields to `RegistryListItem`)
- deploys-app/apiserver#165 (populates them in `registry.List`)

Until apiserver ships, the fields are `0` for real data; the table degrades gracefully.

## Screenshots

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/262-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/262-after.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)