### PR TITLE
deployment/env-group: scope list views to non-sensitive fields

### DIFF
--- a/src/lib/components/DeploymentStatusIcon.svelte
+++ b/src/lib/components/DeploymentStatusIcon.svelte
@@ -5,7 +5,11 @@
 	interface Props {
 		action: Api.DeploymentAction
 		status: Api.DeploymentStatus
-		url: string
+		// The signed pod-status URL. Optional: deployment.list omits it (it's a
+		// bearer capability gated behind deployment.get), so the list view passes
+		// no url and the icon resolves from props alone without polling. The
+		// detail page (deployment.get) supplies it for live pod-readiness.
+		url?: string
 		type: Api.DeploymentType
 	}
 
@@ -32,8 +36,9 @@
 	// Pod readiness only changes the icon for a running (non-paused) success
 	// deployment; every other state is resolved from props alone, so there's no
 	// reason to hit statusUrl for it. Static deployments have no pods (served by
-	// the static-gateway, no statusUrl), so they never poll either.
-	const needsPodStatus = $derived(status === 'success' && action !== 'pause' && type !== 'Static')
+	// the static-gateway, no statusUrl), so they never poll either. A missing url
+	// (the deployment.list view) also can't poll — it resolves from props alone.
+	const needsPodStatus = $derived(!!url && status === 'success' && action !== 'pause' && type !== 'Static')
 
 	function getIconClass (): string {
 		if (status !== 'success') {
@@ -46,6 +51,13 @@
 
 		if (type === 'Static') {
 			// No pods to wait on — a successful release is simply done.
+			return 'fa-solid fa-check-circle text-positive/80'
+		}
+
+		if (!url) {
+			// No statusUrl (the deployment.list view omits the signed JWT): we
+			// can't poll live pod readiness, so resolve a successful deployment to
+			// the plain success icon rather than spin forever.
 			return 'fa-solid fa-check-circle text-positive/80'
 		}
 
@@ -80,7 +92,7 @@
 
 	async function poll () {
 		clearTimer()
-		if (destroyed) {
+		if (destroyed || !url) {
 			return
 		}
 

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -27,6 +27,19 @@ const err = (message: string): { ok: false, error: { message: string } } => ({ o
 
 const list = <T>(items: T[]) => ok({ items })
 
+// deployment.list returns a reduced, non-sensitive projection (Api.DeploymentListItem):
+// it omits env + the signed log JWTs (statusUrl/logUrl/…) + the other sensitive
+// fields. Mirror that here so the mock list view exercises the real post-change
+// behaviour — e.g. the status icon resolves from props without a statusUrl to poll.
+const DEPLOYMENT_LIST_OMIT = new Set([
+	'env', 'envGroups', 'command', 'args', 'workloadIdentity', 'pullSecret',
+	'disk', 'mountData', 'nodePort', 'annotations', 'access', 'sidecars',
+	'internalUrl', 'logUrl', 'eventUrl', 'podsUrl', 'statusUrl', 'errorsUrl',
+	'address', 'internalAddress'
+])
+const toDeploymentListItem = (d: Record<string, unknown>): Record<string, unknown> =>
+	Object.fromEntries(Object.entries(d).filter(([k]) => !DEPLOYMENT_LIST_OMIT.has(k)))
+
 /**
  * Synthesize a metric line: a single named series of [unixSeconds, value] points.
  */
@@ -1267,7 +1280,7 @@ const handlers: Record<string, (args: any) => object> = {
 	'location.list': () => list(locations),
 	'location.get': (args) => ok(locations.find((l) => l.id === args?.location) ?? locations[0]),
 
-	'deployment.list': () => list(deployments),
+	'deployment.list': () => list(deployments.map(toDeploymentListItem)),
 	// revision > 0 returns that revision's historical spec (like the real
 	// deployment.get), with per-revision differences so the rollback modal's
 	// config diff has something to show.
@@ -1841,7 +1854,15 @@ const handlers: Record<string, (args: any) => object> = {
 	'workloadIdentity.create': () => ok({}),
 	'workloadIdentity.delete': () => ok({}),
 
-	'envGroup.list': () => list(envGroups),
+	// envGroup.list returns metadata + envCount only (Api.EnvGroupListItem); the
+	// values map lives behind envGroup.get.
+	'envGroup.list': () => list(envGroups.map((g) => ({
+		project: g.project,
+		name: g.name,
+		envCount: Object.keys(g.env ?? {}).length,
+		createdAt: g.createdAt,
+		createdBy: g.createdBy
+	}))),
 	'envGroup.get': (args) => ok({ ...envGroups[0], name: args?.name ?? 'shared' }),
 	'envGroup.create': () => ok({}),
 	'envGroup.update': () => ok({}),

--- a/src/routes/(auth)/(project)/deployment/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/+page.svelte
@@ -52,7 +52,7 @@
 	 * the action has to be checked first — otherwise a deployment being torn down
 	 * would mislabel as "Deploying".
 	 */
-	function statusPill (it: Api.Deployment): { label: string, tone: string } | null {
+	function statusPill (it: Api.DeploymentListItem): { label: string, tone: string } | null {
 		if (it.action === 'delete') {
 			return { label: 'Deleting', tone: 'negative' }
 		}
@@ -131,7 +131,11 @@
 						<td>
 							<div style="display:flex; align-items:flex-start;">
 								<div style="padding-top:0.15rem;">
-									<DeploymentStatusIcon action={it.action} status={it.status} url={it.statusUrl} type={it.type} />
+									<!-- No url: deployment.list omits the signed statusUrl JWT (it's a
+								     bearer capability gated behind deployment.get/deployment.logs), so
+								     the list icon shows the stored status without live pod-readiness
+								     polling. The detail page (deployment.get) still polls. -->
+								<DeploymentStatusIcon action={it.action} status={it.status} type={it.type} />
 								</div>
 								<div class="cell-stack">
 									<div class="cell-line">

--- a/src/routes/(auth)/(project)/deployment/+page.ts
+++ b/src/routes/(auth)/(project)/deployment/+page.ts
@@ -1,3 +1,3 @@
 import { listLoad } from '$lib/loaders'
 
-export const load = listLoad<Api.Deployment, 'deployments'>('deployment.list', 'deployments')
+export const load = listLoad<Api.DeploymentListItem, 'deployments'>('deployment.list', 'deployments')

--- a/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
@@ -44,7 +44,7 @@
 
 	let disks = $state<Api.Disk[]>([])
 
-	let envGroups = $state<Api.EnvGroup[]>([])
+	let envGroups = $state<Api.EnvGroupListItem[]>([])
 
 	const form = $state({
 		location: deployment?.location || '',
@@ -205,7 +205,7 @@
 	}
 
 	async function fetchEnvGroups () {
-		const resp = await api.invoke<Api.List<Api.EnvGroup>>('envGroup.list', { project }, fetch)
+		const resp = await api.invoke<Api.List<Api.EnvGroupListItem>>('envGroup.list', { project }, fetch)
 		if (!resp.ok) {
 			if (resp.error?.forbidden) {
 				permission.envGroups = false
@@ -252,10 +252,16 @@
 
 	let envGroupModal = $state<EnvGroupModal | null>(null)
 
-	function viewEnvGroup (name: string) {
-		const g = envGroupByName.get(name)
-		if (!g) return
-		envGroupModal?.open(g)
+	// envGroup.list is a non-sensitive index (names + count, no values), so fetch
+	// the full group on demand to preview its variables. Reading the values
+	// requires envgroup.get — a list-only caller gets a forbidden error here.
+	async function viewEnvGroup (name: string) {
+		const resp = await api.invoke<Api.EnvGroup>('envGroup.get', { project, name }, fetch)
+		if (!resp.ok) {
+			modal.error({ error: resp.error })
+			return
+		}
+		envGroupModal?.open(resp.result)
 	}
 
 	function convertSidecars () {

--- a/src/routes/(auth)/(project)/env-group/+page.svelte
+++ b/src/routes/(auth)/(project)/env-group/+page.svelte
@@ -29,7 +29,7 @@
 				{it.name}
 			</a>
 		</td>
-		<td><span class="count-pill"><i class="fa-solid fa-list" aria-hidden="true"></i>{Object.keys(it.env ?? {}).length}</span></td>
+		<td><span class="count-pill"><i class="fa-solid fa-list" aria-hidden="true"></i>{it.envCount}</span></td>
 		<td>
 			<span class="cell-time" title={format.datetime(it.createdAt)}>{format.fromNow(it.createdAt) || '—'}</span>
 		</td>

--- a/src/routes/(auth)/(project)/env-group/+page.ts
+++ b/src/routes/(auth)/(project)/env-group/+page.ts
@@ -1,3 +1,3 @@
 import { listLoad } from '$lib/loaders'
 
-export const load = listLoad<Api.EnvGroup, 'envGroups'>('envGroup.list', 'envGroups')
+export const load = listLoad<Api.EnvGroupListItem, 'envGroups'>('envGroup.list', 'envGroups')

--- a/src/routes/(auth)/(project)/github/workflow/+page.ts
+++ b/src/routes/(auth)/(project)/github/workflow/+page.ts
@@ -8,7 +8,7 @@ export const load: PageLoad = async ({ parent, url, fetch }) => {
 	const [links, locations, envGroups, pullSecrets, githubPullRole] = await Promise.all([
 		api.invoke<Api.List<Api.GithubLink>>('github.list', { project }, fetch),
 		api.invoke<Api.List<Api.Location>>('location.list', { project }, fetch),
-		api.invoke<Api.List<Api.EnvGroup>>('envGroup.list', { project }, fetch),
+		api.invoke<Api.List<Api.EnvGroupListItem>>('envGroup.list', { project }, fetch),
 		// No location => every location's pull secrets; the generator filters by
 		// the selected location client-side.
 		api.invoke<Api.List<Api.PullSecret>>('pullSecret.list', { project }, fetch),

--- a/src/routes/(auth)/(project)/route/create/+page.svelte
+++ b/src/routes/(auth)/(project)/route/create/+page.svelte
@@ -76,7 +76,7 @@
 		deployments = []
 		form.targetValue = ''
 
-		const resp = await api.invoke<Api.List<Api.Deployment>>('deployment.list', { project }, fetch)
+		const resp = await api.invoke<Api.List<Api.DeploymentListItem>>('deployment.list', { project }, fetch)
 		if (!resp.ok) {
 			modal.error({ error: resp.error })
 			return

--- a/src/routes/(auth)/(project)/route/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/route/edit/+page.svelte
@@ -113,7 +113,7 @@
 
 	async function fetchDeployments () {
 		deployments = []
-		const resp = await api.invoke<Api.List<Api.Deployment>>('deployment.list', { project }, fetch)
+		const resp = await api.invoke<Api.List<Api.DeploymentListItem>>('deployment.list', { project }, fetch)
 		if (!resp.ok) {
 			modal.error({ error: resp.error })
 			return

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -252,6 +252,17 @@ declare namespace Api {
         createdBy: string
     }
 
+    // Reduced projection returned by envGroup.list (the full env map requires
+    // envGroup.get). An env group is a pure secret store, so the list carries
+    // only metadata + envCount (the number of variables) — never the values.
+    export type EnvGroupListItem = {
+        project: string
+        name: string
+        envCount: number
+        createdAt: string
+        createdBy: string
+    }
+
     export type MountData = {
         [key: string]: string
     }
@@ -378,6 +389,41 @@ declare namespace Api {
         errorsUrl: string
         address: string
         internalAddress: string
+        status: DeploymentStatus
+        action: DeploymentAction
+        allocatedPrice: number
+        createdAt: string
+        createdBy: string
+        successAt: string
+        ttl: number
+        expiresAt: string
+    }
+
+    // Reduced projection returned by deployment.list (a strict subset of
+    // Deployment with identical field names). It deliberately omits every
+    // sensitive field (env, mountData, command, args, annotations,
+    // workloadIdentity, pullSecret, disk, access, sidecars) AND the signed log
+    // JWTs (logUrl/eventUrl/podsUrl/statusUrl/errorsUrl) and in-cluster
+    // address/URL — those are bearer capabilities and require deployment.get.
+    // The security boundary lives in the type: a list item cannot carry a secret.
+    export type DeploymentListItem = {
+        project: string
+        location: string
+        name: string
+        type: DeploymentType
+        revision: number
+        image: string
+        site?: string
+        siteManifestDigest?: string
+        minReplicas: number
+        maxReplicas: number
+        schedule: string
+        port: number
+        protocol: DeploymentProtocol
+        internal: boolean
+        resources: DeploymentResource
+        url: string
+        releaseUrl?: string
         status: DeploymentStatus
         action: DeploymentAction
         allocatedPrice: number

--- a/tests/deployment.spec.js
+++ b/tests/deployment.spec.js
@@ -254,6 +254,7 @@ test.describe('deployment deploy — env groups', () => {
 				result: { ...sampleDeployment, envGroups: ['shared-config'] }
 			},
 			'location.get': { ok: true, result: defaultLocation },
+			// envGroup.list is now a non-sensitive index (name + count, no values).
 			'envGroup.list': {
 				ok: true,
 				result: {
@@ -261,11 +262,23 @@ test.describe('deployment deploy — env groups', () => {
 						{
 							project: 'test-project',
 							name: 'shared-config',
-							env: { LOG_LEVEL: 'info', REGION: 'apac' },
+							envCount: 2,
 							createdAt: '2024-01-01T00:00:00Z',
 							createdBy: '[email protected]'
 						}
 					]
+				}
+			},
+			// The View popup fetches the values via envGroup.get (requires
+			// envgroup.get), not from the list item.
+			'envGroup.get': {
+				ok: true,
+				result: {
+					project: 'test-project',
+					name: 'shared-config',
+					env: { LOG_LEVEL: 'info', REGION: 'apac' },
+					createdAt: '2024-01-01T00:00:00Z',
+					createdBy: '[email protected]'
 				}
 			}
 		})

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -316,6 +316,10 @@ export const sampleWorkloadIdentity = {
 export const sampleEnvGroup = {
 	project: 'test-project',
 	name: 'shared-config',
+	// envCount is the list projection's count (EnvGroupListItem); env is the full
+	// values map returned by envGroup.get. Both are kept on the shared fixture so
+	// it serves list (count pill) and get (values) without two fixtures.
+	envCount: 2,
 	env: {
 		LOG_LEVEL: 'info',
 		FEATURE_FLAG: 'true'


### PR DESCRIPTION
## What

Tracks `SPEC-list-field-scoping.md` in the console. `deployment.list` and `envGroup.list` now return **reduced projections** (no `env`, no secrets, no signed log URLs), so the console reads only the fields the list actually carries.

## Changes

- **Types** — add `Api.DeploymentListItem` (a strict subset of `Api.Deployment`) and `Api.EnvGroupListItem` (metadata + `envCount`); point the deployment and env-group list `listLoad` loaders at them. `statusPill` narrows to the list type.
- **`DeploymentStatusIcon`** — `url` is now optional. `deployment.list` omits the signed `statusUrl` (a bearer capability gated behind `deployment.get`/`deployment.logs`), so the list passes **no** url and the icon resolves from the stored `status` without polling live pod readiness. The **detail page** (`deployment.get`) still supplies `statusUrl` and polls as before.
- **Env-group list** — the variable-count pill reads `it.envCount` (server-supplied) instead of `Object.keys(it.env)`; the list no longer ships `env`.
- **Mock + test fixture** — `deployment.list` projects out the sensitive fields (so the offline mock exercises the real degraded behaviour); `envGroup.list` returns `envCount`; `sampleEnvGroup` gains `envCount`.

## Behaviour note

The deployment **list** status icon no longer reflects *live pod readiness* (it can't, without the `statusUrl` capability) — it shows the stored deploy status (e.g. a successful deployment is a green check). Live pod-readiness detail remains on the **detail** page, which uses `deployment.get`. This is the intended security trade-off: the list was handing a signed log-service token to anyone with `deployment.list`.

## Verification

`bun check` and `bun lint` clean. `tests/deployment.spec.js` + `tests/env-group.spec.js` (27 tests) pass.

## Screenshots (offline mock)

Both list pages render correctly from the reduced projections — the deployment list resolves every status icon from props alone (no `statusUrl`), and the env-group count pill reads `envCount`.

| Deployment list | Env-group list |
| --- | --- |
| ![deployment list](https://raw.githubusercontent.com/deploys-app/console/screenshots/286-deployment-list.png) | ![env-group list](https://raw.githubusercontent.com/deploys-app/console/screenshots/286-env-group-list.png) |

(The change is visually transparent in the offline mock: its `success` deployments are all fully-ready, so the only place the live warning-triangle previously appeared — a running-but-not-all-pods-ready deployment — isn't simulated. Shown is the after state.)

## Depends on

api#110 (types) + apiserver#202 (the wire change). The runtime degradation is forward-compatible: once apiserver#202 ships, `statusUrl` is absent from `list` regardless of this PR, so this must ship with/before it.