### PR TITLE
notification: hide Discord webhook secret in the channel UI

### DIFF
--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -732,7 +732,8 @@ const notificationChannels = [
 	{
 		project: 'acme',
 		name: 'team-discord',
-		config: { type: 'discord', url: 'https://discord.com/api/webhooks/123/abc', insecureSkipVerify: false },
+		// the API returns a Discord URL with its secret token redacted
+		config: { type: 'discord', url: 'https://discord.com/api/webhooks/123456789/••••••', insecureSkipVerify: false },
 		subscription: { events: [], outcomes: ['failure'] },
 		disabled: true,
 		createdAt: CREATED_AT,

--- a/src/routes/(auth)/(project)/notification/create/+page.svelte
+++ b/src/routes/(auth)/(project)/notification/create/+page.svelte
@@ -36,7 +36,10 @@
 	const form = $state(untrack(() => ({
 		name: channel?.name ?? '',
 		type: (channel?.config?.type ?? 'webhook') as string,
-		url: channel?.config?.url ?? '',
+		// A Discord URL embeds a secret token and is returned redacted, so — like
+		// the secret — it is write-only: never prefilled on edit, and leaving it
+		// blank keeps the stored URL.
+		url: channel?.config?.type === 'discord' ? '' : (channel?.config?.url ?? ''),
 		// Secret is write-only: never prefilled. On edit, leaving it blank keeps the
 		// stored one.
 		secret: '',
@@ -57,6 +60,12 @@
 	// belonged to the old type, so a fresh one is needed.
 	const originalType = $derived(channel?.config?.type ?? 'webhook')
 	const secretRequired = $derived(form.type === 'webhook' && (!isEdit || originalType !== 'webhook'))
+
+	// A Discord URL is write-only (the server returns it redacted), just like the
+	// secret: required when creating or when switching to discord, but on a
+	// discord→discord edit a blank value keeps the stored URL.
+	const urlWriteOnly = $derived(form.type === 'discord')
+	const urlRequired = $derived(form.type !== 'pull' && (!urlWriteOnly || !isEdit || originalType !== 'discord'))
 
 	let saving = $state(false)
 
@@ -170,10 +179,18 @@
 				<div class="field">
 					<label for="input-url">URL</label>
 					<div class="input">
-						<input id="input-url" type="url" placeholder="https://example.com/webhook" bind:value={form.url} required>
+						<input id="input-url" type="url"
+							placeholder={urlWriteOnly && !urlRequired ? 'Unchanged' : 'https://example.com/webhook'}
+							bind:value={form.url} required={urlRequired}>
 					</div>
 					{#if form.type === 'discord'}
-						<p class="text-content/50 text-sm mt-1">The Discord channel's incoming webhook URL.</p>
+						<p class="text-content/50 text-sm mt-1">
+							{#if urlWriteOnly && !urlRequired}
+								The Discord channel's incoming webhook URL is stored with its secret token hidden — leave blank to keep the current URL, or paste a new one to replace it.
+							{:else}
+								The Discord channel's incoming webhook URL.
+							{/if}
+						</p>
 					{/if}
 				</div>
 			{/if}


### PR DESCRIPTION
## What

The apiserver now returns a Discord webhook URL with its secret token **redacted** (`.../webhooks/{id}/••••••` — see deploys-app/apiserver#170). This PR adapts the console:

- **List + detail pages** show the masked URL as-is (no token exposed in the Target column or the detail view).
- **Edit form** treats the Discord URL as **write-only**, exactly like the signing secret: it is no longer pre-filled, the field shows an **"Unchanged"** placeholder, and a blank value keeps the stored URL (retype to replace). It stays **required** on create and when switching a channel to Discord.
- **Mock** discord fixture now carries a redacted URL so offline dev/screenshots match the API.

## Why

A Discord webhook URL embeds a secret token, so showing it verbatim on the list page leaked the credential (screenshots, shoulder-surfing, shared screens). Masking it server-side + making the field write-only mirrors how the webhook secret is already handled.

## Screenshots

**List** — Discord target masked:

![list](https://raw.githubusercontent.com/deploys-app/console/screenshots/265-list.png)

**Edit** — URL field write-only ("Unchanged", blank keeps stored):

![edit](https://raw.githubusercontent.com/deploys-app/console/screenshots/265-edit.png)

**Detail** — masked URL in the read view:

![detail](https://raw.githubusercontent.com/deploys-app/console/screenshots/265-detail.png)

## Dependencies / merge order

Behaviour depends on **deploys-app/apiserver#170** (token redaction + URL write-only on update), which in turn depends on **deploys-app/api#94**. The console change is backward-safe on its own: if the API still returned a full URL, the only visible effect would be the edit field defaulting to blank for Discord.

`bun check` and `bun lint` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)