### PR TITLE
format: storage() picks a binary unit by magnitude

### DIFF
--- a/src/lib/format/index.ts
+++ b/src/lib/format/index.ts
@@ -28,8 +28,14 @@ export function memory (v: string): string {
 	return `${m[1]} ${m[2]}B`
 }
 
+const storageUnits = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB']
+
 export function storage (v: number): string {
-	return ((v ?? 0) / 1024 / 1024 / 1024).toLocaleString(undefined, { maximumFractionDigits: 2 }) + ' GiB'
+	const bytes = v ?? 0
+	const a = Math.abs(bytes)
+	let i = 0
+	while (a >= 1024 ** (i + 1) && i < storageUnits.length - 1) i++
+	return (bytes / 1024 ** i).toLocaleString(undefined, { maximumFractionDigits: 2 }) + ' ' + storageUnits[i]
 }
 
 const compactNumber = new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 })

--- a/tests/registry.spec.js
+++ b/tests/registry.spec.js
@@ -57,7 +57,7 @@ test.describe('registry', () => {
 		const main = page.locator('.content-wrapper')
 		await expect(main.getByRole('columnheader', { name: 'Size' })).toBeVisible()
 		const row = main.getByRole('row').filter({ hasText: 'latest' })
-		await expect(row.getByRole('cell', { name: '0.17 GiB' })).toBeVisible()
+		await expect(row.getByRole('cell', { name: '175.78 MiB' })).toBeVisible()
 	})
 
 	test('manifests tab shows per-manifest size', async ({ page }) => {
@@ -71,6 +71,6 @@ test.describe('registry', () => {
 		await page.goto('/registry/detail/manifests?project=test-project&repository=web')
 		const main = page.locator('.content-wrapper')
 		await expect(main.getByRole('columnheader', { name: 'Size' })).toBeVisible()
-		await expect(main.getByRole('cell', { name: '0.15 GiB' })).toBeVisible()
+		await expect(main.getByRole('cell', { name: '149 MiB' })).toBeVisible()
 	})
 })


### PR DESCRIPTION
## What

`format.storage` now chooses the binary unit (B / KiB / MiB / GiB / TiB / PiB) by magnitude instead of always rendering GiB. Sizes below 1 GiB read naturally:

- `184320000` → **175.78 MiB** (was `0.17 GiB`)
- `156237824` → **149 MiB** (was `0.15 GiB`)
- `0` → **0 B**

## Why

The registry size displays (list, detail header, tags/manifests tabs) mostly show sub-GiB images, where a fractional GiB is hard to read. Per request: when size is less than 1 GiB, don't show GiB.

## Scope

`format.storage` is shared, so this also improves the registry list and detail header. Disk sizes are unaffected (they use a literal `GiB` suffix on values already denominated in GiB, not `format.storage`).

Registry Playwright assertions updated to the new strings.

## Screenshots

| Tags | Manifests |
| --- | --- |
| ![tags](https://raw.githubusercontent.com/deploys-app/console/screenshots/264-tags.png) | ![manifests](https://raw.githubusercontent.com/deploys-app/console/screenshots/264-manifests.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)