### PR TITLE
billing: show invoice payment method in the UI

### DIFF
--- a/src/lib/components/PayInvoiceModal.svelte
+++ b/src/lib/components/PayInvoiceModal.svelte
@@ -206,6 +206,11 @@
 		background-color: hsl(var(--hsl-content) / 0.06);
 		border: 1px solid hsl(var(--hsl-content) / 0.15);
 		border-radius: 6px;
+		/* This row is a grid item (the modal's button column). Grid items default
+		   to min-width:auto, which would let a long file name push the row — and
+		   the whole modal — wider than the panel. min-width:0 lets it shrink so
+		   the .file-name ellipsis below actually kicks in. */
+		min-width: 0;
 	}
 
 	.selected-file .file-icon {

--- a/src/lib/components/PayInvoiceModal.svelte
+++ b/src/lib/components/PayInvoiceModal.svelte
@@ -83,6 +83,10 @@
 		if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
 		return `${(n / 1024 / 1024).toFixed(1)} MB`
 	}
+
+	function money (v: number, currency: string): string {
+		return `${v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${currency}`
+	}
 </script>
 
 <div class="modal" onclick={onBackdrop} class:is-active={isActive} aria-hidden={!isActive}>
@@ -90,8 +94,26 @@
 		<div class="modal-close" onclick={close} onkeypress={close} tabindex="0" role="button">✕</div>
 		<h4><strong>Pay invoice {invoice?.number}</strong></h4>
 		<p class="mt-1 text-content/70">
-			Upload your bank transfer slip as proof of payment. We'll verify it and mark the invoice as paid.
+			Transfer the amount to the account below, then upload your bank transfer slip as proof of payment. We'll verify it and mark the invoice as paid.
 		</p>
+
+		{#if invoice?.payment?.accountNo}
+			<div class="pay-to">
+				<div class="pay-to-title">Transfer to</div>
+				<div class="pay-grid">
+					<div class="pay-key">Amount due</div>
+					<div class="font-semibold tabular-nums">{money(invoice.total, invoice.currency)}</div>
+					<div class="pay-key">Bank</div>
+					<div>{invoice.payment.bank}</div>
+					<div class="pay-key">Account name</div>
+					<div>{invoice.payment.accountName}</div>
+					<div class="pay-key">Account no.</div>
+					<div class="tabular-nums">{invoice.payment.accountNo}</div>
+					<div class="pay-key">PromptPay</div>
+					<div class="tabular-nums">{invoice.payment.promptPay}</div>
+				</div>
+			</div>
+		{/if}
 
 		<input
 			bind:this={elFile}
@@ -146,6 +168,34 @@
 		height: 1px;
 		opacity: 0;
 		pointer-events: none;
+	}
+
+	.pay-to {
+		margin-top: 1rem;
+		padding: 0.75rem 1rem;
+		background-color: hsl(var(--hsl-content) / 0.06);
+		border: 1px solid hsl(var(--hsl-content) / 0.15);
+		border-radius: 6px;
+	}
+
+	.pay-to-title {
+		font-size: var(--fs-1);
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.6);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		margin-bottom: 0.5rem;
+	}
+
+	.pay-grid {
+		display: grid;
+		grid-template-columns: max-content 1fr;
+		column-gap: 1.25rem;
+		row-gap: 0.35rem;
+	}
+
+	.pay-grid .pay-key {
+		color: hsl(var(--hsl-content) / 0.65);
 	}
 
 	.selected-file {

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -1079,6 +1079,16 @@ const invoices = [
 	}
 ]
 
+// Seller settlement details returned by billing.getInvoice. Placeholder demo
+// values for offline dev — not the real account (the live values come from
+// apiserver's invoicepdf.Payment).
+const mockPayment = {
+	bank: 'Test Bank',
+	accountName: 'Demo Seller Co., Ltd.',
+	accountNo: '1234567890',
+	promptPay: '0812345678'
+}
+
 function invoiceListItem (inv: (typeof invoices)[number]) {
 	return {
 		id: inv.id,
@@ -1164,7 +1174,7 @@ const handlers: Record<string, (args: any) => object> = {
 		}
 	}),
 	'billing.listInvoices': () => list(invoices.map(invoiceListItem)),
-	'billing.getInvoice': (args) => ok(invoices.find((i) => i.id === args?.invoiceId) ?? invoices[0]),
+	'billing.getInvoice': (args) => ok({ ...(invoices.find((i) => i.id === args?.invoiceId) ?? invoices[0]), payment: mockPayment }),
 	'billing.downloadInvoice': (args) => {
 		const inv = invoices.find((i) => i.id === args?.invoiceId) ?? invoices[0]
 		return ok({

--- a/src/routes/(auth)/billing/invoice/+page.svelte
+++ b/src/routes/(auth)/billing/invoice/+page.svelte
@@ -247,6 +247,29 @@
 			<div class="grand value">{money(invoice.total)}</div>
 		</div>
 	</div>
+
+	{#if invoice.status === 'open' && invoice.payment?.accountNo}
+		<hr>
+
+		<div>
+			<h6 class="mb-3"><strong>How to pay</strong></h6>
+			<p class="mb-3 text-content/70">
+				Transfer {money(invoice.total)} to the account below, then use the
+				<strong>Pay</strong> button above to upload your slip. We'll verify it and
+				mark the invoice as paid.
+			</p>
+			<div class="meta">
+				<div class="key">Bank</div>
+				<div>{invoice.payment.bank}</div>
+				<div class="key">Account name</div>
+				<div>{invoice.payment.accountName}</div>
+				<div class="key">Account no.</div>
+				<div class="tabular-nums">{invoice.payment.accountNo}</div>
+				<div class="key">PromptPay</div>
+				<div class="tabular-nums">{invoice.payment.promptPay}</div>
+			</div>
+		</div>
+	{/if}
 </div>
 
 <PayInvoiceModal bind:this={payModal} onuploaded={onSlipUploaded} />

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -594,6 +594,17 @@ declare namespace Api {
         voidedAt: string
         createdAt: string
         lineItems: InvoiceLineItem[]
+        // Seller settlement details (bank transfer + PromptPay). Static company
+        // info, identical on every invoice; lets the UI show "how to pay"
+        // without rendering the PDF.
+        payment: InvoicePayment
+    }
+
+    export type InvoicePayment = {
+        bank: string
+        accountName: string
+        accountNo: string
+        promptPay: string
     }
 
     export type InvoiceDownloadResult = {

--- a/tests/billing.spec.js
+++ b/tests/billing.spec.js
@@ -48,6 +48,51 @@ test.describe('invoice detail', () => {
 		await expect(apiRow.locator('td').nth(2)).toHaveText('1.70 USD')
 	})
 
+	test('shows how-to-pay payment details on an open invoice', async ({ page }) => {
+		await setMocks({
+			'billing.getInvoice': { ok: true, result: sampleInvoice }, // status: open
+			'billing.get': { ok: true, result: sampleBillingAccount }
+		})
+
+		await page.goto('/billing/invoice?id=inv-1')
+
+		// The bank-transfer / PromptPay details are visible inline — no PDF needed.
+		await expect(page.getByRole('heading', { name: 'How to pay' })).toBeVisible()
+		await expect(page.getByText('Test Bank')).toBeVisible()
+		await expect(page.getByText('1234567890')).toBeVisible()
+		await expect(page.getByText('0812345678')).toBeVisible()
+	})
+
+	test('hides the how-to-pay panel on a paid invoice', async ({ page }) => {
+		await setMocks({
+			'billing.getInvoice': { ok: true, result: { ...sampleInvoice, status: 'paid', paidAt: '2026-05-03T00:00:00Z' } },
+			'billing.get': { ok: true, result: sampleBillingAccount }
+		})
+
+		await page.goto('/billing/invoice?id=inv-1')
+
+		// Payment instructions only matter while the invoice is still payable.
+		await expect(page.getByRole('heading', { name: 'How to pay' })).toHaveCount(0)
+	})
+
+	test('pay modal shows the transfer-to account details', async ({ page }) => {
+		await setMocks({
+			'billing.getInvoice': { ok: true, result: sampleInvoice }, // status: open
+			'billing.get': { ok: true, result: sampleBillingAccount }
+		})
+
+		await page.goto('/billing/invoice?id=inv-1')
+		await page.getByRole('button', { name: 'Pay' }).click()
+
+		// The destination account a customer must transfer to is shown in the modal
+		// itself, so paying never requires opening the PDF.
+		const modal = page.locator('.modal.is-active .modal-panel')
+		await expect(modal.getByText('Transfer to')).toBeVisible()
+		await expect(modal.getByText('10.70 USD')).toBeVisible()
+		await expect(modal.getByText('1234567890')).toBeVisible()
+		await expect(modal.getByText('0812345678')).toBeVisible()
+	})
+
 	test('hides the receipt button on unpaid invoices', async ({ page }) => {
 		await setMocks({
 			'billing.getInvoice': { ok: true, result: sampleInvoice }, // status: open

--- a/tests/billing.spec.js
+++ b/tests/billing.spec.js
@@ -93,6 +93,41 @@ test.describe('invoice detail', () => {
 		await expect(modal.getByText('0812345678')).toBeVisible()
 	})
 
+	test('truncates a long slip file name instead of widening the modal', async ({ page }) => {
+		await setMocks({
+			'billing.getInvoice': { ok: true, result: sampleInvoice }, // status: open
+			'billing.get': { ok: true, result: sampleBillingAccount }
+		})
+
+		await page.goto('/billing/invoice?id=inv-1')
+		await page.getByRole('button', { name: 'Pay' }).click()
+
+		// A long, unbreakable (no-spaces) name is the worst case: without min-width:0
+		// on the selected-file row it pushes the whole modal wider than its panel.
+		await page.locator('input[type=file]').setInputFiles({
+			name: 'transfer-slip-payment-confirmation-screenshot-from-mobile-banking-app-INV-2026-0009-original-highres.pdf',
+			mimeType: 'application/pdf',
+			buffer: Buffer.from('%PDF-1.4 mock slip')
+		})
+
+		const name = page.locator('.selected-file .file-name')
+		await expect(name).toBeVisible()
+
+		// The name must be clipped (scrollWidth > clientWidth = ellipsis active) and
+		// the row must not exceed the modal panel's inner width.
+		const m = await page.evaluate(() => {
+			const n = document.querySelector('.selected-file .file-name')
+			const panel = document.querySelector('.modal.is-active .modal-panel')
+			return {
+				ellipsized: n.scrollWidth > n.clientWidth,
+				rowWidth: document.querySelector('.selected-file').getBoundingClientRect().width,
+				panelWidth: panel.getBoundingClientRect().width
+			}
+		})
+		expect(m.ellipsized).toBe(true)
+		expect(m.rowWidth).toBeLessThanOrEqual(m.panelWidth)
+	})
+
 	test('hides the receipt button on unpaid invoices', async ({ page }) => {
 		await setMocks({
 			'billing.getInvoice': { ok: true, result: sampleInvoice }, // status: open

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -347,7 +347,14 @@ export const sampleInvoice = {
 	lineItems: [
 		{ projectId: '1001', project: 'web-frontend', description: 'Web frontend', amount: 9 },
 		{ projectId: '1002', project: 'api-service', description: 'API service', amount: 1.7 }
-	]
+	],
+	// Seller settlement details (placeholder demo values, not the real account).
+	payment: {
+		bank: 'Test Bank',
+		accountName: 'Demo Seller Co., Ltd.',
+		accountNo: '1234567890',
+		promptPay: '0812345678'
+	}
 }
 
 export const sampleRepository = {


### PR DESCRIPTION
## What

Surfaces the invoice **payment method** (the seller's bank-transfer + PromptPay details) directly in the console, so customers no longer have to download the invoice PDF to find out where to pay.

- **Invoice page** — a "How to pay" panel on open (payable) invoices: the amount to transfer and the destination account (bank / account name / account no. / PromptPay).
- **Pay modal** — a "Transfer to" block showing the amount due and the same account. Previously the modal asked the customer to upload a transfer slip **without ever showing which account to transfer to**.

Both surfaces read the new `InvoiceItem.payment` field (companion api/apiserver PRs) and are defensively guarded on the data being present, so they cleanly no-op until the apiserver field is deployed.

## Why

The payment instructions existed only on the rendered PDF — users didn't realize they had to download it to see where to pay. This closes that gap.

## Notes
- Mock fixture (`mock.ts`, `fixtures/mocks.js`) updated to mirror the real API shape; 3 new Playwright tests added (panel shown on open, hidden on paid, modal shows the destination account). `bun lint`, `bun check`, and the billing suite (10 tests) pass.
- Depends on api#104 + apiserver#179 for the live `payment` field.

## Screenshots

### Invoice page — How to pay panel (new)
| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/269-before-page.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/269-after-page.png) |

### Pay modal — Transfer-to account (new)
| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/269-before-modal.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/269-after-modal.png) |

### Dark mode
![dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/269-after-page-dark.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Long file-name handling (pre-existing modal bug, fixed here)

A long, unbreakable slip file name previously pushed the row — and the whole modal — wider than its panel (the selected-file row is a grid item, which defaults to `min-width:auto`), clipping the button labels. Added `min-width:0` so the existing `.file-name` ellipsis kicks in; the name now truncates and the modal keeps its size. Regression test added.

![long filename](https://raw.githubusercontent.com/deploys-app/console/screenshots/269-modal-longname.png)
