### PR TITLE
feat(errors): refresh button, wider pod palette, finish the dedup

### DIFF
--- a/src/lib/errors/ErrorsRail.svelte
+++ b/src/lib/errors/ErrorsRail.svelte
@@ -9,6 +9,10 @@
 		// loading or in a terminal state).
 		count?: string | null
 		brand?: string
+		// Manual re-fetch. While `refreshing` is true the icon spins and the button
+		// is disabled.
+		onRefresh?: () => void
+		refreshing?: boolean
 	}
 
 	let {
@@ -16,7 +20,9 @@
 		sort = $bindable(),
 		query = $bindable(),
 		count = null,
-		brand = 'Errors'
+		brand = 'Errors',
+		onRefresh,
+		refreshing = false
 	}: Props = $props()
 </script>
 
@@ -69,6 +75,17 @@
 			</button>
 		{/if}
 	</label>
+
+	{#if onRefresh}
+		<button
+			type="button"
+			class="rail-refresh"
+			onclick={() => onRefresh?.()}
+			disabled={refreshing}
+			aria-label="Refresh errors">
+			<i class="fa-solid fa-arrows-rotate" class:fa-spin={refreshing} aria-hidden="true"></i>
+		</button>
+	{/if}
 </header>
 
 <style>
@@ -233,4 +250,30 @@
 		color: hsl(var(--hsl-content) / 0.4);
 		pointer-events: none;
 	}
+
+	/* manual refresh — compact icon button matching the rail controls' height */
+	.rail-refresh {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.85rem;
+		height: 1.85rem;
+		background: hsl(var(--hsl-content) / 0.04);
+		border: 1px solid hsl(var(--hsl-content) / 0.08);
+		border-radius: 6px;
+		color: hsl(var(--hsl-content) / 0.55);
+		font-size: 0.75rem;
+		cursor: pointer;
+		transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+	}
+	.rail-refresh:hover:not(:disabled) {
+		background: hsl(var(--hsl-content) / 0.07);
+		color: hsl(var(--hsl-content) / 0.85);
+	}
+	.rail-refresh:focus-visible {
+		outline: none;
+		border-color: hsl(var(--hsl-primary) / 0.5);
+		box-shadow: 0 0 0 3px hsl(var(--hsl-primary) / 0.08);
+	}
+	.rail-refresh:disabled { cursor: default; color: hsl(var(--hsl-content) / 0.4); }
 </style>

--- a/src/lib/errors/LoadMoreBar.svelte
+++ b/src/lib/errors/LoadMoreBar.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	interface Props {
+		nextCursor: string | undefined
+		query: string
+		loadingMore: boolean
+		loadMoreError: boolean
+		onLoadMore: () => void
+	}
+	const { nextCursor, query, loadingMore, loadMoreError, onLoadMore }: Props = $props()
+</script>
+
+{#if nextCursor}
+	<div class="load-more-bar">
+		{#if query.trim()}
+			<!-- The filter runs over loaded rows only, so paging more in while a query
+			     is active just hides them — explain instead of an inert button. -->
+			<span class="load-more-hint">Filter applies to loaded issues only — clear it to load more.</span>
+		{:else}
+			{#if loadMoreError}
+				<span class="load-more-error">Couldn't load more issues.</span>
+			{/if}
+			<button
+				type="button"
+				class="button is-variant-secondary is-size-small"
+				class:is-loading={loadingMore}
+				disabled={loadingMore}
+				onclick={onLoadMore}>
+				{loadMoreError ? 'Try again' : 'Load more'}
+			</button>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.load-more-bar {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.85rem;
+		border-top: 1px solid hsl(var(--hsl-content) / 0.06);
+	}
+	.load-more-hint {
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-content) / 0.5);
+		text-align: center;
+	}
+	.load-more-error {
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-negative));
+		text-align: center;
+	}
+</style>

--- a/src/lib/errors/StatePane.svelte
+++ b/src/lib/errors/StatePane.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte'
+
+	interface Props {
+		// Which line-icon to show above the title; omit for the bare loading pane.
+		icon?: 'lock' | 'alert' | 'check'
+		title: string
+		hint?: string
+		// Optional trailing content, e.g. a "Try again" button.
+		action?: Snippet
+	}
+	const { icon, title, hint, action }: Props = $props()
+</script>
+
+<div class="state-pane">
+	{#if icon === 'lock'}
+		<svg class="state-pane__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+			<rect x="3" y="11" width="18" height="11" rx="2"></rect>
+			<path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+		</svg>
+	{:else if icon === 'alert'}
+		<svg class="state-pane__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+			<circle cx="12" cy="12" r="9"></circle>
+			<path d="M12 8v4M12 16h.01"></path>
+		</svg>
+	{:else if icon === 'check'}
+		<svg class="state-pane__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+			<path d="M9 12l2 2 4-4"></path>
+			<circle cx="12" cy="12" r="9"></circle>
+		</svg>
+	{/if}
+	<div class="state-pane__title">{title}</div>
+	{#if hint}
+		<div class="state-pane__hint">{hint}</div>
+	{/if}
+	{@render action?.()}
+</div>
+
+<style>
+	.state-pane {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.7rem;
+		min-height: 18rem;
+		padding: 3rem 1.5rem;
+		text-align: center;
+		font-family: var(--ffml-primary);
+	}
+	.state-pane__icon {
+		width: 2.5rem;
+		height: 2.5rem;
+		color: hsl(var(--hsl-content) / 0.3);
+	}
+	.state-pane__title {
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.7);
+	}
+	.state-pane__hint {
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-content) / 0.45);
+		max-width: 26rem;
+	}
+</style>

--- a/src/lib/errors/format.ts
+++ b/src/lib/errors/format.ts
@@ -37,9 +37,9 @@ export function kindMeta (kind: Api.ErrorKind): { label: string, hue: number } {
 	return KIND_META[kind] ?? { label: kind, hue: 250 }
 }
 
-// Eight evenly-spaced hues; hashing a stable string (pod or deployment name)
+// Twelve spread-out hues; hashing a stable string (pod or deployment name)
 // into the palette gives each one a stable, distinguishable colour.
-const HUES = [355, 28, 48, 142, 175, 205, 260, 312]
+const HUES = [355, 18, 40, 62, 96, 142, 168, 192, 212, 248, 282, 320]
 
 export function hashHue (s: string): number {
 	let h = 0

--- a/src/routes/(auth)/(project)/deployment/(detail)/errors/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/errors/+page.svelte
@@ -7,6 +7,8 @@
 	import ErrorsRail from '$lib/errors/ErrorsRail.svelte'
 	import KindBadge from '$lib/errors/KindBadge.svelte'
 	import StatusChip from '$lib/errors/StatusChip.svelte'
+	import StatePane from '$lib/errors/StatePane.svelte'
+	import LoadMoreBar from '$lib/errors/LoadMoreBar.svelte'
 	import type { PageData } from './$types'
 
 	const { data }: { data: PageData } = $props()
@@ -414,53 +416,6 @@
 	}
 	.detail-loading { padding: 0.85rem 0; font-size: 0.8125rem; color: hsl(var(--hsl-content) / 0.5); }
 
-	/* states */
-	.state-pane {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-		gap: 0.7rem;
-		min-height: 18rem;
-		padding: 3rem 1.5rem;
-		text-align: center;
-		font-family: var(--ffml-primary);
-	}
-	.state-pane__icon {
-		width: 2.5rem;
-		height: 2.5rem;
-		color: hsl(var(--hsl-content) / 0.3);
-	}
-	.state-pane__title {
-		font-size: 0.875rem;
-		font-weight: 600;
-		color: hsl(var(--hsl-content) / 0.7);
-	}
-	.state-pane__hint {
-		font-size: 0.75rem;
-		color: hsl(var(--hsl-content) / 0.45);
-		max-width: 26rem;
-	}
-
-	.load-more-bar {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 0.5rem;
-		padding: 0.85rem;
-		border-top: 1px solid hsl(var(--hsl-content) / 0.06);
-	}
-	.load-more-hint {
-		font-size: 0.75rem;
-		color: hsl(var(--hsl-content) / 0.5);
-		text-align: center;
-	}
-	.load-more-error {
-		font-size: 0.75rem;
-		color: hsl(var(--hsl-negative));
-		text-align: center;
-	}
-
 	@media (max-width: 768px) {
 		.issue-row {
 			grid-template-columns: [kind] 3.5rem [title] 1fr [count] auto [status] auto;
@@ -476,60 +431,40 @@
 		bind:status
 		bind:sort
 		bind:query
-		count={loaded && !forbidden && !unavailable && !errorMessage ? countLabel : null} />
+		count={loaded && !forbidden && !unavailable && !errorMessage ? countLabel : null}
+		onRefresh={loadIssues}
+		refreshing={loading} />
 
 	<main class="errors-surface">
 		{#if loading && !issues.length}
-			<div class="state-pane">
-				<div class="state-pane__title">Loading errors…</div>
-			</div>
+			<StatePane title="Loading errors…" />
 		{:else if forbidden}
-			<div class="state-pane">
-				<svg class="state-pane__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-					<rect x="3" y="11" width="18" height="11" rx="2"></rect>
-					<path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
-				</svg>
-				<div class="state-pane__title">You don't have access to errors</div>
-				<div class="state-pane__hint">Viewing application errors requires the <code>{READ_PERMISSION}</code> permission.</div>
-			</div>
+			<StatePane
+				icon="lock"
+				title="You don't have access to errors"
+				hint={`Viewing application errors requires the ${READ_PERMISSION} permission.`} />
 		{:else if unavailable}
-			<div class="state-pane">
-				<svg class="state-pane__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-					<circle cx="12" cy="12" r="9"></circle>
-					<path d="M12 8v4M12 16h.01"></path>
-				</svg>
-				<div class="state-pane__title">Error detection isn't available for this location yet.</div>
-				<div class="state-pane__hint">This deployment's location has no log capture, so application errors can't be detected here.</div>
-			</div>
+			<StatePane
+				icon="alert"
+				title="Error detection isn't available for this location yet."
+				hint="This deployment's location has no log capture, so application errors can't be detected here." />
 		{:else if errorMessage}
-			<div class="state-pane">
-				<svg class="state-pane__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-					<circle cx="12" cy="12" r="9"></circle>
-					<path d="M12 8v4M12 16h.01"></path>
-				</svg>
-				<div class="state-pane__title">Couldn't load errors</div>
-				<div class="state-pane__hint">{errorMessage}</div>
-				<button
-					type="button"
-					class="button is-variant-secondary is-size-small"
-					class:is-loading={loading}
-					onclick={loadIssues}>
-					Try again
-				</button>
-			</div>
+			<StatePane icon="alert" title="Couldn't load errors" hint={errorMessage}>
+				{#snippet action()}
+					<button
+						type="button"
+						class="button is-variant-secondary is-size-small"
+						class:is-loading={loading}
+						onclick={loadIssues}>
+						Try again
+					</button>
+				{/snippet}
+			</StatePane>
 		{:else if visibleIssues.length === 0}
-			<div class="state-pane">
-				<svg class="state-pane__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-					<path d="M9 12l2 2 4-4"></path>
-					<circle cx="12" cy="12" r="9"></circle>
-				</svg>
-				<div class="state-pane__title">
-					{query.trim() ? 'No issues match your filter.' : 'No application errors detected.'}
-				</div>
-				{#if !query.trim()}
-					<div class="state-pane__hint">Stack traces and unhandled exceptions printed by this app would show up here.</div>
-				{/if}
-			</div>
+			<StatePane
+				icon="check"
+				title={query.trim() ? 'No issues match your filter.' : 'No application errors detected.'}
+				hint={query.trim() ? undefined : 'Stack traces and unhandled exceptions printed by this app would show up here.'} />
 		{:else}
 			<ul class="issue-list">
 				{#each visibleIssues as issue (issue.id)}
@@ -630,27 +565,7 @@
 				{/each}
 			</ul>
 
-			{#if nextCursor}
-				<div class="load-more-bar">
-					{#if query.trim()}
-						<!-- The filter runs over loaded rows only, so paging more in while a
-						     query is active just hides them — explain instead of an inert button. -->
-						<span class="load-more-hint">Filter applies to loaded issues only — clear it to load more.</span>
-					{:else}
-						{#if loadMoreError}
-							<span class="load-more-error">Couldn't load more issues.</span>
-						{/if}
-						<button
-							type="button"
-							class="button is-variant-secondary is-size-small"
-							class:is-loading={loadingMore}
-							disabled={loadingMore}
-							onclick={loadMore}>
-							{loadMoreError ? 'Try again' : 'Load more'}
-						</button>
-					{/if}
-				</div>
-			{/if}
+			<LoadMoreBar {nextCursor} {query} {loadingMore} {loadMoreError} onLoadMore={loadMore} />
 		{/if}
 	</main>
 </div>

--- a/src/routes/(auth)/(project)/errors/+page.svelte
+++ b/src/routes/(auth)/(project)/errors/+page.svelte
@@ -5,6 +5,8 @@
 	import ErrorsRail from '$lib/errors/ErrorsRail.svelte'
 	import KindBadge from '$lib/errors/KindBadge.svelte'
 	import StatusChip from '$lib/errors/StatusChip.svelte'
+	import StatePane from '$lib/errors/StatePane.svelte'
+	import LoadMoreBar from '$lib/errors/LoadMoreBar.svelte'
 	import type { PageData } from './$types'
 
 	const { data }: { data: PageData } = $props()
@@ -266,53 +268,6 @@
 		cursor: help;
 	}
 
-	/* states */
-	.state-pane {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-		gap: 0.7rem;
-		min-height: 18rem;
-		padding: 3rem 1.5rem;
-		text-align: center;
-		font-family: var(--ffml-primary);
-	}
-	.state-pane__icon {
-		width: 2.5rem;
-		height: 2.5rem;
-		color: hsl(var(--hsl-content) / 0.3);
-	}
-	.state-pane__title {
-		font-size: 0.875rem;
-		font-weight: 600;
-		color: hsl(var(--hsl-content) / 0.7);
-	}
-	.state-pane__hint {
-		font-size: 0.75rem;
-		color: hsl(var(--hsl-content) / 0.45);
-		max-width: 26rem;
-	}
-
-	.load-more-bar {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 0.5rem;
-		padding: 0.85rem;
-		border-top: 1px solid hsl(var(--hsl-content) / 0.06);
-	}
-	.load-more-hint {
-		font-size: 0.75rem;
-		color: hsl(var(--hsl-content) / 0.5);
-		text-align: center;
-	}
-	.load-more-error {
-		font-size: 0.75rem;
-		color: hsl(var(--hsl-negative));
-		text-align: center;
-	}
-
 	@media (max-width: 768px) {
 		.issue-row {
 			grid-template-columns: [kind] 3.5rem [deployment] 6rem [title] 1fr [count] auto [status] auto;
@@ -334,60 +289,40 @@
 		bind:status
 		bind:sort
 		bind:query
-		count={loaded && !forbidden && !unavailable && !errorMessage ? countLabel : null} />
+		count={loaded && !forbidden && !unavailable && !errorMessage ? countLabel : null}
+		onRefresh={loadIssues}
+		refreshing={loading} />
 
 	<main class="errors-surface">
 		{#if loading && !issues.length}
-			<div class="state-pane">
-				<div class="state-pane__title">Loading errors…</div>
-			</div>
+			<StatePane title="Loading errors…" />
 		{:else if forbidden}
-			<div class="state-pane">
-				<svg class="state-pane__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-					<rect x="3" y="11" width="18" height="11" rx="2"></rect>
-					<path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
-				</svg>
-				<div class="state-pane__title">You don't have access to errors</div>
-				<div class="state-pane__hint">Viewing application errors requires the <code>{READ_PERMISSION}</code> permission.</div>
-			</div>
+			<StatePane
+				icon="lock"
+				title="You don't have access to errors"
+				hint={`Viewing application errors requires the ${READ_PERMISSION} permission.`} />
 		{:else if unavailable}
-			<div class="state-pane">
-				<svg class="state-pane__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-					<circle cx="12" cy="12" r="9"></circle>
-					<path d="M12 8v4M12 16h.01"></path>
-				</svg>
-				<div class="state-pane__title">Error detection isn't available yet.</div>
-				<div class="state-pane__hint">No location in this project has log capture, so application errors can't be detected.</div>
-			</div>
+			<StatePane
+				icon="alert"
+				title="Error detection isn't available yet."
+				hint="No location in this project has log capture, so application errors can't be detected." />
 		{:else if errorMessage}
-			<div class="state-pane">
-				<svg class="state-pane__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-					<circle cx="12" cy="12" r="9"></circle>
-					<path d="M12 8v4M12 16h.01"></path>
-				</svg>
-				<div class="state-pane__title">Couldn't load errors</div>
-				<div class="state-pane__hint">{errorMessage}</div>
-				<button
-					type="button"
-					class="button is-variant-secondary is-size-small"
-					class:is-loading={loading}
-					onclick={loadIssues}>
-					Try again
-				</button>
-			</div>
+			<StatePane icon="alert" title="Couldn't load errors" hint={errorMessage}>
+				{#snippet action()}
+					<button
+						type="button"
+						class="button is-variant-secondary is-size-small"
+						class:is-loading={loading}
+						onclick={loadIssues}>
+						Try again
+					</button>
+				{/snippet}
+			</StatePane>
 		{:else if visibleIssues.length === 0}
-			<div class="state-pane">
-				<svg class="state-pane__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-					<path d="M9 12l2 2 4-4"></path>
-					<circle cx="12" cy="12" r="9"></circle>
-				</svg>
-				<div class="state-pane__title">
-					{query.trim() ? 'No issues match your filter.' : 'No application errors across this project.'}
-				</div>
-				{#if !query.trim()}
-					<div class="state-pane__hint">Stack traces and unhandled exceptions printed by your apps would show up here.</div>
-				{/if}
-			</div>
+			<StatePane
+				icon="check"
+				title={query.trim() ? 'No issues match your filter.' : 'No application errors across this project.'}
+				hint={query.trim() ? undefined : 'Stack traces and unhandled exceptions printed by your apps would show up here.'} />
 		{:else}
 			<ul class="issue-list">
 				{#each visibleIssues as issue (issue.id)}
@@ -412,27 +347,7 @@
 				{/each}
 			</ul>
 
-			{#if nextCursor}
-				<div class="load-more-bar">
-					{#if query.trim()}
-						<!-- The filter runs over loaded rows only, so paging more in while a
-						     query is active just hides them — explain instead of an inert button. -->
-						<span class="load-more-hint">Filter applies to loaded issues only — clear it to load more.</span>
-					{:else}
-						{#if loadMoreError}
-							<span class="load-more-error">Couldn't load more issues.</span>
-						{/if}
-						<button
-							type="button"
-							class="button is-variant-secondary is-size-small"
-							class:is-loading={loadingMore}
-							disabled={loadingMore}
-							onclick={loadMore}>
-							{loadMoreError ? 'Try again' : 'Load more'}
-						</button>
-					{/if}
-				</div>
-			{/if}
+			<LoadMoreBar {nextCursor} {query} {loadingMore} {loadMoreError} onLoadMore={loadMore} />
 		{/if}
 	</main>
 </div>


### PR DESCRIPTION
The three **"worth doing"** leftovers from the Tier-4 error-pages review (follows #277–#280, which completed Tiers 1–4).

## What changed
1. **Manual refresh button.** `ErrorsRail` gains an optional refresh icon button (`onRefresh` + `refreshing` props). The error list only loads on mount / filter change, so today there's no way to pull fresh data without toggling a filter. The icon spins and the button disables while a reload is in flight. Both pages wire it to `loadIssues` + `loading`.
2. **Wider pod palette.** The colour-hash palette went **8 → 12 hues** (`format.ts`) so pods/deployments stay more distinguishable when there are many of them.
3. **Finished the CSS dedup.** Extracted **`StatePane.svelte`** (icon / title / hint + optional `action` snippet) and **`LoadMoreBar.svelte`**, and rewired both pages to use them — removing the last duplicated state-pane / load-more markup + CSS (the two pages each had verbatim copies). Net **−250 lines** of duplication.

## Notes
- The forbidden-state hint drops its `<code>` wrapper (now plain text) — a small, conscious trade for the simple string-based `StatePane`.
- This closes out the actionable items from the review. The remaining ideas (nav open-issue badge — needs a count source/polling; back-nav snapshot restore; skeleton load) are deferred as independent features.

## Verification
- `bun check` + `bun lint` clean (0 / 0). **0 svelte-check warnings ⇒ no orphaned selectors/imports** after the deletions.
- Playwright: the refresh button **re-fetches `error.list`** (1 → 2 calls) and has an `aria-label`; the extracted `StatePane` renders the error state with **Try again**.
- Passed `/scrutinize`.

## Screenshots
The refresh button (⟳) sits at the right of the rail; pod/deployment colours use the wider 12-hue palette.

**Per-deployment Errors tab** — light / dark:

| light | dark |
| --- | --- |
| ![deploy light](https://raw.githubusercontent.com/deploys-app/console/screenshots/281-deploy-light.png) | ![deploy dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/281-deploy-dark.png) |

**Project-wide Errors page** — light / dark:

| light | dark |
| --- | --- |
| ![project light](https://raw.githubusercontent.com/deploys-app/console/screenshots/281-project-light.png) | ![project dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/281-project-dark.png) |

**Error state** (now from the shared `StatePane`):

![state error](https://raw.githubusercontent.com/deploys-app/console/screenshots/281-state-error.png)
