### PR TITLE
feat(route): Host header override in create/edit/detail

### DIFF
--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -359,6 +359,18 @@ const routes = [
 		config: {},
 		createdAt: CREATED_AT,
 		createdBy: USER_EMAIL
+	},
+	{
+		location: LOCATION_ID,
+		domain: 'legacy.example.com',
+		path: '/',
+		target: 'http://203.0.113.10:8080',
+		deployment: 'http://203.0.113.10:8080',
+		// External upstream with a Host-header override — the backend
+		// virtual-hosts on Host, so the edge forwards `legacy.internal`.
+		config: { host: 'legacy.internal' },
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL
 	}
 ]
 
@@ -1696,12 +1708,16 @@ const handlers: Record<string, (args: any) => object> = {
 	'domain.purgeCache': () => ok({}),
 
 	'route.list': () => list(routes),
-	'route.get': (args) => ok({
-		...routes[0],
-		location: args?.location ?? routes[0].location,
-		domain: args?.domain ?? routes[0].domain,
-		path: args?.path ?? routes[0].path
-	}),
+	'route.get': (args) => {
+		const match = routes.find((r) => r.domain === args?.domain && r.path === (args?.path ?? '/'))
+		const base = match ?? routes[0]
+		return ok({
+			...base,
+			location: args?.location ?? base.location,
+			domain: args?.domain ?? base.domain,
+			path: args?.path ?? base.path
+		})
+	},
 	'route.createV2': () => ok({}),
 	'route.delete': () => ok({}),
 

--- a/src/routes/(auth)/(project)/route/create/+page.svelte
+++ b/src/routes/(auth)/(project)/route/create/+page.svelte
@@ -20,6 +20,7 @@
 		targetPrefix: '',
 		targetValue: '',
 		config: {
+			host: '',
 			enableBasicAuth: false,
 			basicAuth: {
 				user: '',
@@ -31,6 +32,10 @@
 
 	const targetPlaceholder = $derived(routeTargetMeta[form.targetPrefix]?.placeholder ?? '')
 	const targetHint = $derived(routeTargetMeta[form.targetPrefix]?.hint ?? '')
+
+	// The Host-header override only applies to an external server (http://) target;
+	// the api rejects it for every other target type, so the field is hidden.
+	const showHostOverride = $derived(form.targetPrefix === 'http://')
 
 	let domains = $state<Api.Domain[]>([])
 	let deployments = $state<{ name: string, paused: boolean }[]>([])
@@ -115,6 +120,7 @@
 				path: form.path,
 				target: `${form.targetPrefix}${form.targetValue}`,
 				config: {
+					host: showHostOverride ? form.config.host.trim() : '',
 					basicAuth: form.config.enableBasicAuth
 						? {
 							user: form.config.basicAuth.user,
@@ -238,6 +244,16 @@
 			<div class="field mt-3">
 				<h6><strong>Advanced Settings</strong></h6>
 			</div>
+
+			{#if showHostOverride}
+				<div class="field">
+					<label for="input-host">Host header override</label>
+					<div class="input">
+						<input id="input-host" bind:value={form.config.host} placeholder="leave empty to keep the request's Host">
+					</div>
+					<p class="page-sub">Override the <code>Host</code> header sent to the upstream — useful when the backend serves content by host name. A bare hostname or IP, optional <code>:port</code>.</p>
+				</div>
+			{/if}
 
 			<div class="field">
 				<div class="checkbox">

--- a/src/routes/(auth)/(project)/route/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/route/edit/+page.svelte
@@ -40,6 +40,7 @@
 			// Basic-auth and forward-auth are mutually exclusive, so a single
 			// three-way selector matches the backend constraint.
 			auth: cfg.basicAuth ? 'basic' : cfg.forwardAuth ? 'forward' : 'none',
+			host: cfg.host ?? '',
 			basicAuth: {
 				user: cfg.basicAuth?.user ?? '',
 				password: cfg.basicAuth?.password ?? ''
@@ -87,6 +88,10 @@
 
 	const targetPlaceholder = $derived(routeTargetMeta[form.targetPrefix]?.placeholder ?? '')
 	const targetHint = $derived(routeTargetMeta[form.targetPrefix]?.hint ?? '')
+
+	// The Host-header override only applies to an external server (http://) target;
+	// the api rejects it for every other target type, so the field is hidden.
+	const showHostOverride = $derived(form.targetPrefix === 'http://')
 
 	let deployments = $state<{ name: string, paused: boolean }[]>([])
 
@@ -147,6 +152,7 @@
 		saving = true
 		try {
 			const config = {
+				host: showHostOverride ? form.host.trim() : '',
 				basicAuth: form.auth === 'basic'
 					? { user: form.basicAuth.user, password: form.basicAuth.password }
 					: null,
@@ -262,6 +268,16 @@
 				{#if targetHint}
 					<p class="page-sub">{targetHint}</p>
 				{/if}
+			</div>
+		{/if}
+
+		{#if showHostOverride}
+			<div class="field">
+				<label for="input-host">Host header override</label>
+				<div class="input">
+					<input id="input-host" bind:value={form.host} placeholder="leave empty to keep the request's Host">
+				</div>
+				<p class="text-content/50 text-sm mt-1">Override the <code>Host</code> header sent to the upstream — useful when the backend serves content by host name. A bare hostname or IP, optional <code>:port</code>.</p>
 			</div>
 		{/if}
 

--- a/src/routes/(auth)/(project)/route/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/route/manage/+page.svelte
@@ -55,6 +55,7 @@
 	const authIcon = $derived({ basic: 'fa-lock', forward: 'fa-shield-halved', none: 'fa-lock-open' }[authType])
 	const basic = $derived(route.config?.basicAuth)
 	const fwd = $derived(route.config?.forwardAuth)
+	const hostOverride = $derived(route.config?.host)
 	const reqHeaders = $derived(fwd?.authRequestHeaders ?? [])
 	const resHeaders = $derived(fwd?.authResponseHeaders ?? [])
 
@@ -481,6 +482,15 @@
 						<span></span>
 					{/if}
 				</div>
+				{#if hostOverride}
+					<div class="spec">
+						<span class="spec__label">Host header</span>
+						<span class="spec__value is-mono">{hostOverride}</span>
+						<span class="spec__copy copy" data-clipboard-text={hostOverride} title="Copy host header">
+							<i class="fa-light fa-copy"></i>
+						</span>
+					</div>
+				{/if}
 				<div class="spec">
 					<span class="spec__label">Created</span>
 					<span class="spec__value">

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -104,6 +104,9 @@ declare namespace Api {
             authRequestHeaders: string[]
             authResponseHeaders: string[]
         }
+        // Override the Host header forwarded upstream (external http:// and
+        // deployment:// targets). Empty keeps the request's original Host.
+        host?: string
     }
 
     export type Route = {

--- a/tests/route.spec.js
+++ b/tests/route.spec.js
@@ -1,5 +1,5 @@
 import { test, expect, setMocks, getRequestLog } from './helpers.js'
-import { sampleRoute, sampleDeployment } from './fixtures/mocks.js'
+import { sampleRoute, sampleDeployment, sampleDomain } from './fixtures/mocks.js'
 
 test.describe('routes', () => {
 	test('lists routes', async ({ page }) => {
@@ -79,6 +79,26 @@ test.describe('route detail', () => {
 		await expect(page.locator('#input-auth')).toHaveCount(0)
 	})
 
+	test('shows the Host header override when set', async ({ page }) => {
+		await setMocks({
+			'route.get': {
+				ok: true,
+				result: {
+					...sampleRoute,
+					domain: 'legacy.example.com',
+					target: 'http://203.0.113.10:8080',
+					config: { host: 'legacy.internal' }
+				}
+			}
+		})
+
+		await page.goto('/route/manage?project=test-project&location=gke&domain=legacy.example.com&path=%2F')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('Host header', { exact: true })).toBeVisible()
+		await expect(main.getByText('legacy.internal', { exact: true })).toBeVisible()
+	})
+
 	test('delete confirms then calls route.delete', async ({ page }) => {
 		await setMocks({
 			'route.get': { ok: true, result: sampleRoute },
@@ -124,6 +144,54 @@ test.describe('route edit', () => {
 		await expect(page.locator('#input-target_value')).toHaveValue('https://elsewhere.example.com')
 		// Basic-auth config seeds the auth fields.
 		await expect(page.locator('#input-basic_auth_user')).toHaveValue('admin')
+		// A redirect target has no upstream, so the Host override field is hidden.
+		await expect(page.locator('#input-host')).toHaveCount(0)
+	})
+
+	test('seeds and saves the Host header override for an external route', async ({ page }) => {
+		await setMocks({
+			'route.get': {
+				ok: true,
+				result: {
+					...sampleRoute,
+					domain: 'legacy.example.com',
+					target: 'http://203.0.113.10:8080',
+					config: { host: 'legacy.internal' }
+				}
+			},
+			'route.createV2': { ok: true, result: {} }
+		})
+
+		await page.goto('/route/edit?project=test-project&location=gke&domain=legacy.example.com&path=%2F')
+
+		// The external http:// target shows the Host field, seeded from config.host.
+		await expect(page.locator('#input-host')).toHaveValue('legacy.internal')
+
+		await page.locator('#input-host').fill('new.internal')
+		await page.getByRole('button', { name: 'Save' }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/route.createV2')
+		}).toBeTruthy()
+
+		const req = (await getRequestLog()).find((r) => r.path === '/route.createV2')
+		if (!req) throw new Error('expected a route.createV2 request')
+		const body = JSON.parse(req.body)
+		expect(body.target).toBe('http://203.0.113.10:8080')
+		expect(body.config.host).toBe('new.internal')
+	})
+
+	test('hides the host field for a deployment target', async ({ page }) => {
+		// The override is external-only, so a deployment route never shows it.
+		await setMocks({
+			'route.get': { ok: true, result: sampleRoute },
+			'deployment.list': { ok: true, result: { items: [sampleDeployment] } }
+		})
+
+		await page.goto(editUrl)
+
+		await expect(page.locator('#input-host')).toHaveCount(0)
 	})
 
 	test('saves forward-auth config via route.createV2 and returns to the detail page', async ({ page }) => {
@@ -256,5 +324,68 @@ test.describe('route create — deployment picker', () => {
 		await page.locator('#input-target_deployment').click()
 		await pausedOption.click()
 		await expect(warning).toBeVisible()
+	})
+})
+
+test.describe('route create — host override', () => {
+	const createUrl = '/route/create?project=test-project'
+
+	async function selectLocationAndDomain (page) {
+		await page.goto(createUrl)
+		await page.locator('#input-location').click()
+		await page.getByRole('option', { name: 'gke' }).click()
+		await page.locator('#input-domain').click()
+		await page.getByRole('option', { name: 'example.com', exact: true }).click()
+	}
+
+	test('shows the host field for External server and sends config.host', async ({ page }) => {
+		await setMocks({
+			'domain.list': { ok: true, result: { items: [sampleDomain] } },
+			'route.createV2': { ok: true, result: {} }
+		})
+
+		await selectLocationAndDomain(page)
+
+		// Redirect has no upstream → no host field.
+		await page.locator('#input-target_prefix').click()
+		await page.getByRole('option', { name: 'Redirect', exact: true }).click()
+		await expect(page.locator('#input-host')).toHaveCount(0)
+
+		// External server → the host override field appears.
+		await page.locator('#input-target_prefix').click()
+		await page.getByRole('option', { name: 'External server (HTTP)', exact: true }).click()
+		await expect(page.locator('#input-host')).toBeVisible()
+
+		await page.locator('#input-target_value').fill('203.0.113.10:8080')
+		await page.locator('#input-host').fill('legacy.internal')
+		await page.getByRole('button', { name: 'Save' }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/route.createV2')
+		}).toBeTruthy()
+
+		const req = (await getRequestLog()).find((r) => r.path === '/route.createV2')
+		if (!req) throw new Error('expected a route.createV2 request')
+		const body = JSON.parse(req.body)
+		expect(body.target).toBe('http://203.0.113.10:8080')
+		expect(body.config.host).toBe('legacy.internal')
+	})
+
+	test('hides the host field for a deployment target', async ({ page }) => {
+		// The override is external-only (the api rejects host on a deployment
+		// target), so the field never appears for a deployment route.
+		await setMocks({
+			'domain.list': { ok: true, result: { items: [sampleDomain] } },
+			'deployment.list': { ok: true, result: { items: [sampleDeployment] } }
+		})
+
+		await selectLocationAndDomain(page)
+		await page.locator('#input-target_prefix').click()
+		await page.getByRole('option', { name: 'Deployment', exact: true }).click()
+		await page.locator('#input-target_deployment').click()
+		await page.getByRole('option', { name: 'web', exact: true }).click()
+
+		await expect(page.locator('#input-host')).toHaveCount(0)
 	})
 })


### PR DESCRIPTION
## What

Surface the new `RouteConfig.host` (upstream Host-header override) in the console.

- **Create + Edit** — a **Host header override** field, shown only for the **External server (`http://`)** target (the api rejects `host` on any other target type). Sent as `config.host`; the edit form seeds + round-trips it. Redirect/deployment targets hide it.
- **Detail** — a **Host header** spec row when set.
- **mock** — an external route with a host override; `route.get` resolves by domain/path so the detail/edit screens reflect the right route.

## Screenshots

**Create** (External server selected — host field under Advanced Settings):

![create](https://raw.githubusercontent.com/deploys-app/console/screenshots/282-create.png)

| Detail (Host header row) | Edit (host field seeded) |
| --- | --- |
| ![detail](https://raw.githubusercontent.com/deploys-app/console/screenshots/282-detail.png) | ![edit](https://raw.githubusercontent.com/deploys-app/console/screenshots/282-edit.png) |

## Tests

Adds Playwright coverage in `tests/route.spec.js`: detail row; edit seed+save (external); create shows+sends for External; redirect and deployment targets hide the field. `bun lint`, `bun check`, and all route specs green.

---
Pairs with **deploys-app/api#108** (Host header override).
