### PR TITLE
Add project-level Errors view

### DIFF
--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -18,6 +18,7 @@ export const projectMenu: ProjectMenuItem[] = [
 	{ id: 'dashboard', title: 'Dashboard', icon: 'fa-columns', link: '/' },
 	{ id: 'metrics', title: 'Metrics', icon: 'fa-chart-line', link: '/metrics' },
 	{ id: 'deployment', title: 'Deployments', icon: 'fa-rocket', link: '/deployment' },
+	{ id: 'errors', title: 'Errors', icon: 'fa-bug', link: '/errors' },
 	{ id: 'domain', title: 'Domains', icon: 'fa-globe', link: '/domain' },
 	{ id: 'route', title: 'Routes', icon: 'fa-router', link: '/route' },
 	{ id: 'waf', title: 'Firewall', icon: 'fa-shield-halved', link: '/waf', preview: true },

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -1340,9 +1340,21 @@ const handlers: Record<string, (args: any) => object> = {
 		}
 		const base = Date.now()
 		const at = (mins: number) => new Date(base - mins * 60_000).toISOString()
-		const all: Api.DeploymentErrorIssue[] = [
+
+		// Whether the caller scoped to a single deployment (`name` present) or asked
+		// for the project-wide view (`name` omitted). The project-wide list spans
+		// several deployments/locations; the per-deployment list stamps every issue
+		// with the queried deployment so its `deployment`/`location` echo the query.
+		const projectWide = !args?.name
+		const deploymentName = String(args?.name ?? 'api')
+		const location = String(args?.location ?? LOCATION_ID)
+
+		// Per-deployment fixture: every issue belongs to the queried deployment.
+		const single: Api.DeploymentErrorIssue[] = [
 			{
 				id: 'iss_go_nilmap',
+				deployment: deploymentName,
+				location,
 				fingerprint: 'a1b2c3d4e5',
 				kind: 'go',
 				title: 'panic: assignment to entry in nil map',
@@ -1354,6 +1366,8 @@ const handlers: Record<string, (args: any) => object> = {
 			},
 			{
 				id: 'iss_py_keyerror',
+				deployment: deploymentName,
+				location,
 				fingerprint: 'b2c3d4e5f6',
 				kind: 'python',
 				title: "KeyError: 'user_id'",
@@ -1365,6 +1379,8 @@ const handlers: Record<string, (args: any) => object> = {
 			},
 			{
 				id: 'iss_node_undef',
+				deployment: deploymentName,
+				location,
 				fingerprint: 'c3d4e5f6a7',
 				kind: 'node',
 				title: "TypeError: Cannot read properties of undefined (reading 'id')",
@@ -1376,6 +1392,8 @@ const handlers: Record<string, (args: any) => object> = {
 			},
 			{
 				id: 'iss_java_npe',
+				deployment: deploymentName,
+				location,
 				fingerprint: 'd4e5f6a7b8',
 				kind: 'java',
 				title: 'java.lang.NullPointerException: Cannot invoke "String.length()"',
@@ -1387,6 +1405,8 @@ const handlers: Record<string, (args: any) => object> = {
 			},
 			{
 				id: 'iss_ruby_nomethod',
+				deployment: deploymentName,
+				location,
 				fingerprint: 'e5f6a7b8c9',
 				kind: 'ruby',
 				title: "NoMethodError: undefined method `name' for nil:NilClass",
@@ -1398,6 +1418,8 @@ const handlers: Record<string, (args: any) => object> = {
 			},
 			{
 				id: 'iss_generic_oom',
+				deployment: deploymentName,
+				location,
 				fingerprint: 'f6a7b8c9d0',
 				kind: 'generic',
 				title: 'fatal: out of memory allocating 268435456 bytes',
@@ -1408,6 +1430,118 @@ const handlers: Record<string, (args: any) => object> = {
 				samplePod: 'web-12-7d9f8-fghij'
 			}
 		]
+
+		// Project-wide fixture: issues span several deployments + locations and
+		// every kind/status, enough to page across two screens. Sorted lastSeen
+		// desc to match the page's default sort.
+		const wide: Api.DeploymentErrorIssue[] = [
+			{
+				id: 'iss_api_go_nilmap',
+				deployment: 'api',
+				location: LOCATION_ID,
+				fingerprint: 'a1b2c3d4e5',
+				kind: 'go',
+				title: 'panic: assignment to entry in nil map',
+				status: 'open',
+				count: 1284,
+				firstSeen: at(60 * 26),
+				lastSeen: at(2),
+				samplePod: 'api-12-7d9f8-abcde'
+			},
+			{
+				id: 'iss_web_node_undef',
+				deployment: 'web',
+				location: LOCATION_ID,
+				fingerprint: 'c3d4e5f6a7',
+				kind: 'node',
+				title: "TypeError: Cannot read properties of undefined (reading 'id')",
+				status: 'open',
+				count: 612,
+				firstSeen: at(60 * 4),
+				lastSeen: at(7),
+				samplePod: 'web-44-58cd1-pqrst'
+			},
+			{
+				id: 'iss_worker_py_keyerror',
+				deployment: 'worker',
+				location: 'gke.cluster-rcf3',
+				fingerprint: 'b2c3d4e5f6',
+				kind: 'python',
+				title: "KeyError: 'user_id'",
+				status: 'open',
+				count: 342,
+				firstSeen: at(60 * 9),
+				lastSeen: at(11),
+				samplePod: 'worker-9-7d9f8-fghij'
+			},
+			{
+				id: 'iss_billing_ruby_nomethod',
+				deployment: 'billing',
+				location: LOCATION_ID,
+				fingerprint: 'e5f6a7b8c9',
+				kind: 'ruby',
+				title: "NoMethodError: undefined method `name' for nil:NilClass",
+				status: 'open',
+				count: 128,
+				firstSeen: at(60 * 12),
+				lastSeen: at(24),
+				samplePod: 'billing-3-aa18c-klmno'
+			},
+			{
+				id: 'iss_api_java_npe',
+				deployment: 'api',
+				location: LOCATION_ID,
+				fingerprint: 'd4e5f6a7b8',
+				kind: 'java',
+				title: 'java.lang.NullPointerException: Cannot invoke "String.length()"',
+				status: 'muted',
+				count: 56,
+				firstSeen: at(60 * 40),
+				lastSeen: at(60 * 3),
+				samplePod: 'api-12-7d9f8-fghij'
+			},
+			{
+				id: 'iss_web_go_index',
+				deployment: 'web',
+				location: 'gke.cluster-rcf3',
+				fingerprint: 'aa11bb22cc',
+				kind: 'go',
+				title: 'panic: runtime error: index out of range [3] with length 3',
+				status: 'open',
+				count: 41,
+				firstSeen: at(60 * 6),
+				lastSeen: at(60 * 4),
+				samplePod: 'web-44-58cd1-uvwxy'
+			},
+			{
+				id: 'iss_worker_generic_oom',
+				deployment: 'worker',
+				location: 'gke.cluster-rcf3',
+				fingerprint: 'f6a7b8c9d0',
+				kind: 'generic',
+				title: 'fatal: out of memory allocating 268435456 bytes',
+				status: 'resolved',
+				count: 17,
+				firstSeen: at(60 * 90),
+				lastSeen: at(60 * 50),
+				samplePod: 'worker-9-7d9f8-zabcd'
+			},
+			{
+				id: 'iss_billing_py_zerodiv',
+				deployment: 'billing',
+				location: LOCATION_ID,
+				fingerprint: '0a1b2c3d4e',
+				kind: 'python',
+				title: 'ZeroDivisionError: division by zero',
+				status: 'resolved',
+				count: 5,
+				firstSeen: at(60 * 120),
+				lastSeen: at(60 * 80),
+				samplePod: 'billing-3-aa18c-efghi'
+			}
+		]
+
+		const all = projectWide ? wide : single
 		const status = (args?.status as Api.DeploymentErrorStatusFilter | undefined) ?? 'open'
 		const filtered = status === 'all' ? all : all.filter((it) => it.status === status)
 		// Two-page paging: first request (no cursor) returns the first 3, then
@@ -1475,6 +1609,8 @@ const handlers: Record<string, (args: any) => object> = {
 		const s = samples[id] ?? samples.iss_go_nilmap
 		const issue: Api.DeploymentErrorIssueDetail = {
 			id,
+			deployment: String(args?.name ?? 'api'),
+			location: String(args?.location ?? LOCATION_ID),
 			fingerprint: 'a1b2c3d4e5',
 			kind: id.startsWith('iss_py')
 				? 'python'

--- a/src/routes/(auth)/(project)/errors/+page.svelte
+++ b/src/routes/(auth)/(project)/errors/+page.svelte
@@ -1,0 +1,612 @@
+<script lang="ts">
+	import { onMount } from 'svelte'
+	import api from '$lib/api'
+	import type { PageData } from './$types'
+
+	const { data }: { data: PageData } = $props()
+	const project = $derived(data.project)
+
+	// Reading errors is gated by the same deployment.logs permission as the
+	// per-deployment Errors tab (one surface; keep in lockstep with the server).
+	const READ_PERMISSION = 'deployment.logs'
+
+	type StatusFilter = Api.DeploymentErrorStatusFilter
+
+	const STATUS_FILTERS: { value: StatusFilter, label: string }[] = [
+		{ value: 'open', label: 'Open' },
+		{ value: 'resolved', label: 'Resolved' },
+		{ value: 'muted', label: 'Muted' },
+		{ value: 'all', label: 'All' }
+	]
+
+	// Short, language-coloured kind badges. Hues are token-based so they recolour
+	// with the theme. Kept LOCAL, mirroring the per-deployment Errors tab.
+	const KIND_META: Record<Api.DeploymentErrorKind, { label: string, hue: number }> = {
+		go: { label: 'Go', hue: 198 },
+		java: { label: 'Java', hue: 18 },
+		python: { label: 'Py', hue: 142 },
+		node: { label: 'Node', hue: 96 },
+		ruby: { label: 'Ruby', hue: 355 },
+		generic: { label: 'Generic', hue: 250 }
+	}
+
+	function kindMeta (kind: Api.DeploymentErrorKind) {
+		return KIND_META[kind] ?? { label: kind, hue: 250 }
+	}
+
+	// Eight evenly-spaced hues; hashing the deployment name into the palette gives
+	// every deployment a stable, distinguishable colour (local copy).
+	const POD_HUES = [355, 28, 48, 142, 175, 205, 260, 312]
+
+	function nameHue (s: string): number {
+		let h = 0
+		for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0
+		return POD_HUES[Math.abs(h) % POD_HUES.length]
+	}
+
+	// ts is ISO 8601; nowMs is a shared "now" tick so all rows refresh together.
+	function relTime (ts: string, nowMs: number): string {
+		const t = Date.parse(ts)
+		if (isNaN(t)) return ''
+		const diff = Math.max(0, nowMs - t)
+		if (diff < 1000) return 'now'
+		if (diff < 60_000) return `${Math.floor(diff / 1000)}s`
+		if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m`
+		if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h`
+		return `${Math.floor(diff / 86_400_000)}d`
+	}
+
+	// Deep-link to this issue on the owning deployment's Errors tab, where the
+	// full detail + triage (resolve / mute / reopen) lives.
+	function issueHref (issue: Api.DeploymentErrorIssue): string {
+		const q = new URLSearchParams({
+			project,
+			location: issue.location,
+			name: issue.deployment
+		})
+		return `/deployment/errors?${q.toString()}`
+	}
+
+	let status = $state<StatusFilter>('open')
+	let query = $state('')
+	let issues = $state<Api.DeploymentErrorIssue[]>([])
+	let nextCursor = $state<string | undefined>(undefined)
+	let loading = $state(false)
+	let loadingMore = $state(false)
+	// Distinguish "no data yet" from the various terminal states so we never flash
+	// the empty state before the first fetch resolves.
+	let loaded = $state(false)
+	let forbidden = $state(false)
+	let errorMessage = $state('')
+	let now = $state(Date.now())
+
+	const visibleIssues = $derived.by(() => {
+		const q = query.trim().toLowerCase()
+		if (!q) return issues
+		return issues.filter((it) =>
+			it.title.toLowerCase().includes(q) ||
+			it.kind.toLowerCase().includes(q) ||
+			it.deployment.toLowerCase().includes(q) ||
+			it.location.toLowerCase().includes(q) ||
+			it.samplePod.toLowerCase().includes(q))
+	})
+
+	function classifyError (resp: Api.Response<unknown>): void {
+		forbidden = false
+		errorMessage = ''
+		if (resp.error?.forbidden) {
+			forbidden = true
+			return
+		}
+		errorMessage = resp.error?.message || 'Failed to load application errors.'
+	}
+
+	async function loadIssues (): Promise<void> {
+		loading = true
+		// Reset terminal states on each fresh load so a filter change after a
+		// forbidden response can recover.
+		forbidden = false
+		errorMessage = ''
+		// Project-wide listing: deployment.errors with no `name` aggregates issues
+		// across every deployment in the project.
+		const resp = await api.invoke<Api.DeploymentErrorsResult>('deployment.errors', {
+			project,
+			status,
+			sort: 'lastSeen'
+		}, fetch)
+		if (resp.ok) {
+			issues = resp.result.issues ?? []
+			nextCursor = resp.result.nextCursor || undefined
+		} else {
+			issues = []
+			nextCursor = undefined
+			classifyError(resp)
+		}
+		loaded = true
+		loading = false
+	}
+
+	async function loadMore (): Promise<void> {
+		if (!nextCursor || loadingMore) return
+		loadingMore = true
+		const resp = await api.invoke<Api.DeploymentErrorsResult>('deployment.errors', {
+			project,
+			status,
+			sort: 'lastSeen',
+			cursor: nextCursor
+		}, fetch)
+		if (resp.ok) {
+			issues = [...issues, ...(resp.result.issues ?? [])]
+			nextCursor = resp.result.nextCursor || undefined
+		}
+		loadingMore = false
+	}
+
+	// Label the loaded count with the active filter's noun, so it stays accurate
+	// whichever status is selected (e.g. "3 open", "2 resolved", "6 issues").
+	const countLabel = $derived(
+		query.trim()
+			? `${visibleIssues.length} shown`
+			: status === 'all'
+				? `${issues.length} ${issues.length === 1 ? 'issue' : 'issues'}`
+				: `${issues.length} ${status}`
+	)
+
+	onMount(() => {
+		loadIssues()
+		const ticker = setInterval(() => { now = Date.now() }, 1000)
+		return () => clearInterval(ticker)
+	})
+
+	// Reload when the status filter changes (after the first mount). Reading
+	// `status` here is what subscribes the effect to its changes.
+	let trackedStatus = $state<StatusFilter | null>(null)
+	$effect(() => {
+		const current = status
+		if (trackedStatus === current) return
+		const first = trackedStatus === null
+		trackedStatus = current
+		if (!first) loadIssues()
+	})
+</script>
+
+<style>
+	.errors-shell {
+		--shell-divider: hsl(var(--hsl-content) / 0.08);
+		--shell-bg: hsl(var(--hsl-base-100));
+		display: flex;
+		flex-direction: column;
+		background: var(--shell-bg);
+		border: 1px solid var(--shell-divider);
+		border-radius: 10px;
+		overflow: hidden;
+		font-feature-settings: 'tnum' 1;
+	}
+
+	.errors-rail {
+		display: flex;
+		align-items: center;
+		gap: 0.85rem;
+		padding: 0.6rem 1rem;
+		border-bottom: 1px solid var(--shell-divider);
+		background: linear-gradient(180deg,
+			hsl(var(--hsl-base-200)) 0%,
+			hsl(var(--hsl-base-100)) 100%);
+		box-shadow: inset 0 1px 0 hsl(var(--hsl-content) / 0.04);
+		font-family: var(--ffml-primary);
+		flex-wrap: wrap;
+	}
+
+	.errors-rail__brand {
+		margin: 0;
+		font-weight: 600;
+		color: hsl(var(--hsl-content));
+		font-size: 0.9rem;
+	}
+
+	.errors-rail__count {
+		color: hsl(var(--hsl-content) / 0.5);
+		font-size: 0.8125rem;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.errors-rail__spacer { flex: 1; }
+
+	/* status filter pills */
+	.filter-pills {
+		display: inline-flex;
+		background: hsl(var(--hsl-content) / 0.05);
+		border: 1px solid hsl(var(--hsl-content) / 0.08);
+		border-radius: 7px;
+		padding: 2px;
+		gap: 2px;
+	}
+
+	.filter-pill {
+		border: none;
+		background: transparent;
+		border-radius: 5px;
+		padding: 0 0.65rem;
+		height: 1.6rem;
+		font-family: var(--ffml-primary);
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.55);
+		cursor: pointer;
+		transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+	}
+	.filter-pill:hover { color: hsl(var(--hsl-content) / 0.85); }
+	.filter-pill[data-active='true'] {
+		background: hsl(var(--hsl-base-100));
+		color: hsl(var(--hsl-content));
+		box-shadow: 0 1px 2px hsl(var(--hsl-content) / 0.1);
+	}
+
+	/* Compact rail search, matching the per-deployment Errors tab — the .input
+	   component class can't be used here (its min-height: 2.5rem towers over the
+	   ~1.85rem status pills next to it). */
+	.filter-search {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		height: 1.85rem;
+		padding: 0 0.55rem;
+		background: hsl(var(--hsl-content) / 0.04);
+		border: 1px solid hsl(var(--hsl-content) / 0.08);
+		border-radius: 6px;
+		transition: border-color 0.15s ease, background 0.15s ease;
+	}
+	.filter-search:focus-within {
+		border-color: hsl(var(--hsl-primary) / 0.5);
+		background: hsl(var(--hsl-base-100));
+		box-shadow: 0 0 0 3px hsl(var(--hsl-primary) / 0.08);
+	}
+	.filter-search__icon { font-size: 0.625rem; color: hsl(var(--hsl-content) / 0.4); }
+	.filter-search__input {
+		background: transparent;
+		border: none;
+		outline: none;
+		font-size: 0.8125rem;
+		color: hsl(var(--hsl-content));
+		width: 11rem;
+	}
+	.filter-search__input::placeholder { color: hsl(var(--hsl-content) / 0.4); letter-spacing: 0.02em; }
+	.filter-search__clear {
+		background: transparent;
+		border: none;
+		padding: 0 0.1rem;
+		color: hsl(var(--hsl-content) / 0.4);
+		cursor: pointer;
+		font-size: 0.625rem;
+		line-height: 1;
+	}
+	.filter-search__clear:hover { color: hsl(var(--hsl-content)); }
+
+	/* surface */
+	.errors-surface {
+		position: relative;
+		flex: 1;
+		min-height: 14rem;
+		max-height: calc(100dvh - 18rem);
+		overflow-y: auto;
+		overflow-x: hidden;
+	}
+
+	.issue-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.issue-item { border-bottom: 1px solid hsl(var(--hsl-content) / 0.05); }
+	.issue-item:last-child { border-bottom: none; }
+
+	.issue-row {
+		display: grid;
+		grid-template-columns: [kind] 4.25rem [deployment] 9rem [title] 1fr [count] auto [time] 3rem [status] 5.25rem;
+		align-items: center;
+		column-gap: 0.85rem;
+		width: 100%;
+		padding: 0.65rem 1rem;
+		border: none;
+		background: transparent;
+		text-align: left;
+		text-decoration: none;
+		font-family: var(--ffml-primary);
+		transition: background-color 0.12s ease;
+	}
+	.issue-row:hover { background: hsl(var(--hsl-content) / 0.035); }
+
+	.kind-badge {
+		grid-column: kind;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.12rem 0;
+		width: 100%;
+		border-radius: 5px;
+		font-size: 0.6875rem;
+		font-weight: 700;
+		letter-spacing: 0.02em;
+		background: hsl(var(--kind-hue) 60% 50% / 0.14);
+		color: hsl(var(--kind-hue) 62% 42%);
+		border: 1px solid hsl(var(--kind-hue) 60% 50% / 0.28);
+	}
+	:global(.dark) .kind-badge {
+		background: hsl(var(--kind-hue) 60% 60% / 0.16);
+		color: hsl(var(--kind-hue) 70% 72%);
+		border-color: hsl(var(--kind-hue) 60% 60% / 0.3);
+	}
+
+	/* deployment column — the column that distinguishes this project-wide view
+	   from the per-deployment tab. */
+	.issue-deployment {
+		grid-column: deployment;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.1rem;
+	}
+	.issue-deployment__name {
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: hsl(var(--name-hue) 55% 42%);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	:global(.dark) .issue-deployment__name { color: hsl(var(--name-hue) 65% 70%); }
+	.issue-deployment__loc {
+		font-size: 0.625rem;
+		color: hsl(var(--hsl-content) / 0.4);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.issue-title {
+		grid-column: title;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.1rem;
+	}
+	.issue-title__text {
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content));
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	.issue-title__pod {
+		font-family: var(--ffml-mono);
+		font-size: 0.6875rem;
+		color: hsl(var(--hsl-content) / 0.4);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.issue-count {
+		grid-column: count;
+		font-variant-numeric: tabular-nums;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.75);
+		display: inline-flex;
+		align-items: baseline;
+		gap: 0.25rem;
+	}
+	.issue-count__unit { font-size: 0.625rem; font-weight: 500; color: hsl(var(--hsl-content) / 0.4); }
+
+	.issue-time {
+		grid-column: time;
+		text-align: right;
+		font-variant-numeric: tabular-nums;
+		font-size: 0.6875rem;
+		color: hsl(var(--hsl-content) / 0.45);
+		cursor: help;
+	}
+
+	.status-chip {
+		grid-column: status;
+		justify-self: end;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+		padding: 0.1rem 0.5rem;
+		border-radius: 999px;
+		font-size: 0.6875rem;
+		font-weight: 600;
+		text-transform: capitalize;
+		white-space: nowrap;
+	}
+	.status-chip::before {
+		content: '';
+		width: 0.4rem;
+		height: 0.4rem;
+		border-radius: 50%;
+		background: currentColor;
+	}
+	.status-chip[data-status='open'] {
+		background: hsl(var(--hsl-negative) / 0.12);
+		color: hsl(var(--hsl-negative));
+	}
+	.status-chip[data-status='resolved'] {
+		background: hsl(var(--hsl-positive) / 0.12);
+		color: hsl(var(--hsl-positive));
+	}
+	.status-chip[data-status='muted'] {
+		background: hsl(var(--hsl-content) / 0.08);
+		color: hsl(var(--hsl-content) / 0.55);
+	}
+
+	/* states */
+	.state-pane {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.7rem;
+		min-height: 18rem;
+		padding: 3rem 1.5rem;
+		text-align: center;
+		font-family: var(--ffml-primary);
+	}
+	.state-pane__icon {
+		width: 2.5rem;
+		height: 2.5rem;
+		color: hsl(var(--hsl-content) / 0.3);
+	}
+	.state-pane__title {
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.7);
+	}
+	.state-pane__hint {
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-content) / 0.45);
+		max-width: 26rem;
+	}
+
+	.load-more-bar {
+		display: flex;
+		justify-content: center;
+		padding: 0.85rem;
+		border-top: 1px solid hsl(var(--hsl-content) / 0.06);
+	}
+
+	@media (max-width: 768px) {
+		.issue-row {
+			grid-template-columns: [kind] 3.5rem [deployment] 6rem [title] 1fr [count] auto [status] auto;
+			row-gap: 0.2rem;
+		}
+		.issue-time { display: none; }
+	}
+</style>
+
+<div class="page-head">
+	<div>
+		<h4><strong>Errors</strong></h4>
+		<p class="page-sub">Application errors across every deployment in this project</p>
+	</div>
+</div>
+
+<div class="errors-shell">
+	<header class="errors-rail">
+		<h6 class="errors-rail__brand">Issues</h6>
+		{#if loaded && !forbidden && !errorMessage}
+			<span class="errors-rail__count">{countLabel}</span>
+		{/if}
+
+		<span class="errors-rail__spacer"></span>
+
+		<div class="filter-pills" role="tablist" aria-label="Status filter">
+			{#each STATUS_FILTERS as f (f.value)}
+				<button
+					type="button"
+					class="filter-pill"
+					role="tab"
+					aria-selected={status === f.value}
+					data-active={status === f.value}
+					onclick={() => (status = f.value)}>
+					{f.label}
+				</button>
+			{/each}
+		</div>
+
+		<label class="filter-search">
+			<i class="fa-solid fa-magnifying-glass filter-search__icon" aria-hidden="true"></i>
+			<input
+				class="filter-search__input"
+				type="text"
+				placeholder="Filter issues…"
+				aria-label="Filter issues"
+				spellcheck="false"
+				autocomplete="off"
+				bind:value={query} />
+			{#if query}
+				<button type="button" class="filter-search__clear" onclick={() => (query = '')} aria-label="Clear filter">
+					<i class="fa-solid fa-xmark"></i>
+				</button>
+			{/if}
+		</label>
+	</header>
+
+	<main class="errors-surface">
+		{#if loading && !loaded}
+			<div class="state-pane">
+				<div class="state-pane__title">Loading errors…</div>
+			</div>
+		{:else if forbidden}
+			<div class="state-pane">
+				<svg class="state-pane__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+					<rect x="3" y="11" width="18" height="11" rx="2"></rect>
+					<path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+				</svg>
+				<div class="state-pane__title">You don't have access to errors</div>
+				<div class="state-pane__hint">Viewing application errors requires the <code>{READ_PERMISSION}</code> permission.</div>
+			</div>
+		{:else if errorMessage}
+			<div class="state-pane">
+				<svg class="state-pane__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+					<circle cx="12" cy="12" r="9"></circle>
+					<path d="M12 8v4M12 16h.01"></path>
+				</svg>
+				<div class="state-pane__title">Couldn't load errors</div>
+				<div class="state-pane__hint">{errorMessage}</div>
+			</div>
+		{:else if visibleIssues.length === 0}
+			<div class="state-pane">
+				<svg class="state-pane__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+					<path d="M9 12l2 2 4-4"></path>
+					<circle cx="12" cy="12" r="9"></circle>
+				</svg>
+				<div class="state-pane__title">
+					{query.trim() ? 'No issues match your filter.' : 'No application errors across this project.'}
+				</div>
+				{#if !query.trim()}
+					<div class="state-pane__hint">Stack traces and unhandled exceptions printed by your apps would show up here.</div>
+				{/if}
+			</div>
+		{:else}
+			<ul class="issue-list">
+				{#each visibleIssues as issue (issue.id)}
+					{@const meta = kindMeta(issue.kind)}
+					<li class="issue-item">
+						<a class="issue-row" href={issueHref(issue)}>
+							<span class="kind-badge" style={`--kind-hue: ${meta.hue}`}>{meta.label}</span>
+							<span class="issue-deployment" style={`--name-hue: ${nameHue(issue.deployment)}`}>
+								<span class="issue-deployment__name" title={issue.deployment}>{issue.deployment}</span>
+								<span class="issue-deployment__loc" title={issue.location}>{issue.location}</span>
+							</span>
+							<span class="issue-title">
+								<span class="issue-title__text" title={issue.title}>{issue.title}</span>
+								<span class="issue-title__pod" title={issue.samplePod}>{issue.samplePod}</span>
+							</span>
+							<span class="issue-count" title={`${issue.count} occurrences`}>
+								{issue.count.toLocaleString()}<span class="issue-count__unit">×</span>
+							</span>
+							<span class="issue-time" title={issue.lastSeen}>{relTime(issue.lastSeen, now)}</span>
+							<span class="status-chip" data-status={issue.status}>{issue.status}</span>
+						</a>
+					</li>
+				{/each}
+			</ul>
+
+			{#if nextCursor}
+				<div class="load-more-bar">
+					<button
+						type="button"
+						class="button is-variant-secondary is-size-small"
+						class:is-loading={loadingMore}
+						disabled={loadingMore}
+						onclick={loadMore}>
+						Load more
+					</button>
+				</div>
+			{/if}
+		{/if}
+	</main>
+</div>

--- a/src/routes/(auth)/(project)/errors/+page.ts
+++ b/src/routes/(auth)/(project)/errors/+page.ts
@@ -1,0 +1,10 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async ({ parent }) => {
+	const { project } = await parent()
+	return {
+		project,
+		menu: 'errors',
+		overrideRedirect: '/errors'
+	}
+}

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -930,8 +930,15 @@ declare namespace Api {
     export type DeploymentErrorSort = 'lastSeen' | 'firstSeen' | 'count'
 
     // One grouped issue as returned by deployment.errors (the list view).
+    //
+    // `deployment` + `location` identify which deployment the issue belongs to.
+    // They are always present; on the per-deployment call they echo the queried
+    // deployment, and on the project-wide call (deployment.errors without a
+    // `name`) they are the column that distinguishes issues across deployments.
     export type DeploymentErrorIssue = {
         id: string
+        deployment: string
+        location: string
         fingerprint: string
         kind: DeploymentErrorKind
         title: string
@@ -962,10 +969,15 @@ declare namespace Api {
 
     // Args of deployment.errors (list). status defaults to 'open', sort to
     // 'lastSeen'; cursor is the opaque page token from a prior nextCursor.
+    //
+    // `location` + `name` are optional: supplying both scopes the listing to a
+    // single deployment, while OMITTING `name` lists error issues across every
+    // deployment in the project (the project-wide Errors view). Each returned
+    // issue carries its own `deployment` + `location` regardless.
     export type DeploymentErrorsArgs = {
         project: string
-        location: string
-        name: string
+        location?: string
+        name?: string
         status?: DeploymentErrorStatusFilter
         limit?: number
         cursor?: string


### PR DESCRIPTION
PR 3/3 of the project-level Errors view.

A new top-level **Errors** item in the project sidebar (next to Deployments / Domains / Routes) opens a Sentry-style list of application-error issues aggregated **across every deployment in the project** — the project-wide counterpart to the per-deployment Errors tab.

## Screenshots

| Light | Dark |
| --- | --- |
| ![light](https://raw.githubusercontent.com/deploys-app/console/screenshots/272-light.png) | ![dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/272-dark.png) |

## What it adds
- **Route** `/errors` (`src/routes/(auth)/(project)/errors/`): calls `deployment.errors` with just `{ project, status?, sort?, cursor? }` (no `name`) for the project-wide listing.
- **Deployment column** — each row surfaces the owning deployment + location (the key new column vs the per-deployment tab), plus the kind badge, title, occurrence count, last-seen relative time, and status chip. Default sort lastSeen desc; offset `nextCursor` "Load more".
- **Rows deep-link** to the issue on the per-deployment Errors tab (`/deployment/errors?project=…&location=…&name=…`), where the full detail and triage (resolve / mute / reopen) already live — nothing is rebuilt here.
- **Controls** mirror the per-deployment tab: status filter pills (Open default / Resolved / Muted / All), the compact rail search (icon + transparent input, not the heavy `.input` class), and forbidden (`deployment.logs`) / error / empty states.
- **Types** — `Api.DeploymentErrorIssue` gains `deployment` + `location` (always present); `DeploymentErrorsArgs` relaxes `location`/`name` to optional (project-wide when `name` is omitted).
- **Mock** — `deployment.errors` returns a project-wide fixture (issues spanning multiple deployments / kinds / statuses with 2-page paging) when called without a `name`; per-deployment behavior unchanged.

## Verification
- `bun check` → 0 errors / 0 warnings.
- `bun lint` → clean.
- Captured light + dark at 1320px against the mock (sidebar item present + active, deployment column, badges, status chips, filter pills, paging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011d4bVuGLnCbcJD9ZvastPH