### PR TITLE
fix(deployment): native dropdown for the detail tabs on mobile

### DIFF
--- a/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
@@ -69,9 +69,9 @@
      size the implicit column to the children's max-content and push the
      page past the viewport on narrow / iPhone-sized screens. -->
 <div class="panel is-level-300 grid grid-cols-1 gap-6">
-	<div class="tabs is-variant-underline w-full flex-col lg:flex-row">
+	<div class="tabs is-variant-underline w-full overflow-x-auto">
 		{#each tabs as t (t.path)}
-			<a class="tab-button" class:is-active={$page.url.pathname === t.path} href={tabHref(t.path)}>
+			<a class="tab-button shrink-0 whitespace-nowrap" class:is-active={$page.url.pathname === t.path} href={tabHref(t.path)}>
 				{t.label}
 			</a>
 		{/each}

--- a/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Header from '../_components/Header.svelte'
 	import { page } from '$app/stores'
+	import { goto } from '$app/navigation'
 	import { onMount } from 'svelte'
 	import api from '$lib/api'
 	import type { LayoutData } from './$types'
@@ -69,9 +70,23 @@
      size the implicit column to the children's max-content and push the
      page past the viewport on narrow / iPhone-sized screens. -->
 <div class="panel is-level-300 grid grid-cols-1 gap-6">
-	<div class="tabs is-variant-underline w-full overflow-x-auto">
+	<!-- Mobile (< lg): native dropdown — keeps the section content above the
+	     fold on narrow viewports where 7 stacked or side-scrolling tabs would
+	     dominate. Desktop (lg+): the underlined tab row. -->
+	<div class="select lg:hidden">
+		<select
+			aria-label="Section"
+			value={$page.url.pathname}
+			onchange={(e) => goto(tabHref((e.currentTarget as HTMLSelectElement).value))}
+		>
+			{#each tabs as t (t.path)}
+				<option value={t.path}>{t.label}</option>
+			{/each}
+		</select>
+	</div>
+	<div class="tabs is-variant-underline w-full hidden lg:flex">
 		{#each tabs as t (t.path)}
-			<a class="tab-button shrink-0 whitespace-nowrap" class:is-active={$page.url.pathname === t.path} href={tabHref(t.path)}>
+			<a class="tab-button" class:is-active={$page.url.pathname === t.path} href={tabHref(t.path)}>
 				{t.label}
 			</a>
 		{/each}


### PR DESCRIPTION
## Summary

Below the `lg` breakpoint the deployment detail tab bar stacked vertically, so the seven tabs (Metrics / Details / Revisions / Routes / Logs / Errors / Events) pushed every section below the fold on phone-sized viewports.

Swap the tab row for a native `<select>` on mobile — the platform's compact picker — and keep the underlined tab row at `lg`+.

| before (mobile) | after (mobile) | after (desktop) |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/285-before.png) | ![mobile](https://raw.githubusercontent.com/deploys-app/console/screenshots/285-after-mobile.png) | ![desktop](https://raw.githubusercontent.com/deploys-app/console/screenshots/285-after-desktop.png) |

(Mobile captured at 390×844 / iPhone 14, desktop at 1280×800.)

## Test plan

- [x] `bun lint` passes
- [x] `bun check` passes
- [x] Verified at 390×844 — dropdown picker navigates between sections; section content visible above the fold
- [x] Verified at 1280×800 — underlined tab row unchanged from before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bJ3W6cVGHE6Zav4apxS7y