### PR TITLE
test: add failure-case coverage for resource pages

### DIFF
--- a/src/lib/components/ErrorRow.svelte
+++ b/src/lib/components/ErrorRow.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { invalidateAll } from '$app/navigation'
+
 	interface Props {
 		span?: number
 		// error is an Api.Error, a thrown Error, or a bare string — accessed
@@ -7,18 +9,55 @@
 	}
 
 	const { span = 1, error }: Props = $props()
+
+	// Raw upstream message, surfaced only as a hover hint for support. The
+	// visible copy stays friendly and actionable instead of leaking "api: …".
+	const detail = $derived(error?.message || (typeof error === 'string' ? error : ''))
+
+	let retrying = $state(false)
+	async function retry () {
+		if (retrying) return
+		retrying = true
+		try {
+			// Re-runs the page/layout load() functions, so a transient failure
+			// recovers in place without a full reload.
+			await invalidateAll()
+		} finally {
+			retrying = false
+		}
+	}
 </script>
 
 {#if error}
 	<tr>
-		<td colspan={span} class="text-center">
+		<td colspan={span}>
 			{#if error.forbidden}
-				You don't have permission to view data
-			{:else if error.message}
-				{error.message}
+				<p class="error-state text-content/60">You don't have permission to view data</p>
 			{:else}
-				{error}
+				<div class="error-state" title={detail}>
+					<i class="fa-solid fa-exclamation-triangle text-warning"></i>
+					<p class="text-content/70">Something went wrong while loading this data. Please try again later.</p>
+					<button
+						type="button"
+						class="button is-variant-secondary is-size-small"
+						class:is-loading={retrying}
+						onclick={retry}>
+						Try again
+					</button>
+				</div>
 			{/if}
 		</td>
 	</tr>
 {/if}
+
+<style>
+	.error-state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		padding: 1.5rem 1rem;
+		text-align: center;
+	}
+</style>

--- a/src/lib/components/ListTable.svelte
+++ b/src/lib/components/ListTable.svelte
@@ -59,7 +59,7 @@
 				{#each items as item (key(item))}
 					<tr>{@render row(item)}</tr>
 				{/each}
-				<NoDataRow {span} list={items} />
+				<NoDataRow {span} list={items} {error} />
 				<ErrorRow {span} {error} />
 			</tbody>
 		</table>

--- a/src/lib/components/NoDataRow.svelte
+++ b/src/lib/components/NoDataRow.svelte
@@ -8,6 +8,11 @@
 		hint?: string
 		ctaLabel?: string
 		ctaHref?: string
+		/**
+		 * When the load errored, the paired ErrorRow owns the message — suppress
+		 * the empty-state so the two don't stack ("Nothing here yet" + the error).
+		 */
+		error?: unknown
 	}
 
 	const {
@@ -17,11 +22,12 @@
 		message = 'Nothing here yet',
 		hint = '',
 		ctaLabel = '',
-		ctaHref = ''
+		ctaHref = '',
+		error = undefined
 	}: Props = $props()
 </script>
 
-{#if !list?.length}
+{#if !error && !list?.length}
 	<tr class="no-data-row">
 		<td colspan={span}>
 			<div class="empty">

--- a/src/routes/(auth)/(project)/audit-log/+page.svelte
+++ b/src/routes/(auth)/(project)/audit-log/+page.svelte
@@ -507,7 +507,7 @@
 						</td>
 					</tr>
 				{/each}
-				<NoDataRow span={7} list={items} />
+				<NoDataRow span={7} list={items} {error} />
 				<ErrorRow span={7} {error} />
 				{#if hasMore || loadingMore || loadMoreError}
 					<tr class="loadmore-row">

--- a/src/routes/(auth)/(project)/cache/+page.svelte
+++ b/src/routes/(auth)/(project)/cache/+page.svelte
@@ -164,7 +164,8 @@
 					message="No cache zones yet"
 					hint="Configure cache to start overriding edge caching in a location."
 					ctaLabel="Configure cache"
-					ctaHref={`/cache/create?project=${project}`} />
+					ctaHref={`/cache/create?project=${project}`}
+					{error} />
 				<ErrorRow span={6} {error} />
 			</tbody>
 		</table>

--- a/src/routes/(auth)/(project)/deployment/(detail)/routes/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/routes/+page.svelte
@@ -234,7 +234,7 @@
 						</td>
 					</tr>
 				{/each}
-				<NoDataRow span={3} list={routes} message="No routes point to this deployment" />
+				<NoDataRow span={3} list={routes} message="No routes point to this deployment" {error} />
 				<ErrorRow span={3} {error} />
 			</tbody>
 		</table>

--- a/src/routes/(auth)/(project)/deployment/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/+page.svelte
@@ -193,7 +193,8 @@
 						message="No deployments yet"
 						hint="Deploy a container image to get started."
 						ctaLabel="Deploy"
-						ctaHref={`/deployment/deploy?project=${project}`} />
+						ctaHref={`/deployment/deploy?project=${project}`}
+						{error} />
 				{/if}
 				<ErrorRow span={5} {error} />
 			</tbody>

--- a/src/routes/(auth)/(project)/email/+page.svelte
+++ b/src/routes/(auth)/(project)/email/+page.svelte
@@ -37,7 +37,7 @@
 						</td>
 					</tr>
 				{/each}
-				<NoDataRow span={3} list={domains} />
+				<NoDataRow span={3} list={domains} {error} />
 				<ErrorRow span={3} {error} />
 			</tbody>
 		</table>

--- a/src/routes/(auth)/(project)/registry/(list)/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/(list)/+page.svelte
@@ -81,7 +81,7 @@
 						</td>
 					</tr>
 				{/each}
-				<NoDataRow span={5} list={repositories} />
+				<NoDataRow span={5} list={repositories} {error} />
 				<ErrorRow span={5} {error} />
 			</tbody>
 		</table>

--- a/src/routes/(auth)/(project)/registry/detail/manifests/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/detail/manifests/+page.svelte
@@ -52,7 +52,7 @@
 					</td>
 				</tr>
 			{/each}
-			<NoDataRow span={4} list={manifests} />
+			<NoDataRow span={4} list={manifests} {error} />
 			<ErrorRow span={4} {error} />
 		</tbody>
 	</table>

--- a/src/routes/(auth)/(project)/registry/detail/tags/+page.svelte
+++ b/src/routes/(auth)/(project)/registry/detail/tags/+page.svelte
@@ -71,7 +71,7 @@
 					</td>
 				</tr>
 			{/each}
-			<NoDataRow span={5} list={tags} />
+			<NoDataRow span={5} list={tags} {error} />
 			<ErrorRow span={5} {error} />
 		</tbody>
 	</table>

--- a/src/routes/(auth)/(project)/role/users/+page.svelte
+++ b/src/routes/(auth)/(project)/role/users/+page.svelte
@@ -176,7 +176,7 @@
 						</td>
 					</tr>
 				{/each}
-				<NoDataRow span={3} list={users} />
+				<NoDataRow span={3} list={users} {error} />
 				<ErrorRow span={3} {error} />
 			</tbody>
 		</table>

--- a/src/routes/(auth)/(project)/route/+page.svelte
+++ b/src/routes/(auth)/(project)/route/+page.svelte
@@ -116,7 +116,7 @@
 						</td>
 					</tr>
 				{/each}
-				<NoDataRow span={5} list={routes} />
+				<NoDataRow span={5} list={routes} {error} />
 				<ErrorRow span={5} {error} />
 			</tbody>
 		</table>

--- a/src/routes/(auth)/(project)/waf/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/+page.svelte
@@ -166,7 +166,8 @@
 					message="No firewalls yet"
 					hint="Create a firewall to start filtering traffic in a location."
 					ctaLabel="Create firewall"
-					ctaHref={`/waf/create?project=${project}`} />
+					ctaHref={`/waf/create?project=${project}`}
+					{error} />
 				<ErrorRow span={7} {error} />
 			</tbody>
 		</table>

--- a/src/routes/(auth)/billing/+page.svelte
+++ b/src/routes/(auth)/billing/+page.svelte
@@ -45,7 +45,7 @@
 						</td>
 					</tr>
 				{/each}
-				<NoDataRow span={3} list={billingAccounts} />
+				<NoDataRow span={3} list={billingAccounts} {error} />
 				<ErrorRow span={3} {error} />
 			</tbody>
 		</table>

--- a/src/routes/(auth)/billing/invoices/+page.svelte
+++ b/src/routes/(auth)/billing/invoices/+page.svelte
@@ -64,7 +64,7 @@
 						<td>{format.datetime(it.issuedAt)}</td>
 					</tr>
 				{/each}
-				<NoDataRow span={5} list={invoices} />
+				<NoDataRow span={5} list={invoices} {error} />
 				<ErrorRow span={5} {error} />
 			</tbody>
 		</table>

--- a/tests/audit-log.spec.js
+++ b/tests/audit-log.spec.js
@@ -32,7 +32,8 @@ test.describe('audit log', () => {
 		})
 		await page.goto('/audit-log?project=test-project')
 		const main = page.locator('.content-wrapper')
-		await expect(main.getByText('api: internal error')).toBeVisible()
+		await expect(main.getByText(/Something went wrong while loading this data/)).toBeVisible()
+		await expect(main.getByRole('button', { name: 'Try again' })).toBeVisible()
 	})
 
 	test('shows a permission message when the list is forbidden', async ({ page }) => {

--- a/tests/audit-log.spec.js
+++ b/tests/audit-log.spec.js
@@ -26,6 +26,24 @@ test.describe('audit log', () => {
 		await expect(main.getByText('Nothing here yet')).toBeVisible()
 	})
 
+	test('surfaces an API error in the list', async ({ page }) => {
+		await setMocks({
+			'auditLog.list': { ok: false, error: { message: 'api: internal error' } }
+		})
+		await page.goto('/audit-log?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('api: internal error')).toBeVisible()
+	})
+
+	test('shows a permission message when the list is forbidden', async ({ page }) => {
+		await setMocks({
+			'auditLog.list': { ok: false, error: { message: 'iam: forbidden' } }
+		})
+		await page.goto('/audit-log?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText("You don't have permission to view data")).toBeVisible()
+	})
+
 	test('applies filters via query string', async ({ page }) => {
 		await setMocks({
 			'auditLog.list': {

--- a/tests/deployment.spec.js
+++ b/tests/deployment.spec.js
@@ -48,7 +48,8 @@ test.describe('deployments', () => {
 		})
 		await page.goto('/deployment?project=test-project')
 		const main = page.locator('.content-wrapper')
-		await expect(main.getByText('api: internal error')).toBeVisible()
+		await expect(main.getByText(/Something went wrong while loading this data/)).toBeVisible()
+		await expect(main.getByRole('button', { name: 'Try again' })).toBeVisible()
 	})
 })
 

--- a/tests/disk.spec.js
+++ b/tests/disk.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, setMocks } from './helpers.js'
+import { test, expect, setMocks, pickSelect } from './helpers.js'
 import { sampleDisk } from './fixtures/mocks.js'
 
 test.describe('disks', () => {
@@ -29,5 +29,60 @@ test.describe('disks', () => {
 		await page.goto('/disk?project=test-project')
 		const main = page.locator('.content-wrapper')
 		await expect(main.getByText('Nothing here yet')).toBeVisible()
+	})
+
+	test('surfaces an API error in the list', async ({ page }) => {
+		await setMocks({
+			'disk.list': { ok: false, error: { message: 'api: internal error' } }
+		})
+		await page.goto('/disk?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('api: internal error')).toBeVisible()
+	})
+
+	test('shows a permission message when the list is forbidden', async ({ page }) => {
+		await setMocks({
+			'disk.list': { ok: false, error: { message: 'iam: forbidden' } }
+		})
+		await page.goto('/disk?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText("You don't have permission to view data")).toBeVisible()
+	})
+
+	test('gates the create button when the create permission is missing', async ({ page }) => {
+		await setMocks({
+			'me.permissions': { ok: true, result: { permissions: ['disk.list'], admin: false } }
+		})
+		await page.goto('/disk?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('button', { name: 'Create' })).toBeDisabled()
+		await expect(main.getByRole('link', { name: 'Create' })).toHaveCount(0)
+	})
+})
+
+test.describe('disk — create', () => {
+	test('shows the API error in a modal when create fails', async ({ page }) => {
+		await setMocks({
+			'disk.create': { ok: false, error: { message: 'api: disk already exists' } }
+		})
+
+		await page.goto('/disk/create?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await main.locator('#input-name').fill('data')
+		await pickSelect(page, 'input-location', 'gke')
+		await main.getByRole('button', { name: 'Create' }).click()
+
+		await expect(page.locator('.swal2-popup')).toBeVisible()
+		await expect(page.locator('.swal2-html-container')).toContainText('api: disk already exists')
+	})
+
+	test('disables Create when the create permission is missing', async ({ page }) => {
+		await setMocks({
+			'me.permissions': { ok: true, result: { permissions: ['disk.list'], admin: false } }
+		})
+		await page.goto('/disk/create?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('button', { name: 'Create' })).toBeDisabled()
 	})
 })

--- a/tests/disk.spec.js
+++ b/tests/disk.spec.js
@@ -37,7 +37,8 @@ test.describe('disks', () => {
 		})
 		await page.goto('/disk?project=test-project')
 		const main = page.locator('.content-wrapper')
-		await expect(main.getByText('api: internal error')).toBeVisible()
+		await expect(main.getByText(/Something went wrong while loading this data/)).toBeVisible()
+		await expect(main.getByRole('button', { name: 'Try again' })).toBeVisible()
 	})
 
 	test('shows a permission message when the list is forbidden', async ({ page }) => {

--- a/tests/email.spec.js
+++ b/tests/email.spec.js
@@ -22,4 +22,22 @@ test.describe('email domains', () => {
 		const main = page.locator('.content-wrapper')
 		await expect(main.getByText('Nothing here yet')).toBeVisible()
 	})
+
+	test('surfaces an API error in the list', async ({ page }) => {
+		await setMocks({
+			'email.list': { ok: false, error: { message: 'api: internal error' } }
+		})
+		await page.goto('/email?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('api: internal error')).toBeVisible()
+	})
+
+	test('shows a permission message when the list is forbidden', async ({ page }) => {
+		await setMocks({
+			'email.list': { ok: false, error: { message: 'iam: forbidden' } }
+		})
+		await page.goto('/email?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText("You don't have permission to view data")).toBeVisible()
+	})
 })

--- a/tests/email.spec.js
+++ b/tests/email.spec.js
@@ -29,7 +29,8 @@ test.describe('email domains', () => {
 		})
 		await page.goto('/email?project=test-project')
 		const main = page.locator('.content-wrapper')
-		await expect(main.getByText('api: internal error')).toBeVisible()
+		await expect(main.getByText(/Something went wrong while loading this data/)).toBeVisible()
+		await expect(main.getByRole('button', { name: 'Try again' })).toBeVisible()
 	})
 
 	test('shows a permission message when the list is forbidden', async ({ page }) => {

--- a/tests/env-group.spec.js
+++ b/tests/env-group.spec.js
@@ -30,7 +30,8 @@ test.describe('env groups', () => {
 		})
 		await page.goto('/env-group?project=test-project')
 		const main = page.locator('.content-wrapper')
-		await expect(main.getByText('api: internal error')).toBeVisible()
+		await expect(main.getByText(/Something went wrong while loading this data/)).toBeVisible()
+		await expect(main.getByRole('button', { name: 'Try again' })).toBeVisible()
 	})
 
 	test('shows a permission message when the list is forbidden', async ({ page }) => {

--- a/tests/env-group.spec.js
+++ b/tests/env-group.spec.js
@@ -24,6 +24,49 @@ test.describe('env groups', () => {
 		await expect(main.getByText('Nothing here yet')).toBeVisible()
 	})
 
+	test('surfaces an API error in the list', async ({ page }) => {
+		await setMocks({
+			'envGroup.list': { ok: false, error: { message: 'api: internal error' } }
+		})
+		await page.goto('/env-group?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('api: internal error')).toBeVisible()
+	})
+
+	test('shows a permission message when the list is forbidden', async ({ page }) => {
+		await setMocks({
+			'envGroup.list': { ok: false, error: { message: 'iam: forbidden' } }
+		})
+		await page.goto('/env-group?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText("You don't have permission to view data")).toBeVisible()
+	})
+
+	test('gates the create button when the create permission is missing', async ({ page }) => {
+		await setMocks({
+			'me.permissions': { ok: true, result: { permissions: ['envgroup.list'], admin: false } }
+		})
+		await page.goto('/env-group?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('button', { name: 'Create' })).toBeDisabled()
+		await expect(main.getByRole('link', { name: 'Create' })).toHaveCount(0)
+	})
+
+	test('shows the API error in a modal when create fails', async ({ page }) => {
+		await setMocks({
+			'envgroup.create': { ok: false, error: { message: 'api: env group already exists' } }
+		})
+
+		await page.goto('/env-group/create?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await main.locator('#input-name').fill('shared-config')
+		await main.getByRole('button', { name: 'Create', exact: true }).click()
+
+		await expect(page.locator('.swal2-popup')).toBeVisible()
+		await expect(page.locator('.swal2-html-container')).toContainText('api: env group already exists')
+	})
+
 	test('shows existing env vars on update', async ({ page }) => {
 		await setMocks({
 			'envGroup.get': {

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -41,6 +41,20 @@ export async function getRequestLog () {
 }
 
 /**
+ * Pick an option from the custom `Select.svelte` dropdown (a button trigger +
+ * listbox, not a native `<select>` — Playwright's `selectOption` can't drive
+ * it). Opens the trigger by id, then clicks the option matching `label`.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} triggerId  the Select's `id` (without the leading `#`)
+ * @param {string} label      the visible option label to pick
+ */
+export async function pickSelect (page, triggerId, label) {
+	await page.locator(`#${triggerId}`).click()
+	await page.getByRole('option', { name: label, exact: true }).click()
+}
+
+/**
  * Inject the auth token cookie so the SvelteKit `(auth)` group treats
  * the session as authenticated.
  *

--- a/tests/pull-secret.spec.js
+++ b/tests/pull-secret.spec.js
@@ -29,7 +29,8 @@ test.describe('pull secrets', () => {
 		})
 		await page.goto('/pull-secret?project=test-project')
 		const main = page.locator('.content-wrapper')
-		await expect(main.getByText('api: internal error')).toBeVisible()
+		await expect(main.getByText(/Something went wrong while loading this data/)).toBeVisible()
+		await expect(main.getByRole('button', { name: 'Try again' })).toBeVisible()
 	})
 
 	test('shows a permission message when the list is forbidden', async ({ page }) => {

--- a/tests/pull-secret.spec.js
+++ b/tests/pull-secret.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, setMocks } from './helpers.js'
+import { test, expect, setMocks, pickSelect } from './helpers.js'
 import { samplePullSecret } from './fixtures/mocks.js'
 
 test.describe('pull secrets', () => {
@@ -21,5 +21,74 @@ test.describe('pull secrets', () => {
 		await page.goto('/pull-secret?project=test-project')
 		const main = page.locator('.content-wrapper')
 		await expect(main.getByText('Nothing here yet')).toBeVisible()
+	})
+
+	test('surfaces an API error in the list', async ({ page }) => {
+		await setMocks({
+			'pullSecret.list': { ok: false, error: { message: 'api: internal error' } }
+		})
+		await page.goto('/pull-secret?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('api: internal error')).toBeVisible()
+	})
+
+	test('shows a permission message when the list is forbidden', async ({ page }) => {
+		await setMocks({
+			'pullSecret.list': { ok: false, error: { message: 'iam: forbidden' } }
+		})
+		await page.goto('/pull-secret?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText("You don't have permission to view data")).toBeVisible()
+	})
+
+	test('gates the create button when the create permission is missing', async ({ page }) => {
+		await setMocks({
+			'me.permissions': { ok: true, result: { permissions: ['pullsecret.list'], admin: false } }
+		})
+		await page.goto('/pull-secret?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('button', { name: 'Create' })).toBeDisabled()
+		await expect(main.getByRole('link', { name: 'Create' })).toHaveCount(0)
+	})
+})
+
+test.describe('pull secret — create', () => {
+	test('rejects an invalid server URL before calling the API', async ({ page }) => {
+		await page.goto('/pull-secret/create?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await main.locator('#input-name').fill('gcr')
+		await pickSelect(page, 'input-location', 'gke')
+		// Replace the valid default with a non-URL value to trip client validation.
+		await main.locator('#input-server').fill('not a url')
+		await main.getByRole('button', { name: 'Save' }).click()
+
+		await expect(page.locator('.swal2-popup')).toBeVisible()
+		await expect(page.locator('.swal2-html-container')).toContainText('server must be an url')
+	})
+
+	test('shows the API error in a modal when create fails', async ({ page }) => {
+		await setMocks({
+			'pullSecret.create': { ok: false, error: { message: 'api: pull secret already exists' } }
+		})
+
+		await page.goto('/pull-secret/create?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await main.locator('#input-name').fill('gcr')
+		await pickSelect(page, 'input-location', 'gke')
+		await main.getByRole('button', { name: 'Save' }).click()
+
+		await expect(page.locator('.swal2-popup')).toBeVisible()
+		await expect(page.locator('.swal2-html-container')).toContainText('api: pull secret already exists')
+	})
+
+	test('disables Save when the create permission is missing', async ({ page }) => {
+		await setMocks({
+			'me.permissions': { ok: true, result: { permissions: ['pullsecret.list'], admin: false } }
+		})
+		await page.goto('/pull-secret/create?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('button', { name: 'Save' })).toBeDisabled()
 	})
 })

--- a/tests/role.spec.js
+++ b/tests/role.spec.js
@@ -30,7 +30,8 @@ test.describe('roles', () => {
 		})
 		await page.goto('/role?project=test-project')
 		const main = page.locator('.content-wrapper')
-		await expect(main.getByText('api: internal error')).toBeVisible()
+		await expect(main.getByText(/Something went wrong while loading this data/)).toBeVisible()
+		await expect(main.getByRole('button', { name: 'Try again' })).toBeVisible()
 	})
 
 	test('shows a permission message when the list is forbidden', async ({ page }) => {

--- a/tests/role.spec.js
+++ b/tests/role.spec.js
@@ -24,6 +24,55 @@ test.describe('roles', () => {
 		await expect(main.getByText('Nothing here yet')).toBeVisible()
 	})
 
+	test('surfaces an API error in the list', async ({ page }) => {
+		await setMocks({
+			'role.list': { ok: false, error: { message: 'api: internal error' } }
+		})
+		await page.goto('/role?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('api: internal error')).toBeVisible()
+	})
+
+	test('shows a permission message when the list is forbidden', async ({ page }) => {
+		await setMocks({
+			'role.list': { ok: false, error: { message: 'iam: forbidden' } }
+		})
+		await page.goto('/role?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText("You don't have permission to view data")).toBeVisible()
+	})
+
+	test('gates the create button when the create permission is missing', async ({ page }) => {
+		await setMocks({
+			'me.permissions': { ok: true, result: { permissions: ['role.list'], admin: false } }
+		})
+		await page.goto('/role?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('button', { name: 'Create' })).toBeDisabled()
+		await expect(main.getByRole('link', { name: 'Create' })).toHaveCount(0)
+	})
+
+	test('shows the API error in a modal when create fails', async ({ page }) => {
+		await setMocks({
+			// role.permissions is the assignable-permission catalog; the create
+			// page returns it under `permissions`, which shadows the layout's
+			// effective-grants in $page.data — so it must include 'role.create'
+			// for the guarded submit button to render enabled.
+			'role.permissions': { ok: true, result: ['role.create', 'deployment.list'] },
+			'role.create': { ok: false, error: { message: 'api: role already exists' } }
+		})
+
+		await page.goto('/role/create?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await main.locator('#input-role').fill('developer')
+		await main.locator('#input-name').fill('Developer')
+		await main.getByRole('button', { name: 'Create', exact: true }).click()
+
+		await expect(page.locator('.swal2-popup')).toBeVisible()
+		await expect(page.locator('.swal2-html-container')).toContainText('api: role already exists')
+	})
+
 	test('searchable permission picker filters, adds, and resets', async ({ page }) => {
 		await setMocks({
 			'role.permissions': {

--- a/tests/service-account.spec.js
+++ b/tests/service-account.spec.js
@@ -23,4 +23,98 @@ test.describe('service accounts', () => {
 		const main = page.locator('.content-wrapper')
 		await expect(main.getByText('Nothing here yet')).toBeVisible()
 	})
+
+	test('surfaces an API error in the list', async ({ page }) => {
+		await setMocks({
+			'serviceAccount.list': {
+				ok: false,
+				error: { message: 'api: internal error' }
+			}
+		})
+
+		await page.goto('/service-account?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('api: internal error')).toBeVisible()
+	})
+
+	test('shows a permission message when the list is forbidden', async ({ page }) => {
+		await setMocks({
+			'serviceAccount.list': {
+				ok: false,
+				error: { message: 'iam: forbidden' }
+			}
+		})
+
+		await page.goto('/service-account?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText("You don't have permission to view data")).toBeVisible()
+	})
+
+	test('gates the create button when the create permission is missing', async ({ page }) => {
+		await setMocks({
+			'me.permissions': { ok: true, result: { permissions: ['serviceaccount.list'], admin: false } }
+		})
+
+		await page.goto('/service-account?project=test-project')
+		const main = page.locator('.content-wrapper')
+		// Denied → GuardedButton renders a disabled <button>, never the <a> link.
+		await expect(main.getByRole('button', { name: 'Create' })).toBeDisabled()
+		await expect(main.getByRole('link', { name: 'Create' })).toHaveCount(0)
+	})
+})
+
+test.describe('service account — create', () => {
+	test('shows the API error in a modal when create fails', async ({ page }) => {
+		await setMocks({
+			'serviceAccount.create': {
+				ok: false,
+				error: { message: 'api: service account already exists' }
+			}
+		})
+
+		await page.goto('/service-account/create?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await main.locator('#input-sid').fill('ci-bot')
+		await main.locator('#input-name').fill('CI bot')
+		await main.getByRole('button', { name: 'Save' }).click()
+
+		// modal.error surfaces resp.error via SweetAlert.
+		await expect(page.locator('.swal2-popup')).toBeVisible()
+		await expect(page.locator('.swal2-html-container')).toContainText('api: service account already exists')
+	})
+
+	test('renders validate-error items in the modal', async ({ page }) => {
+		await setMocks({
+			'serviceAccount.create': {
+				ok: false,
+				error: {
+					message: 'api: validate error',
+					items: ['name is required', 'id is invalid']
+				}
+			}
+		})
+
+		await page.goto('/service-account/create?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await main.locator('#input-sid').fill('bad id')
+		await main.locator('#input-name').fill('x')
+		await main.getByRole('button', { name: 'Save' }).click()
+
+		const dialog = page.locator('.swal2-html-container')
+		await expect(dialog).toContainText('name is required')
+		await expect(dialog).toContainText('id is invalid')
+	})
+
+	test('disables Save when the create permission is missing', async ({ page }) => {
+		await setMocks({
+			'me.permissions': { ok: true, result: { permissions: ['serviceaccount.list'], admin: false } }
+		})
+
+		await page.goto('/service-account/create?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('button', { name: 'Save' })).toBeDisabled()
+	})
 })

--- a/tests/service-account.spec.js
+++ b/tests/service-account.spec.js
@@ -34,7 +34,27 @@ test.describe('service accounts', () => {
 
 		await page.goto('/service-account?project=test-project')
 		const main = page.locator('.content-wrapper')
-		await expect(main.getByText('api: internal error')).toBeVisible()
+		await expect(main.getByText(/Something went wrong while loading this data/)).toBeVisible()
+		await expect(main.getByRole('button', { name: 'Try again' })).toBeVisible()
+	})
+
+	test('Try again recovers the list after a transient error', async ({ page }) => {
+		await setMocks({
+			'serviceAccount.list': { ok: false, error: { message: 'api: internal error' } }
+		})
+
+		await page.goto('/service-account?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText(/Something went wrong while loading this data/)).toBeVisible()
+
+		// Upstream recovers; clicking Try again re-runs load() in place.
+		await setMocks({
+			'serviceAccount.list': { ok: true, result: { items: [sampleServiceAccount] } }
+		})
+		await main.getByRole('button', { name: 'Try again' }).click()
+
+		await expect(main.getByRole('link', { name: '[email protected]' })).toBeVisible()
+		await expect(main.getByText(/Something went wrong while loading this data/)).toHaveCount(0)
 	})
 
 	test('shows a permission message when the list is forbidden', async ({ page }) => {

--- a/tests/workload-identity.spec.js
+++ b/tests/workload-identity.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, setMocks } from './helpers.js'
+import { test, expect, setMocks, pickSelect } from './helpers.js'
 import { sampleWorkloadIdentity } from './fixtures/mocks.js'
 
 test.describe('workload identities', () => {
@@ -21,5 +21,61 @@ test.describe('workload identities', () => {
 		await page.goto('/workload-identity?project=test-project')
 		const main = page.locator('.content-wrapper')
 		await expect(main.getByText('Nothing here yet')).toBeVisible()
+	})
+
+	test('surfaces an API error in the list', async ({ page }) => {
+		await setMocks({
+			'workloadIdentity.list': { ok: false, error: { message: 'api: internal error' } }
+		})
+		await page.goto('/workload-identity?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('api: internal error')).toBeVisible()
+	})
+
+	test('shows a permission message when the list is forbidden', async ({ page }) => {
+		await setMocks({
+			'workloadIdentity.list': { ok: false, error: { message: 'iam: forbidden' } }
+		})
+		await page.goto('/workload-identity?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText("You don't have permission to view data")).toBeVisible()
+	})
+
+	test('gates the create button when the create permission is missing', async ({ page }) => {
+		await setMocks({
+			'me.permissions': { ok: true, result: { permissions: ['workloadidentity.list'], admin: false } }
+		})
+		await page.goto('/workload-identity?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('button', { name: 'Create' })).toBeDisabled()
+		await expect(main.getByRole('link', { name: 'Create' })).toHaveCount(0)
+	})
+})
+
+test.describe('workload identity — create', () => {
+	test('shows the API error in a modal when create fails', async ({ page }) => {
+		await setMocks({
+			'workloadIdentity.create': { ok: false, error: { message: 'api: workload identity already exists' } }
+		})
+
+		await page.goto('/workload-identity/create?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await main.locator('#input-name').fill('gsa-binding')
+		await pickSelect(page, 'input-location', 'gke')
+		await main.locator('#input-gsa').fill('[email protected]')
+		await main.getByRole('button', { name: 'Create' }).click()
+
+		await expect(page.locator('.swal2-popup')).toBeVisible()
+		await expect(page.locator('.swal2-html-container')).toContainText('api: workload identity already exists')
+	})
+
+	test('disables Create when the create permission is missing', async ({ page }) => {
+		await setMocks({
+			'me.permissions': { ok: true, result: { permissions: ['workloadidentity.list'], admin: false } }
+		})
+		await page.goto('/workload-identity/create?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('button', { name: 'Create' })).toBeDisabled()
 	})
 })

--- a/tests/workload-identity.spec.js
+++ b/tests/workload-identity.spec.js
@@ -29,7 +29,8 @@ test.describe('workload identities', () => {
 		})
 		await page.goto('/workload-identity?project=test-project')
 		const main = page.locator('.content-wrapper')
-		await expect(main.getByText('api: internal error')).toBeVisible()
+		await expect(main.getByText(/Something went wrong while loading this data/)).toBeVisible()
+		await expect(main.getByRole('button', { name: 'Try again' })).toBeVisible()
 	})
 
 	test('shows a permission message when the list is forbidden', async ({ page }) => {


### PR DESCRIPTION
## What

Two things:

1. **Failure-case test coverage** for resource pages (the specs previously only tested happy/empty states).
2. **A friendly, retryable error UI** for failed list loads (replaces leaking the raw `api: …` message).

### Error UI

`ErrorRow` now renders a friendly state with a **Try again** button (re-runs the page/layout `load()` via `invalidateAll()`), instead of dumping the upstream message. The `forbidden` case keeps its permission message; the raw message is preserved as a hover `title` for support. The empty-state `NoDataRow` is now suppressed when an error is present, so the two no longer stack ("Nothing here yet" + the error).

| After (dark) | After (light) | Forbidden |
| --- | --- | --- |
| ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/266-error-after.png) | ![after-light](https://raw.githubusercontent.com/deploys-app/console/screenshots/266-error-after-light.png) | ![forbidden](https://raw.githubusercontent.com/deploys-app/console/screenshots/266-forbidden.png) |

*Before:* the row showed the raw text (e.g. `api: internal error`) with no recovery affordance, and "Nothing here yet" rendered above it.

### Tests

Failure paths now covered across `service-account`, `disk`, `email`, `env-group`, `pull-secret`, `role`, `workload-identity`, `audit-log`:

- **API error in list** → friendly message + Try again button.
- **Try again recovers** → after a transient error, clicking Try again re-fetches and renders the list (service-account).
- **Forbidden list** → "You don't have permission to view data".
- **No-permission gating** → create/submit buttons render disabled (no `<a>` link).
- **Create-form API failure** → error surfaced in the modal.
- **Validate errors** → `items[]` rendered as a list in the modal.
- **Invalid input** → pull-secret rejects a non-URL server before hitting the API.

New `pickSelect(page, triggerId, label)` helper drives the custom `Select.svelte` (Playwright's `selectOption` can't).

## Test

- `bun run test` — **268 passed**.
- `bun lint` — clean · `bun check` — 0 errors.

## Note (follow-up, separate PR — #267)

Found a latent gating bug while writing the role test: `role/create/+page.ts` returned the assignable-permission catalog under the key `permissions`, shadowing the `(project)` layout's effective-grants in `$page.data`, so `GuardedButton` on that page checked the catalog instead of the user's grants. Fixed in #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)