### PR TITLE
nav: mark Errors as preview

### DIFF
--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -18,7 +18,7 @@ export const projectMenu: ProjectMenuItem[] = [
 	{ id: 'dashboard', title: 'Dashboard', icon: 'fa-columns', link: '/' },
 	{ id: 'metrics', title: 'Metrics', icon: 'fa-chart-line', link: '/metrics' },
 	{ id: 'deployment', title: 'Deployments', icon: 'fa-rocket', link: '/deployment' },
-	{ id: 'errors', title: 'Errors', icon: 'fa-bug', link: '/errors' },
+	{ id: 'errors', title: 'Errors', icon: 'fa-bug', link: '/errors', preview: true },
 	{ id: 'domain', title: 'Domains', icon: 'fa-globe', link: '/domain' },
 	{ id: 'route', title: 'Routes', icon: 'fa-router', link: '/route' },
 	{ id: 'waf', title: 'Firewall', icon: 'fa-shield-halved', link: '/waf', preview: true },


### PR DESCRIPTION
## Summary
- Add `preview: true` to the Errors entry in `src/lib/nav.ts` so the sidebar renders the existing "Preview" badge next to "Errors", consistent with Firewall, Cache, GitHub, Scheduler, and Notifications.

Screenshots to follow on the `screenshots` branch.

## Test plan
- [ ] Sidebar shows a "Preview" badge next to the "Errors" item
- [ ] `bun lint` passes
- [ ] `bun check` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_013C75tCQZAAGipLXeN4oTha)_