### PR TITLE
fix: stop role-create catalog shadowing effective grants

### DIFF
--- a/src/routes/(auth)/(project)/role/create/+page.svelte
+++ b/src/routes/(auth)/(project)/role/create/+page.svelte
@@ -10,7 +10,7 @@
 
 	const { data }: { data: PageData } = $props()
 	const role = $derived(data.role)
-	const permissions = $derived(data.permissions)
+	const allPermissions = $derived(data.allPermissions)
 
 	const project = $derived(data.project)
 
@@ -117,7 +117,7 @@
 					emptyText="No matching permission"
 					resetOnSelect
 					onchange={(v) => addPermission(String(v))}
-					options={permissions.filter((x) => !form.permissions.includes(x)).map((it) => ({ value: it, label: it }))} />
+					options={allPermissions.filter((x) => !form.permissions.includes(x)).map((it) => ({ value: it, label: it }))} />
 			</div>
 
 			<div class="table-container">

--- a/src/routes/(auth)/(project)/role/create/+page.ts
+++ b/src/routes/(auth)/(project)/role/create/+page.ts
@@ -23,6 +23,10 @@ export const load: PageLoad = async ({ url, parent, fetch }) => {
 	return {
 		menu: 'role',
 		role,
-		permissions: permissions.result ?? []
+		// The assignable-permission catalog. Deliberately NOT named `permissions`:
+		// the (project) layout returns the caller's effective grants under that
+		// key, and a page-data field of the same name would shadow it in
+		// $page.data — breaking GuardedButton's `can()` on this page.
+		allPermissions: permissions.result ?? []
 	}
 }

--- a/tests/role.spec.js
+++ b/tests/role.spec.js
@@ -24,6 +24,38 @@ test.describe('roles', () => {
 		await expect(main.getByText('Nothing here yet')).toBeVisible()
 	})
 
+	// Regression: the create page's assignable-permission catalog is returned
+	// under `allPermissions`, not `permissions`, so it no longer shadows the
+	// layout's effective-grants in $page.data. The guarded Create button must
+	// therefore reflect the caller's grants, independent of the catalog contents.
+	test('create button reflects grants, not the permission catalog', async ({ page }) => {
+		// Grants WITHOUT role.create, but a catalog that DOES list it. Pre-fix the
+		// catalog shadowed the grants and the button rendered enabled; now it's
+		// gated by the missing grant.
+		await setMocks({
+			'me.permissions': { ok: true, result: { permissions: ['role.list'], admin: false } },
+			'role.permissions': { ok: true, result: ['role.create', 'deployment.list'] }
+		})
+
+		await page.goto('/role/create?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Create role' })).toBeVisible()
+		await expect(main.getByRole('button', { name: 'Create', exact: true })).toBeDisabled()
+	})
+
+	test('create button is enabled with the grant even if the catalog omits it', async ({ page }) => {
+		// Grant present (default '*'); catalog deliberately omits role.create —
+		// proving the button is driven by grants, not catalog membership.
+		await setMocks({
+			'role.permissions': { ok: true, result: ['deployment.list'] }
+		})
+
+		await page.goto('/role/create?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Create role' })).toBeVisible()
+		await expect(main.getByRole('button', { name: 'Create', exact: true })).toBeEnabled()
+	})
+
 	test('searchable permission picker filters, adds, and resets', async ({ page }) => {
 		await setMocks({
 			'role.permissions': {


### PR DESCRIPTION
## Problem

`role/create/+page.ts` returned the **assignable-permission catalog** under the key `permissions`. The `(project)` layout returns the caller's **effective grants** under that same key, and a page-data field of the same name shadows it in `$page.data`.

So `GuardedButton permission="role.create"` evaluated `can('role.create')` against the catalog — which always contains the literal string `role.create` — instead of the user's grants. Net effect: **the Create button on the role create/edit page was never actually permission-gated.** A user without `role.create` saw it enabled and only discovered the denial on submit (API rejection).

Found while adding failure-case tests (#266): the role create button rendered disabled under `me.permissions: ['*']` purely because the test's catalog mock omitted `role.create`, which is the inverse symptom of the same shadow.

## Fix

Rename the loader's catalog field to `allPermissions` so it no longer collides with the layout's `permissions`. The guard now reads the layout's real effective grants. The picker options are updated to the new field name; no markup or styling changes.

## Tests

Added two regression tests in `tests/role.spec.js`:
- grants **without** `role.create` + catalog **with** it → button **disabled** (pre-fix: wrongly enabled).
- grant present + catalog **without** `role.create` → button **enabled** (proves it's driven by grants, not catalog membership; this assertion fails pre-fix).

`bun run test tests/role.spec.js` → 5 passed · `bun lint` clean · `bun check` 0 errors.

## Screenshots

N/A — logic-only change (a `load()` data-key rename); no visual/layout change. The enabled/disabled behavior is covered by the regression tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)