### PR TITLE
Preview environments: immutable Release URL + preview expiry

### DIFF
--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -179,7 +179,8 @@ function deployment (project = 'acme') {
 		createdAt: CREATED_AT,
 		createdBy: USER_EMAIL,
 		successAt: CREATED_AT,
-		ttl: 0
+		ttl: 0,
+		expiresAt: ''
 	}
 }
 
@@ -210,7 +211,10 @@ function staticDeployment (project = 'acme', releaseSha = STATIC_RELEASE_SHA) {
 		workloadIdentity: '',
 		internalUrl: '',
 		internalAddress: '',
-		url: 'website.acme.rcf2.deploys.app'
+		url: 'website.acme.rcf2.deploys.app',
+		// Immutable per-release URL: <name>-<release8>.<region> pinned to this
+		// release-sha, so the detail page exercises the Release URL row offline.
+		releaseUrl: `website-${releaseSha.slice(0, 8)}.acme.rcf2.deploys.app`
 	}
 }
 
@@ -231,6 +235,13 @@ const deployments = [
 	deployment('acme'),
 	erroringDeployment('acme'),
 	staticDeployment('acme'),
+	{
+		// A TTL'd Static preview, so the list exercises the "expires in" flag.
+		...staticDeployment('acme'),
+		name: 'website-preview',
+		ttl: 7200,
+		expiresAt: '2026-06-22T00:00:00Z'
+	},
 	{
 		...deployment('acme'),
 		name: 'web-paused',

--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -440,6 +440,17 @@
 						</span>
 					</div>
 				{/if}
+				{#if deployment.type === 'Static' && deployment.releaseUrl}
+					<div class="spec">
+						<span class="spec__label" title="Immutable URL pinned to this exact release — safe to share a specific build">Release URL</span>
+						<a class="spec__link" href={`https://${deployment.releaseUrl}`} target="_blank" rel="noopener">
+							{`https://${deployment.releaseUrl}`}
+						</a>
+						<span class="spec__copy copy" data-clipboard-text={`https://${deployment.releaseUrl}`} title="Copy immutable per-release URL">
+							<i class="fa-light fa-copy"></i>
+						</span>
+					</div>
+				{/if}
 				{#if deployment.type === 'WebService'}
 					<div class="spec">
 						<span class="spec__label">Internal URL</span>

--- a/src/routes/(auth)/(project)/deployment/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/+page.svelte
@@ -89,7 +89,13 @@
 		font-size: 0.74rem;
 	}
 
-	.ttl-flag { font-size: 0.72rem; }
+	.ttl-flag {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.28rem;
+		font-size: 0.72rem;
+		white-space: nowrap;
+	}
 
 	.replicas-none { color: hsl(var(--hsl-content) / 0.35); }
 </style>
@@ -136,10 +142,14 @@
 											<span class="status-pill is-{pill.tone}">{pill.label}</span>
 										{/if}
 										{#if it.ttl === -1}
-											<i class="fa-regular fa-clock ttl-flag text-negative" title="Expired — pending deletion"></i>
+											<span class="ttl-flag text-negative" title="Expired — pending deletion">
+												<i class="fa-regular fa-clock"></i> expired
+											</span>
 										{:else if it.ttl > 0}
-											<i class="fa-regular fa-clock ttl-flag text-warning"
-												title={`Auto-delete at ${format.ttlExpireAt(it.ttl)} (in ${format.duration(it.ttl)})`}></i>
+											<span class="ttl-flag text-warning"
+												title={`Auto-delete at ${format.ttlExpireAt(it.ttl)}`}>
+												<i class="fa-regular fa-clock"></i> expires in {format.duration(it.ttl)}
+											</span>
 										{/if}
 									</div>
 									<div class="cell-meta">

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -356,6 +356,7 @@ declare namespace Api {
         sidecars: Sidecar[]
         access?: DeploymentAccessConfig | null
         url: string
+        releaseUrl?: string
         internalUrl: string
         logUrl: string
         eventUrl: string
@@ -371,6 +372,7 @@ declare namespace Api {
         createdBy: string
         successAt: string
         ttl: number
+        expiresAt: string
     }
 
     export type ServiceAccountKey = {


### PR DESCRIPTION
Console surface for **Preview Environments** (`SPEC-preview-environments.md` §D).

## What's in this PR
- **Static deployment Details page** — a copyable **Release URL** row beside the default URL: the immutable per-release link (B2), shown only for Static deployments that have one.
- **Deployment list** — TTL'd deployments now show a visible **"expires in &lt;duration&gt;"** flag (was an icon-only tooltip), so a preview's auto-delete window is obvious at a glance; expired rows show "expired".
- **`Api.Deployment`** type gains `releaseUrl?`/`expiresAt`; mock fixtures gain a Static release URL and a TTL'd `website-preview` so both render under `dev:mock`.

`bun check` and `bun lint` both green.

## Screenshots

**Static deployment Details — new "Release URL" row** (light / dark):

| ![detail light](https://raw.githubusercontent.com/deploys-app/console/screenshots/275-detail-light.png) | ![detail dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/275-detail-dark.png) |
| --- | --- |

**Deployment list — "expires in" flag on the TTL'd `website-preview`** (light / dark):

| ![list light](https://raw.githubusercontent.com/deploys-app/console/screenshots/275-list-light.png) | ![list dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/275-list-dark.png) |
| --- | --- |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYMGjvqWELm2ctgKamiMSS