### PR TITLE
fix(deployment): make detail-page tables usable on mobile

### DIFF
--- a/src/lib/deployment/HistoryLogs.svelte
+++ b/src/lib/deployment/HistoryLogs.svelte
@@ -195,6 +195,31 @@
 		.log-row { grid-template-columns: [time] 2.75rem [mark] 2px [pod] 6.5rem [msg] 1fr; column-gap: 0.4rem; padding: 0.125rem 0.5rem; font-size: 0.75rem; }
 		.log-filter__input { width: 6rem; }
 	}
+
+	/* Phones: a 6.5rem pod chip + time leaves the message too narrow to read, and
+	   the rail's filter + range pills + Refresh overflow the shell. Stack the row
+	   (time · pod over a full-width message) and let the rail actions wrap onto
+	   their own full-width line. */
+	@media (max-width: 640px) {
+		.log-row {
+			grid-template-columns: 2px auto minmax(0, 1fr);
+			grid-template-areas:
+				'mark time pod'
+				'mark msg  msg';
+			column-gap: 0.5rem;
+			row-gap: 0.1rem;
+			padding: 0.3rem 0.75rem;
+			align-items: center;
+		}
+		.log-row__mark { grid-area: mark; }
+		.log-row__time { grid-area: time; text-align: left; padding-top: 0; }
+		.log-row__pod  { grid-area: pod; justify-self: start; }
+		.log-row__msg  { grid-area: msg; }
+
+		.log-rail__actions { width: 100%; margin-left: 0; flex-wrap: wrap; }
+		.log-filter { flex: 1 1 100%; }
+		.log-filter__input { flex: 1; width: auto; }
+	}
 </style>
 
 <div class="log-shell">

--- a/src/lib/deployment/LiveLogs.svelte
+++ b/src/lib/deployment/LiveLogs.svelte
@@ -246,6 +246,31 @@
 		.log-row { grid-template-columns: [time] 2.75rem [mark] 2px [pod] 6.5rem [msg] 1fr; column-gap: 0.4rem; padding: 0.125rem 0.5rem; font-size: 0.75rem; }
 		.log-filter__input { width: 6rem; }
 	}
+
+	/* Phones: a 6.5rem pod chip + time leaves the message too narrow to read, and
+	   the rail's filter + Pause/Clear/Raw overflow the shell (which clips them, so
+	   Clear/Raw become unreachable). Stack the row (time · pod over a full-width
+	   message) and let the rail actions wrap onto their own full-width line. */
+	@media (max-width: 640px) {
+		.log-row {
+			grid-template-columns: 2px auto minmax(0, 1fr);
+			grid-template-areas:
+				'mark time pod'
+				'mark msg  msg';
+			column-gap: 0.5rem;
+			row-gap: 0.1rem;
+			padding: 0.3rem 0.75rem;
+			align-items: center;
+		}
+		.log-row__mark { grid-area: mark; }
+		.log-row__time { grid-area: time; text-align: left; padding-top: 0; }
+		.log-row__pod  { grid-area: pod; justify-self: start; }
+		.log-row__msg  { grid-area: msg; }
+
+		.log-rail__actions { width: 100%; margin-left: 0; flex-wrap: wrap; }
+		.log-filter { flex: 1 1 100%; }
+		.log-filter__input { flex: 1; width: auto; }
+	}
 </style>
 
 <div class="log-shell">

--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -441,6 +441,41 @@
 		border-color: hsl(var(--hsl-content) / 0.2);
 	}
 
+	/* Phones: the fixed 10rem label column crushes the value into a sliver that
+	   breaks mid-word (e.g. "registr y.deplo ys.app"). Stack each spec — label
+	   (with its copy/extend control) on top, value on its own full-width line. */
+	@media (max-width: 640px) {
+		.spec {
+			grid-template-columns: minmax(0, 1fr) auto;
+			grid-template-areas:
+				'label copy'
+				'value value';
+			column-gap: 0.5rem;
+			row-gap: 0.15rem;
+			align-items: center;
+			padding: 0.4rem 0;
+		}
+		.spec > :nth-child(1) { grid-area: label; }
+		.spec > :nth-child(2) { grid-area: value; min-width: 0; }
+		.spec > :nth-child(3) { grid-area: copy; justify-self: end; align-self: center; }
+
+		/* env / mount key-value list: stack key above value so a long key can't
+		   starve the value (and pre-formatted mount data can scroll, not clip).
+		   The 1.6rem zebra pitch no longer lines up with the taller stacked rows,
+		   so drop it; the value's bottom border still separates entries. */
+		.kv-list { grid-template-columns: 1fr; background: none; }
+		.kv-list__key {
+			border-right: none;
+			border-bottom: none;
+			overflow-wrap: anywhere;
+			padding-bottom: 0.1rem;
+		}
+		.kv-list__val {
+			padding-top: 0;
+			overflow-x: auto;
+		}
+	}
+
 </style>
 
 <!-- ─── DETAILS shell ─── -->

--- a/src/routes/(auth)/(project)/deployment/(detail)/events/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/events/+page.svelte
@@ -410,6 +410,28 @@
 			font-size: 0.75rem;
 		}
 	}
+
+	/* Phones: the four fixed columns starve the message column to a few px,
+	   forcing it to wrap one glyph per line. Stack instead — a header line
+	   (time · type · reason) over a full-width message, with the severity bar
+	   spanning both. */
+	@media (max-width: 640px) {
+		.event-row {
+			grid-template-columns: 2px auto auto minmax(0, 1fr);
+			grid-template-areas:
+				'mark time type reason'
+				'mark msg  msg  msg';
+			column-gap: 0.5rem;
+			row-gap: 0.2rem;
+			padding: 0.5rem 0.85rem;
+			align-items: center;
+		}
+		.event-row__mark   { grid-area: mark; }
+		.event-row__time   { grid-area: time; text-align: left; padding-top: 0; }
+		.event-row__type   { grid-area: type; }
+		.event-row__reason { grid-area: reason; padding-top: 0; }
+		.event-row__msg    { grid-area: msg; }
+	}
 </style>
 
 <DeploymentPodErrors

--- a/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/revision/+page.svelte
@@ -506,8 +506,8 @@
 		.rev-row {
 			grid-template-columns:
 				[mark]  3px
-				[rev]   3.5rem
-				[image] 1fr
+				[rev]   auto
+				[image] minmax(0, 1fr)
 				[act]   auto;
 			grid-template-areas: 'mark rev image act'
 								 'mark meta meta act';
@@ -516,6 +516,39 @@
 		}
 		.rev-row__meta { grid-column: 2 / 4; align-items: flex-start; }
 		.rev-row__image { direction: ltr; }
+	}
+
+	/* Phones: the rev cell (#7 + Active tag), the image and the Rollback button
+	   can't share one line — at a fixed rev width the Active tag overran the image
+	   and overlapped it. Drop to a card: rev + action on top, then the image and
+	   the meta each on their own full-width line. The image can now show in full
+	   instead of being truncated to a sliver. */
+	@media (max-width: 640px) {
+		.rev-row {
+			grid-template-columns: 3px minmax(0, 1fr) auto;
+			grid-template-areas:
+				'mark rev   act'
+				'mark image image'
+				'mark meta  meta';
+			column-gap: 0.6rem;
+			row-gap: 0.25rem;
+			padding: 0.7rem 0.85rem;
+			align-items: center;
+		}
+		.rev-row__mark  { grid-area: mark; }
+		.rev-row__rev   { grid-area: rev; }
+		.rev-row__act   { grid-area: act; justify-self: end; }
+		.rev-row__image {
+			grid-area: image;
+			direction: ltr;
+			white-space: normal;
+			overflow: visible;
+			text-overflow: clip;
+			overflow-wrap: anywhere;
+			font-size: 0.75rem;
+			color: hsl(var(--hsl-content) / 0.6);
+		}
+		.rev-row__meta { grid-area: meta; align-items: flex-start; }
 	}
 </style>
 


### PR DESCRIPTION
## Problem

Fixes #287. On phone widths the deployment detail page's data-dense surfaces broke:

- **Events** — the four fixed columns starved the message to a few px, wrapping it one glyph per line (unreadable).
- **Logs (Live + History)** — the rail's filter + Pause/Clear/Raw overflowed the shell (`overflow:hidden`), so Clear/Raw were clipped off-screen and unreachable.
- **Revisions** — the fixed rev column couldn't hold `#7 + Active`, so the Active tag overran and overlapped the image text.
- **Details** — a fixed 10rem label column crushed values into a sliver that broke mid-word (e.g. `registr y.deplo ys.app`).

## Change

CSS-only. New scoped `@media (max-width: 640px)` blocks stack each row into a card (issue **Option A**): a compact header line over a full-width message/value, with the severity bar spanning the card.

- **Events / Logs** rows: `time · type · reason` (events) / `time · pod` (logs) header over a full-width message.
- **Logs rail**: the filter goes full-width and the actions wrap, so every button stays reachable (verified down to 320px).
- **Revisions**: rev + Rollback on top, image and meta each on their own line; the `768px` rev column is widened `3.5rem → auto` so the Active tag fits at tablet widths too.
- **Details**: spec rows stack label-over-value; the env/mount key-value list stacks key-over-value (long keys wrap, pre-formatted mount data scrolls).

No markup/JS/API change → DOM and focus order are unchanged and desktop (≥1024) is untouched.

## Verification

- `bun lint` + `bun check`: clean.
- All **288 Playwright e2e** pass.
- Visually verified across light/dark at 375 & 320px, plus a stress pass (400-char log tokens, 120-char image refs, long env keys) — nothing overflows the shell.

## Screenshots (375px, before → after)

### Events — message was wrapping one glyph per line → stacked card
![events](https://raw.githubusercontent.com/deploys-app/console/screenshots/288-events.png)

### Logs — Clear/Raw were clipped off-screen → filter full-width, buttons wrap
![logs](https://raw.githubusercontent.com/deploys-app/console/screenshots/288-logs.png)

### Revisions — `#7 Active` overlapped the image → stacked card
![revisions](https://raw.githubusercontent.com/deploys-app/console/screenshots/288-revisions.png)

### Details — values broke mid-word → label over full-width value
![detail](https://raw.githubusercontent.com/deploys-app/console/screenshots/288-detail.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
