### PR TITLE
feat(audit-log): show agent (scoped-token) attribution label

### DIFF
--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -941,11 +941,14 @@ const auditLogItems = (() => {
 	const items = []
 	for (let i = 0; i < 137; i++) {
 		const s = samples[i % samples.length]
+		const ch = channels[i % channels.length]
 		items.push({
 			id: 1042 - i,
 			resource: { ...s.resource, locationId: LOCATION_ID },
-			actor: { email: USER_EMAIL, type: 'User' },
-			channel: channels[i % channels.length],
+			// mcp-channel rows are agent actions: attribute the agent session via
+			// the scoped-token label (the principal is still the minter).
+			actor: { email: USER_EMAIL, type: 'User', label: ch === 'mcp' ? 'claude-code:pr-42' : '' },
+			channel: ch,
 			action: s.action,
 			outcome: i % 11 === 0 ? 'failure' : 'success',
 			detail: `${s.detail} (#${1042 - i})`,

--- a/src/routes/(auth)/(project)/+page.svelte
+++ b/src/routes/(auth)/(project)/+page.svelte
@@ -250,6 +250,10 @@
 							</div>
 							<div class="activity-foot">
 								<span class="actor">{it.actor.email}</span>
+								{#if it.actor.label}
+									<span class="foot-sep">·</span>
+									<span class="agent" title="agent session (scoped token)"><i class="fa-solid fa-robot"></i>{it.actor.label}</span>
+								{/if}
 								<span class="foot-sep">·</span>
 								<time class="activity-time">{format.datetime(it.createdAt)}</time>
 							</div>
@@ -494,4 +498,14 @@
 	.foot-sep {
 		opacity: 0.5;
 	}
+
+	.agent {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		font-family: var(--font-family-mono, ui-monospace, monospace);
+		color: hsl(var(--hsl-primary));
+		white-space: nowrap;
+	}
+	.agent i { font-size: 0.6rem; opacity: 0.8; }
 </style>

--- a/src/routes/(auth)/(project)/audit-log/+page.svelte
+++ b/src/routes/(auth)/(project)/audit-log/+page.svelte
@@ -361,6 +361,21 @@
 		vertical-align: middle;
 	}
 
+	.agent-tag {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+		margin-left: 0.25rem;
+		padding: 0.05rem 0.4rem;
+		border-radius: 4px;
+		font-size: 0.75rem;
+		font-family: var(--font-family-mono, ui-monospace, monospace);
+		background: hsl(var(--hsl-primary) / 0.12);
+		color: hsl(var(--hsl-primary));
+		vertical-align: middle;
+	}
+	.agent-tag i { font-size: 0.62rem; opacity: 0.8; }
+
 	.loadmore-row > td {
 		padding: 0;
 	}
@@ -485,6 +500,11 @@
 							{it.actor.email}
 							{#if it.actor.type === 'ServiceAccount'}
 								<span class="actor-tag">service account</span>
+							{/if}
+							{#if it.actor.label}
+								<span class="agent-tag" title="agent session (scoped token)">
+									<i class="fa-solid fa-robot"></i>{it.actor.label}
+								</span>
 							{/if}
 						</td>
 						<td><ChannelBadge channel={it.channel} /></td>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -539,6 +539,11 @@ declare namespace Api {
     export type AuditLogActor = {
         email: string
         type: AuditActorType
+        // Attribution tag of the scoped (agent) token the action was made under
+        // (e.g. "claude-code:pr-42"); empty/absent for non-agent actions. The
+        // principal (email/type) is still the minter — the label only names the
+        // agent session.
+        label?: string
     }
 
     export type AuditLogResource = {

--- a/tests/audit-log.spec.js
+++ b/tests/audit-log.spec.js
@@ -1,5 +1,5 @@
 import { test, expect, setMocks } from './helpers.js'
-import { sampleAuditLogItem } from './fixtures/mocks.js'
+import { sampleAuditLogItem, sampleAuditLogItemAgent } from './fixtures/mocks.js'
 
 test.describe('audit log', () => {
 	test('lists audit log entries', async ({ page }) => {
@@ -18,6 +18,38 @@ test.describe('audit log', () => {
 		await expect(main.getByText('[email protected]')).toBeVisible()
 		await expect(main.getByRole('cell', { name: /Success/ })).toBeVisible()
 		await expect(main.getByText('deployed revision 1')).toBeVisible()
+	})
+
+	test('shows the agent label for a scoped-token action, keeping the principal', async ({ page }) => {
+		await setMocks({
+			'auditLog.list': {
+				ok: true,
+				result: { items: [sampleAuditLogItemAgent] }
+			}
+		})
+
+		await page.goto('/audit-log?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		// The minting principal is still shown...
+		await expect(main.getByText('[email protected]')).toBeVisible()
+		// ...alongside the agent-session label from the scoped token.
+		await expect(main.getByText('claude-code:pr-42')).toBeVisible()
+	})
+
+	test('no agent label on a plain (non-scoped) action', async ({ page }) => {
+		await setMocks({
+			'auditLog.list': {
+				ok: true,
+				result: { items: [sampleAuditLogItem] }
+			}
+		})
+
+		await page.goto('/audit-log?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('[email protected]')).toBeVisible()
+		await expect(main.getByText('claude-code:pr-42')).toHaveCount(0)
 	})
 
 	test('empty state when no entries', async ({ page }) => {

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -408,3 +408,25 @@ export const sampleAuditLogItem = {
 	createdAt: now
 }
 
+// An action made through a scoped (agent) token: the principal is still the
+// minter; the agent session is named by actor.label.
+export const sampleAuditLogItemAgent = {
+	id: 2,
+	resource: {
+		type: 'deployment',
+		id: 'd-2',
+		name: 'web',
+		locationId: 'gke'
+	},
+	actor: {
+		email: '[email protected]',
+		type: 'User',
+		label: 'claude-code:pr-42'
+	},
+	channel: 'mcp',
+	action: 'deployment.deploy',
+	outcome: 'success',
+	detail: 'deployed revision 2',
+	createdAt: now
+}
+


### PR DESCRIPTION
Follow-up to the agent-identity feature. The `auditLog.list` RPC now returns `actor.label` (the scoped-token agent-session tag); this surfaces it in the console.

- **Audit Logs table** — the Actor cell shows an agent chip (robot icon + label) when `actor.label` is set, alongside the existing email + service-account tag. The minting principal is never replaced — the label only *names the agent session*.
- **Dashboard recent-activity** — a compact agent marker in the activity footer, for the same attribution at a glance.
- `Api.AuditLogActor` gains the optional `label`; both renders are gated on it (non-agent rows unchanged). Labels also render on the audit log's infinite-scroll pages (same item shape). No new filter — `auditLog.list` has no server-side label filter, so this is render-only.
- Dev mock labels `mcp`-channel rows; `sampleAuditLogItemAgent` fixture + audit-log tests (label shown with principal; absent on a plain action). `bun check` + `bun lint` clean; audit-log + project specs pass.

### Audit Logs page
| Light | Dark |
| --- | --- |
| ![audit light](https://raw.githubusercontent.com/deploys-app/console/screenshots/284-audit-light.png) | ![audit dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/284-audit-dark.png) |

### Dashboard recent activity
![dashboard](https://raw.githubusercontent.com/deploys-app/console/screenshots/284-dashboard.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9FhPEapaKr4VugQBEdisj