### PR TITLE
feat(scoped-token): per-project scoped tokens panel with revoke

### DIFF
--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -30,6 +30,7 @@ export const projectMenu: ProjectMenuItem[] = [
 	{ id: 'role', title: 'Roles', icon: 'fa-user-tag', link: '/role' },
 	{ id: 'role.users', title: 'Users', icon: 'fa-users', link: '/role/users' },
 	{ id: 'service-account', title: 'Service Accounts', icon: 'fa-user-lock', link: '/service-account' },
+	{ id: 'scoped-token', title: 'Scoped Tokens', icon: 'fa-user-clock', link: '/scoped-token' },
 	{ id: 'dropbox', title: 'Dropbox', icon: 'fa-box-open', link: '/dropbox' },
 	{ id: 'registry', title: 'Registry', icon: 'fa-warehouse-full', link: '/registry' },
 	{ id: 'github', title: 'GitHub', icon: 'fa-code-branch', link: '/github', preview: true },

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -818,6 +818,25 @@ const serviceAccounts: ServiceAccount[] = [
 	}
 ]
 
+// Active scoped (agent) tokens for the mock user. The token value is never
+// listed — only the non-secret handle + metadata.
+const scopedTokens = [
+	{
+		id: 'tok_a1b2c3d4e5',
+		label: 'claude-code:pr-42',
+		permissions: ['deployment.get', 'deployment.logs'],
+		createdAt: CREATED_AT,
+		expiresAt: new Date(Date.now() + 45 * 60 * 1000).toISOString()
+	},
+	{
+		id: 'tok_f6g7h8i9j0',
+		label: '',
+		permissions: ['dropbox.upload', 'site.publish'],
+		createdAt: CREATED_AT,
+		expiresAt: new Date(Date.now() + 12 * 60 * 1000).toISOString()
+	}
+]
+
 interface GithubLink {
 	repositoryId: number
 	repository: string
@@ -1136,6 +1155,8 @@ const handlers: Record<string, (args: any) => object> = {
 	// Effective grants for the mock user: the '*' wildcard grants everything, so
 	// all gated buttons (GuardedButton) render enabled by default offline.
 	'me.permissions': () => ok({ permissions: ['*'], admin: false }),
+	'me.listTokens': () => list(scopedTokens),
+	'me.revokeToken': () => ok({}),
 
 	'project.list': () => list(projects),
 	'project.get': (args) => ok(projects.find((p) => p.project === args?.project) ?? { ...projects[0], project: args?.project ?? 'acme' }),

--- a/src/routes/(auth)/(project)/scoped-token/+layout.ts
+++ b/src/routes/(auth)/(project)/scoped-token/+layout.ts
@@ -1,0 +1,8 @@
+import type { LayoutLoad } from './$types'
+
+export const load: LayoutLoad = () => {
+	return {
+		menu: 'scoped-token',
+		overrideRedirect: '/scoped-token'
+	}
+}

--- a/src/routes/(auth)/(project)/scoped-token/+page.svelte
+++ b/src/routes/(auth)/(project)/scoped-token/+page.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+	import type { PageData } from './$types'
+	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import * as modal from '$lib/modal'
+	import * as format from '$lib/format'
+	import api from '$lib/api'
+
+	const { data }: { data: PageData } = $props()
+
+	const project = $derived(data.project)
+	const tokens = $derived(data.tokens)
+	const error = $derived(data.error)
+
+	function revoke (id: string, label: string) {
+		modal.confirm({
+			title: `Revoke scoped token ${label || id}? Requests using it will be rejected immediately.`,
+			yes: 'Revoke',
+			callback: async () => {
+				const resp = await api.invoke('me.revokeToken', { project, id }, fetch)
+				if (!resp.ok) {
+					modal.error({ error: resp.error })
+					return
+				}
+				api.invalidate('me.listTokens')
+			}
+		})
+	}
+</script>
+
+<style>
+	.perm-chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem;
+	}
+	.perm-chip {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.1rem 0.5rem;
+		border-radius: 5px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		font-family: var(--ffml-mono);
+		background: hsl(var(--hsl-content) / 0.06);
+		color: hsl(var(--hsl-content) / 0.8);
+	}
+	.no-perms {
+		font-size: 0.8125rem;
+		color: hsl(var(--hsl-content) / 0.45);
+		font-style: italic;
+	}
+	.token-id {
+		font-family: var(--ffml-mono);
+		font-size: 0.8125rem;
+	}
+	.no-label {
+		color: hsl(var(--hsl-content) / 0.45);
+	}
+</style>
+
+<div class="page-head">
+	<div>
+		<h4><strong>Scoped Tokens</strong></h4>
+		<p class="page-sub">
+			{tokens.length} {tokens.length === 1 ? 'token' : 'tokens'} — your own short-lived, scope-limited agent credentials. Mint with <code>deploys me generate-token</code> or the MCP <code>me.generateToken</code>; revoke any here.
+		</p>
+	</div>
+</div>
+<div class="panel is-level-300">
+	<div class="table-container">
+		<table class="table is-variant-compact">
+			<thead>
+				<tr>
+					<th>ID</th>
+					<th>Label</th>
+					<th>Permissions</th>
+					<th>Expires</th>
+					<th>Created</th>
+					<th class="is-collapse is-align-right"></th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each tokens as it (it.id)}
+					<tr>
+						<td><span class="token-id">{it.id}</span></td>
+						<td>
+							{#if it.label}
+								{it.label}
+							{:else}
+								<span class="no-label">—</span>
+							{/if}
+						</td>
+						<td>
+							{#if it.permissions.length > 0}
+								<div class="perm-chips">
+									{#each it.permissions as p (p)}
+										<span class="perm-chip">{p}</span>
+									{/each}
+								</div>
+							{:else}
+								<span class="no-perms">none</span>
+							{/if}
+						</td>
+						<td>
+							<span class="cell-time" title={format.datetime(it.expiresAt)}>{format.fromNow(it.expiresAt) || '—'}</span>
+						</td>
+						<td>
+							<span class="cell-time" title={format.datetime(it.createdAt)}>{format.fromNow(it.createdAt) || '—'}</span>
+						</td>
+						<td>
+							<button class="icon-button" type="button" aria-label="Revoke" onclick={() => revoke(it.id, it.label)}>
+								<i class="fa-solid fa-trash-alt"></i>
+							</button>
+						</td>
+					</tr>
+				{/each}
+				<NoDataRow span={6} list={tokens} {error} icon="fa-user-clock" message="No active scoped tokens" hint="Scoped tokens are minted programmatically for agents and automation." />
+				<ErrorRow span={6} {error} />
+			</tbody>
+		</table>
+	</div>
+</div>

--- a/src/routes/(auth)/(project)/scoped-token/+page.ts
+++ b/src/routes/(auth)/(project)/scoped-token/+page.ts
@@ -1,0 +1,5 @@
+import { listLoad } from '$lib/loaders'
+
+// me.listTokens lists the caller's OWN active scoped tokens for the project
+// (auth-only, no permission). The token value is never returned.
+export const load = listLoad<Api.ScopedToken, 'tokens'>('me.listTokens', 'tokens')

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -30,6 +30,16 @@ declare namespace Api {
         items: T[]
     }
 
+    // A scoped (agent) token minted via me.generateToken. The token value is
+    // never returned by me.listTokens — only this non-secret metadata.
+    export interface ScopedToken {
+        id: string
+        label: string
+        permissions: string[]
+        createdAt: string
+        expiresAt: string
+    }
+
     export type ProjectQuota = {
         deployments: number
         deploymentMaxReplicas: number

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -114,6 +114,14 @@ export function defaultMocks () {
 			ok: true,
 			result: { items: [] }
 		},
+		'/me.listTokens': {
+			ok: true,
+			result: { items: [] }
+		},
+		'/me.revokeToken': {
+			ok: true,
+			result: {}
+		},
 		'/role.list': {
 			ok: true,
 			result: { items: [] }
@@ -277,6 +285,14 @@ export const sampleServiceAccount = {
 	description: 'used by ci',
 	createdAt: now,
 	createdBy: '[email protected]'
+}
+
+export const sampleScopedToken = {
+	id: 'tok_test123',
+	label: 'claude-code:pr-42',
+	permissions: ['deployment.get', 'deployment.logs'],
+	createdAt: now,
+	expiresAt: '2099-01-01T00:00:00Z'
 }
 
 export const sampleRole = {

--- a/tests/scoped-token.spec.js
+++ b/tests/scoped-token.spec.js
@@ -1,0 +1,102 @@
+import { test, expect, setMocks, getRequestLog } from './helpers.js'
+import { sampleScopedToken } from './fixtures/mocks.js'
+
+test.describe('scoped tokens', () => {
+	test('lists the caller\'s active scoped tokens', async ({ page }) => {
+		await setMocks({
+			'me.listTokens': { ok: true, result: { items: [sampleScopedToken] } }
+		})
+
+		await page.goto('/scoped-token?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Scoped Tokens' })).toBeVisible()
+		await expect(main.getByText('tok_test123')).toBeVisible()
+		await expect(main.getByText('claude-code:pr-42')).toBeVisible()
+		await expect(main.getByText('deployment.get')).toBeVisible()
+	})
+
+	test('empty state when there are no tokens', async ({ page }) => {
+		await page.goto('/scoped-token?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('No active scoped tokens')).toBeVisible()
+	})
+
+	test('surfaces an API error in the list', async ({ page }) => {
+		await setMocks({
+			'me.listTokens': { ok: false, error: { message: 'api: internal error' } }
+		})
+
+		await page.goto('/scoped-token?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText(/Something went wrong while loading this data/)).toBeVisible()
+		await expect(main.getByRole('button', { name: 'Try again' })).toBeVisible()
+	})
+
+	test('Try again recovers the list after a transient error', async ({ page }) => {
+		await setMocks({
+			'me.listTokens': { ok: false, error: { message: 'api: internal error' } }
+		})
+
+		await page.goto('/scoped-token?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText(/Something went wrong while loading this data/)).toBeVisible()
+
+		await setMocks({
+			'me.listTokens': { ok: true, result: { items: [sampleScopedToken] } }
+		})
+		await main.getByRole('button', { name: 'Try again' }).click()
+
+		await expect(main.getByText('tok_test123')).toBeVisible()
+		await expect(main.getByText(/Something went wrong while loading this data/)).toHaveCount(0)
+	})
+
+	test('shows a permission message when the list is forbidden', async ({ page }) => {
+		await setMocks({
+			'me.listTokens': { ok: false, error: { message: 'iam: forbidden' } }
+		})
+
+		await page.goto('/scoped-token?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText("You don't have permission to view data")).toBeVisible()
+	})
+
+	test('revoke confirms then calls me.revokeToken and refreshes', async ({ page }) => {
+		await setMocks({
+			'me.listTokens': { ok: true, result: { items: [sampleScopedToken] } },
+			'me.revokeToken': { ok: true, result: {} }
+		})
+
+		await page.goto('/scoped-token?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('tok_test123')).toBeVisible()
+
+		// After revoke, the list reloads to empty.
+		await setMocks({ 'me.listTokens': { ok: true, result: { items: [] } } })
+
+		await main.getByRole('button', { name: 'Revoke' }).click()
+		await page.locator('.swal2-confirm').click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/me.revokeToken' && JSON.parse(r.body || '{}').id === 'tok_test123')
+		}).toBe(true)
+
+		await expect(main.getByText('No active scoped tokens')).toBeVisible()
+	})
+
+	test('shows the API error in a modal when revoke fails', async ({ page }) => {
+		await setMocks({
+			'me.listTokens': { ok: true, result: { items: [sampleScopedToken] } },
+			'me.revokeToken': { ok: false, error: { message: 'api: internal error' } }
+		})
+
+		await page.goto('/scoped-token?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await main.getByRole('button', { name: 'Revoke' }).click()
+		await page.locator('.swal2-confirm').click()
+
+		await expect(page.locator('.swal2-popup')).toBeVisible()
+		await expect(page.locator('.swal2-html-container')).toContainText('api: internal error')
+	})
+})


### PR DESCRIPTION
Console surface for **SPEC-agent-identity** (A5). A per-project **Scoped Tokens** page so operators can see and kill their own short-lived agent credentials.

- New `(auth)/(project)/scoped-token` route (`+layout.ts`/`+page.ts`/`+page.svelte`): lists the caller's active scoped tokens — id, label, permission chips, expiry, created — via `me.listTokens`, with an inline **revoke** (`modal.confirm` → `me.revokeToken` → `invalidate`).
- **Auth-only, no permission gate** (intentional): `me.listTokens`/`revokeToken` act on the caller's *own* tokens server-side, so the page uses a plain button, not `GuardedButton`. The **token value is never shown** (the list returns only the non-secret id + metadata).
- Nav entry, `Api.ScopedToken` type, dev mock + test default mock + `sampleScopedToken`.
- `tests/scoped-token.spec.js` — 7 tests: list, empty, list API error + recover, forbidden, revoke confirm→call→refresh, revoke error modal. `bun check` + `bun lint` clean; all tests pass.

| Light | Dark |
| --- | --- |
| ![light](https://raw.githubusercontent.com/deploys-app/console/screenshots/283-light.png) | ![dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/283-dark.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9FhPEapaKr4VugQBEdisj