### PR TITLE
fix(errors): Tier-3 accessibility for the error pages

### DIFF
--- a/src/routes/(auth)/(project)/deployment/(detail)/errors/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/errors/+page.svelte
@@ -212,6 +212,9 @@
 			return
 		}
 		expandedId = issue.id
+		// Move focus into the freshly-opened detail region so keyboard users land in
+		// it and screen readers announce it; mouse users see no ring (:focus-visible).
+		requestAnimationFrame(() => document.getElementById(`detail-${issue.id}`)?.focus())
 		await loadDetail(issue.id)
 	}
 
@@ -384,13 +387,27 @@
 	}
 	.filter-search__input::placeholder { color: hsl(var(--hsl-content) / 0.4); letter-spacing: 0.02em; }
 	.filter-search__clear {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.25rem;
+		height: 1.25rem;
 		background: transparent;
 		border: none;
-		padding: 0 0.1rem;
+		border-radius: 4px;
+		padding: 0;
 		color: hsl(var(--hsl-content) / 0.4);
 		cursor: pointer;
-		font-size: 0.625rem;
+		font-size: 0.7rem;
 		line-height: 1;
+	}
+	/* Extend the hit target to ~44px (WCAG) without growing the compact rail —
+	   the icon stays small, the clickable area spills invisibly around it. */
+	.filter-search__clear::after {
+		content: '';
+		position: absolute;
+		inset: -0.75rem;
 	}
 	.filter-search__clear:hover { color: hsl(var(--hsl-content)); }
 
@@ -598,6 +615,9 @@
 		background: hsl(var(--hsl-content) / 0.02);
 		border-top: 1px solid hsl(var(--hsl-content) / 0.06);
 	}
+	/* The panel takes focus on open only to move the reading cursor here; it's a
+	   region, not a control, so suppress the ring (its buttons keep their own). */
+	.issue-detail:focus { outline: none; }
 
 	.detail-actions {
 		display: flex;
@@ -743,13 +763,12 @@
 
 		<span class="errors-rail__spacer"></span>
 
-		<div class="filter-pills" role="tablist" aria-label="Status filter">
+		<div class="filter-pills" role="group" aria-label="Status filter">
 			{#each STATUS_FILTERS as f (f.value)}
 				<button
 					type="button"
 					class="filter-pill"
-					role="tab"
-					aria-selected={status === f.value}
+					aria-pressed={status === f.value}
 					data-active={status === f.value}
 					onclick={() => (status = f.value)}>
 					{f.label}
@@ -848,6 +867,7 @@
 							type="button"
 							class="issue-row"
 							aria-expanded={expandedId === issue.id}
+							aria-controls={expandedId === issue.id ? `detail-${issue.id}` : undefined}
 							onclick={() => toggleExpand(issue)}>
 							<span class="kind-badge" style={`--kind-hue: ${meta.hue}`}>{meta.label}</span>
 							<span class="issue-title">
@@ -862,7 +882,12 @@
 						</button>
 
 						{#if expandedId === issue.id}
-							<div class="issue-detail">
+							<div
+								class="issue-detail"
+								id={`detail-${issue.id}`}
+								role="region"
+								aria-label={`Details for ${issue.title}`}
+								tabindex="-1">
 								<div class="detail-actions">
 									{#if issue.status !== 'resolved'}
 										<GuardedButton

--- a/src/routes/(auth)/(project)/errors/+page.svelte
+++ b/src/routes/(auth)/(project)/errors/+page.svelte
@@ -289,13 +289,27 @@
 	}
 	.filter-search__input::placeholder { color: hsl(var(--hsl-content) / 0.4); letter-spacing: 0.02em; }
 	.filter-search__clear {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.25rem;
+		height: 1.25rem;
 		background: transparent;
 		border: none;
-		padding: 0 0.1rem;
+		border-radius: 4px;
+		padding: 0;
 		color: hsl(var(--hsl-content) / 0.4);
 		cursor: pointer;
-		font-size: 0.625rem;
+		font-size: 0.7rem;
 		line-height: 1;
+	}
+	/* Extend the hit target to ~44px (WCAG) without growing the compact rail —
+	   the icon stays small, the clickable area spills invisibly around it. */
+	.filter-search__clear::after {
+		content: '';
+		position: absolute;
+		inset: -0.75rem;
 	}
 	.filter-search__clear:hover { color: hsl(var(--hsl-content)); }
 
@@ -593,13 +607,12 @@
 
 		<span class="errors-rail__spacer"></span>
 
-		<div class="filter-pills" role="tablist" aria-label="Status filter">
+		<div class="filter-pills" role="group" aria-label="Status filter">
 			{#each STATUS_FILTERS as f (f.value)}
 				<button
 					type="button"
 					class="filter-pill"
-					role="tab"
-					aria-selected={status === f.value}
+					aria-pressed={status === f.value}
 					data-active={status === f.value}
 					onclick={() => (status = f.value)}>
 					{f.label}


### PR DESCRIPTION
Implements the **Tier 3** items from the console error-detection UX review (`console-errors-ux-review.md`) — accessibility — across both error surfaces: the per-deployment **Errors** tab and the project-wide **Errors** page. Follows #277 (Tier 1) and #278 (Tier 2).

These are **semantic** changes — the UI looks the same, so the evidence below is the assertion run plus a "nothing regressed visually" screenshot.

## What changed

1. **Status filter was a fake tab strip.** It used `role="tablist"`/`role="tab"`/`aria-selected` with no tabpanel and no arrow-key roving — so it announced as tabs but didn't behave like them. Now a `role="group"` of **`aria-pressed`** toggle buttons: the single-select state is conveyed without implying tab/arrow-key navigation (each pill stays Tab-focusable). Visual (`data-active`) unchanged.
2. **Clear (✕) tap target was ~10px.** The icon stays small, but it now carries a **44×44px hit area** (WCAG 2.5.5) via an invisible `::after` inset — the compact rail layout is untouched.
3. **Expand control (deployment page).** The row button now references the panel via **`aria-controls`** (set only while expanded, so there's no dangling id), and the detail panel is a **`role="region"`** with an accessible name (`Details for …`) + `tabindex="-1"`. On a user expand, **focus moves into the region** so keyboard users land in it and screen readers announce it. Mouse users see no ring (`:focus-visible`), and the region's own outline is suppressed since it's an announce/scroll target, not a control.

The project page gets only items 1–2 — its rows are `<a>` links to the deployment tab, not expanders.

## Verification
A Playwright run against `bun dev:mock` asserts the runtime semantics (not just the markup):

```
PASS — filter-pills role=group
PASS — no role=tab remains
PASS — active pill aria-pressed=true
PASS — inactive pill aria-pressed=false
PASS — clear hit area ~44px (>=40)
PASS — row aria-controls=detail-iss_go_nilmap
PASS — detail role=region
PASS — detail has aria-label
PASS — focus moved into detail region on expand
```

- `bun check` + `bun lint` clean (0 / 0).
- Passed `/scrutinize`; its fix-then-ship note (bump the hit-area inset so the target is a true 44px, not ~42) is folded in.

## Scope
Remaining Tier 4 (extract the duplicated `KIND_META`/`POD_HUES`/`relTime`/CSS into `$lib/errors/`, nav open-issue badge, refresh button, skeleton load, etc.) is out of scope here.

## Screenshots
_The visuals are unchanged by design; included to confirm no regression._

**Rail** — status pills (now an `aria-pressed` group) + the ✕ clear control (small icon, 44px hit area):

![rail](https://raw.githubusercontent.com/deploys-app/console/screenshots/279-rail-clear.png)

**Expanded issue** (the detail panel is now a focusable `role=region`) — light / dark:

| light | dark |
| --- | --- |
| ![expanded light](https://raw.githubusercontent.com/deploys-app/console/screenshots/279-expanded-light.png) | ![expanded dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/279-expanded-dark.png) |