### PR TITLE
fix(deployment): keep the detail tab row from vanishing on desktop

### DIFF
--- a/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/+layout.svelte
@@ -72,7 +72,19 @@
 <div class="panel is-level-300 grid grid-cols-1 gap-6">
 	<!-- Mobile (< lg): native dropdown — keeps the section content above the
 	     fold on narrow viewports where 7 stacked or side-scrolling tabs would
-	     dominate. Desktop (lg+): the underlined tab row. -->
+	     dominate. Desktop (lg+): the underlined tab row.
+
+	     The tab row uses `max-lg:hidden` (hide only below lg) rather than
+	     `hidden lg:flex` (hide always, re-show at lg). Both render the same, but
+	     the latter makes desktop visibility hinge on the `lg:flex` utility
+	     winning over `hidden` — two equal-specificity utilities whose order
+	     decides the outcome — and if that override ever fails to land (a stale or
+	     partially-propagated CSS bundle mid-deploy, an extension stripping a
+	     rule, …) the tab row AND this dropdown are both hidden at lg+, leaving
+	     zero navigation (see #289). With `max-lg:hidden` desktop visibility comes
+	     from the always-present `.tabs { display: flex }` base, with no override
+	     to lose; the worst case is the row showing on mobile too — never the
+	     reverse. -->
 	<div class="select lg:hidden">
 		<select
 			aria-label="Section"
@@ -84,7 +96,7 @@
 			{/each}
 		</select>
 	</div>
-	<div class="tabs is-variant-underline w-full hidden lg:flex">
+	<div class="tabs is-variant-underline w-full max-lg:hidden">
 		{#each tabs as t (t.path)}
 			<a class="tab-button" class:is-active={$page.url.pathname === t.path} href={tabHref(t.path)}>
 				{t.label}


### PR DESCRIPTION
## Problem

Fixes #289. On desktop, the deployment **detail page lost its tab navigation** (Metrics / Details / Revisions / Logs / …) — only the Metrics content showed, with no way to reach the other sections. It did **not** reproduce on a fresh, consistent build ("cannot repro").

## Root cause

#285 changed the detail tab row from an always-visible `flex-col lg:flex-row` to **`hidden lg:flex`**. That makes desktop visibility hinge on the `lg:flex` utility overriding `hidden` — two **equal-specificity** utilities whose winner is decided by source/load order. CDP confirms the desktop cascade for `.tabs`:

```
.tabs { display:flex }      (component base)
.hidden { display:none }    (utility)
.lg\:flex { display:flex }  @media(≥64rem)  ← wins only because it comes last
```

If that override ever fails to land — a stale or partially-propagated CSS bundle mid-deploy, a CDN edge serving a transitional build, an extension stripping a rule, chunk-order skew — `hidden` wins and `.tabs` is `display:none` at **every** width. Because the mobile dropdown is `lg:hidden`, desktop then shows **neither** the tab row nor the dropdown → zero navigation. That's #289.

## Fix

Hide the tab row only *below* `lg` (`max-lg:hidden`) instead of hiding it always and re-showing at `lg`. Desktop visibility now comes from the always-present `.tabs { display: flex }` base — **no override to lose**. CDP confirms the desktop cascade collapses to just `.tabs{display:flex}`. Worst case becomes the tab row also showing on mobile (harmless), never the reverse. The #285 mobile dropdown is unchanged.

```diff
-<div class="tabs is-variant-underline w-full hidden lg:flex">
+<div class="tabs is-variant-underline w-full max-lg:hidden">
```

## Verification

I couldn't trigger the exact production condition locally, so I **forced the failure mode** — injecting a late `.hidden{display:none}` so `hidden` wins the cascade. On the old markup the nav blanks (reproducing #289); on the new markup the tab row stays put:

![resilience](https://raw.githubusercontent.com/deploys-app/console/screenshots/289-resilience.png)

Normal behaviour is unchanged — tabs at `lg+`, dropdown below:

![normal](https://raw.githubusercontent.com/deploys-app/console/screenshots/289-normal.png)

- CDP matched-styles before/after (above), Chromium + WebKit at 1453/1280/1024/1023/900/375px, dev **and** prod builds.
- `bun lint` + `bun check` clean; all **288 Playwright e2e** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
