### PR TITLE
Extend auto-delete (TTL) button on the deployment detail page

### DIFF
--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -1245,6 +1245,17 @@ const handlers: Record<string, (args: any) => object> = {
 			const sha = `${revision}`.repeat(64).slice(0, 64)
 			return ok({ ...base, revision, site: `site://deploys-static/${args?.project ?? 'acme'}/website@${sha}`, siteManifestDigest: sha })
 		}
+		// A TTL'd Static preview, so the detail page exercises the Auto-delete row
+		// and its Extend button offline.
+		if (args?.name === 'website-preview') {
+			return ok({
+				...staticDeployment(args?.project),
+				name: 'website-preview',
+				location: args?.location ?? LOCATION_ID,
+				ttl: 7200,
+				expiresAt: '2026-06-22T08:00:00Z'
+			})
+		}
 		if (args?.name === 'api') {
 			return ok({ ...erroringDeployment(args?.project), location: args?.location ?? LOCATION_ID })
 		}
@@ -1266,6 +1277,7 @@ const handlers: Record<string, (args: any) => object> = {
 	'deployment.resume': () => ok({}),
 	'deployment.restart': () => ok({}),
 	'deployment.rollback': () => ok({}),
+	'deployment.extendTTL': () => ok({}),
 	'deployment.revisions': (args) => {
 		// Static deployment: per-revision release-shas, no image.
 		if (args?.name === 'website') {

--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte'
 	import { setupCopy } from '$lib/clipboard'
 	import * as format from '$lib/format'
-	import { goto } from '$app/navigation'
+	import { goto, invalidateAll } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
@@ -63,6 +63,40 @@
 
 	const envEntries = $derived(Object.entries(deployment.env || {}))
 	const mountEntries = $derived(Object.entries(deployment.mountData || {}))
+
+	// Extend TTL (preview keep-alive): re-stamp the auto-delete window to now + N
+	// hours without redeploying. Only offered for a deployment that already has a
+	// TTL — extendTTL is rejected server-side on a non-preview deployment.
+	let extendOpen = $state(false)
+	let extendHours = $state(2)
+	let extending = $state(false)
+
+	function openExtend () {
+		extendHours = 2
+		extendOpen = true
+	}
+
+	async function submitExtend () {
+		const ttl = Math.round(extendHours * 3600)
+		if (!(ttl > 0)) {
+			modal.error({ error: 'Enter a positive number of hours.' })
+			return
+		}
+		extending = true
+		const resp = await api.invoke('deployment.extendTTL', {
+			project: deployment.project,
+			location: deployment.location,
+			name: deployment.name,
+			ttl
+		}, fetch)
+		extending = false
+		if (!resp.ok) {
+			modal.error({ error: resp.error })
+			return
+		}
+		extendOpen = false
+		await invalidateAll()
+	}
 </script>
 
 <style>
@@ -770,7 +804,9 @@
 								<i class="fa-regular fa-clock"></i> in {format.duration(deployment.ttl)}
 							</span>
 						</span>
-						<span></span>
+						<GuardedButton permission="deployment.deploy" class="button is-variant-secondary is-size-small" onclick={openExtend} title="Re-stamp the auto-delete window (keep this preview alive)">
+							Extend
+						</GuardedButton>
 					</div>
 				{/if}
 			</div>
@@ -894,3 +930,21 @@
 </DangerZone>
 
 <EnvGroupModal bind:this={envGroupModal} />
+
+<!-- Extend auto-delete window (preview keep-alive). No overlay-click-to-close so
+     a stray click while typing can't dismiss the form. -->
+<div class="modal" class:is-active={extendOpen} aria-hidden={!extendOpen}>
+	<div class="modal-panel" style="width: 100%; max-width: 26rem;">
+		<div class="modal-close" onclick={() => (extendOpen = false)} onkeypress={() => (extendOpen = false)} tabindex="0" role="button">✕</div>
+		<h4><strong>Extend auto-delete</strong></h4>
+		<p class="mt-2 text-sm text-content/60">Re-stamp the window so this deployment auto-deletes that many hours from now. It does not redeploy.</p>
+		<div class="field mt-4">
+			<label class="label" for="extend-hours">Hours from now</label>
+			<input id="extend-hours" class="input" type="number" min="0.25" step="0.25" bind:value={extendHours} />
+		</div>
+		<div class="mt-6 flex justify-end gap-3">
+			<button class="button is-variant-tertiary" type="button" onclick={() => (extendOpen = false)}>Cancel</button>
+			<button class="button" class:is-loading={extending} type="button" disabled={extending} onclick={submitExtend}>Extend</button>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
Follow-up to Preview Environments. `deployment.extendTTL` (preview keep-alive) was API/CLI/MCP-only; this adds the console affordance.

On a TTL'd deployment's **Details → Lifecycle**, the **Auto-delete** row now has an **Extend** button (gated by `deployment.deploy`). It opens a small modal to re-stamp the window N hours from now (default 2), calls `deployment.extendTTL`, and `invalidateAll()`s so the new expiry shows. The button only appears for deployments that already have a TTL — the server rejects `extendTTL` on a non-preview deployment, so this matches that contract.

Mock: added a `deployment.extendTTL` handler and a TTL'd `website-preview` fixture so both the row and the modal render under `dev:mock`.

`bun check` + `bun lint` green.

## Screenshots

**Lifecycle "Auto-delete" row with the new Extend button** (light / dark):

| ![detail light](https://raw.githubusercontent.com/deploys-app/console/screenshots/276-detail-light.png) | ![detail dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/276-detail-dark.png) |
| --- | --- |

**Extend modal** (light / dark):

| ![modal light](https://raw.githubusercontent.com/deploys-app/console/screenshots/276-modal-light.png) | ![modal dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/276-modal-dark.png) |
| --- | --- |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYMGjvqWELm2ctgKamiMSS