### PR TITLE
feat(tables): make list tables readable on mobile

### DIFF
--- a/src/lib/components/ListTable.svelte
+++ b/src/lib/components/ListTable.svelte
@@ -4,6 +4,14 @@
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 
+	// A column is either a plain header string, or an object that can opt the
+	// column out of the mobile layout. `hideMobile` drops the column below the
+	// table's 48rem breakpoint (see `.is-hide-mobile` in app.css) so wide list
+	// pages shed low-value columns on phones while staying a real table; the row
+	// snippet must put `class="is-hide-mobile"` on the matching <td> to keep the
+	// header and body aligned.
+	type Column = string | { label: string, hideMobile?: boolean }
+
 	interface Props {
 		title: string
 		items: T[]
@@ -17,8 +25,9 @@
 		createPermission: string | string[]
 		createHref: string
 		createLabel?: string
-		/** data column headers (the row snippet renders matching cells) */
-		columns: string[]
+		/** data column headers (the row snippet renders matching cells); use
+		 *  `{ label, hideMobile: true }` to drop a column below 48rem */
+		columns: Column[]
 		/** append a right-aligned actions column header (+1 to the empty/error span) */
 		actions?: boolean
 		key: (item: T) => string | number
@@ -34,6 +43,9 @@
 
 	const plural = $derived(nounPlural ?? `${noun}s`)
 	const span = $derived(columns.length + (actions ? 1 : 0))
+
+	const colLabel = (c: Column) => typeof c === 'string' ? c : c.label
+	const colHidden = (c: Column) => typeof c !== 'string' && !!c.hideMobile
 </script>
 
 <div class="page-head">
@@ -51,7 +63,7 @@
 		<table class="table is-variant-compact">
 			<thead>
 				<tr>
-					{#each columns as col (col)}<th>{col}</th>{/each}
+					{#each columns as col (colLabel(col))}<th class:is-hide-mobile={colHidden(col)}>{colLabel(col)}</th>{/each}
 					{#if actions}<th class="is-collapse is-align-right"></th>{/if}
 				</tr>
 			</thead>

--- a/src/routes/(auth)/(project)/audit-log/+page.svelte
+++ b/src/routes/(auth)/(project)/audit-log/+page.svelte
@@ -485,7 +485,7 @@
 					<th>Time</th>
 					<th>Outcome</th>
 					<th>Actor</th>
-					<th>Channel</th>
+					<th class="is-hide-mobile">Channel</th>
 					<th>Action</th>
 					<th>Resource</th>
 					<th>Detail</th>
@@ -507,7 +507,7 @@
 								</span>
 							{/if}
 						</td>
-						<td><ChannelBadge channel={it.channel} /></td>
+						<td class="is-hide-mobile"><ChannelBadge channel={it.channel} /></td>
 						<td><span class="action-cell">{it.action}</span></td>
 						<td>
 							{#if it.resource.type}

--- a/src/routes/(auth)/(project)/cache/+page.svelte
+++ b/src/routes/(auth)/(project)/cache/+page.svelte
@@ -89,9 +89,9 @@
 				<tr>
 					<th>Location</th>
 					<th>Status</th>
-					<th>Description</th>
-					<th>Overrides</th>
-					<th>Decisions (24h)</th>
+					<th class="is-hide-mobile">Description</th>
+					<th class="is-hide-mobile">Overrides</th>
+					<th class="is-hide-mobile">Decisions (24h)</th>
 					<th class="is-collapse is-align-right"></th>
 				</tr>
 			</thead>
@@ -119,15 +119,15 @@
 								</span>
 							{/if}
 						</td>
-						<td>
+						<td class="is-hide-mobile">
 							{#if zone.description}
 								{zone.description}
 							{:else}
 								<span class="text-content/40">—</span>
 							{/if}
 						</td>
-						<td>{zone.overrides?.length ?? 0}</td>
-						<td>
+						<td class="is-hide-mobile">{zone.overrides?.length ?? 0}</td>
+						<td class="is-hide-mobile">
 							<!-- Reserve the loaded size in every state so the row/column keeps
 							     its dimensions while the async sparkline fills in (no layout shift). -->
 							<div class="matches-cell">

--- a/src/routes/(auth)/(project)/deployment/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/+page.svelte
@@ -116,10 +116,10 @@
 			<thead>
 			<tr>
 				<th>Deployment</th>
-				<th>Resources</th>
+				<th class="is-hide-mobile">Resources</th>
 				<th>Replicas</th>
 				<th>Location</th>
-				<th>Last deployed</th>
+				<th class="is-hide-mobile">Last deployed</th>
 			</tr>
 			</thead>
 			<tbody>
@@ -165,7 +165,7 @@
 								</div>
 							</div>
 						</td>
-						<td>
+						<td class="is-hide-mobile">
 							{#if it.type === 'Static'}
 								<span class="resources-none" title="Static sites have no configurable resources">—</span>
 							{:else}
@@ -194,7 +194,7 @@
 								<i class="fa-solid fa-location-dot" aria-hidden="true"></i>{it.location}
 							</span>
 						</td>
-						<td>
+						<td class="is-hide-mobile">
 							<span class="cell-time" title={format.datetime(it.createdAt)}>
 								{format.fromNow(it.createdAt) || '—'}
 							</span>

--- a/src/routes/(auth)/(project)/route/+page.svelte
+++ b/src/routes/(auth)/(project)/route/+page.svelte
@@ -70,8 +70,8 @@
 			<tr>
 				<th>Route</th>
 				<th>Target</th>
-				<th>Location</th>
-				<th>Config</th>
+				<th class="is-hide-mobile">Location</th>
+				<th class="is-hide-mobile">Config</th>
 <!--				<th>Created at</th>-->
 <!--				<th>Created by</th>-->
 				<th class="is-collapse is-align-right"></th>
@@ -84,10 +84,10 @@
 						onkeydown={(e) => onRowKey(e, it)}>
 						<td><span class="cell-name">https://{it.domain}{it.path}</span></td>
 						<td><span class="cell-muted">{it.target}</span></td>
-						<td>
+						<td class="is-hide-mobile">
 							<span class="loc-chip"><i class="fa-solid fa-location-dot" aria-hidden="true"></i>{it.location}</span>
 						</td>
-						<td>
+						<td class="is-hide-mobile">
 							{#if it.config?.basicAuth}
 								<i class="fa-solid fa-lock" title="Basic auth"></i>
 							{/if}

--- a/src/routes/(auth)/(project)/scheduler/+page.svelte
+++ b/src/routes/(auth)/(project)/scheduler/+page.svelte
@@ -30,7 +30,7 @@
 	createPermission="scheduler.create"
 	createHref="/scheduler/create?project={project}"
 	createLabel="Create job"
-	columns={['Name', 'Schedule', 'Method', 'Last run', 'Status']}
+	columns={['Name', 'Schedule', { label: 'Method', hideMobile: true }, { label: 'Last run', hideMobile: true }, 'Status']}
 	actions
 	key={(it) => it.name}>
 	{#snippet row(it)}
@@ -40,8 +40,8 @@
 			</a>
 		</td>
 		<td><span class="font-mono text-sm">{it.schedule}</span></td>
-		<td><span class="method-badge" data-method={it.method}>{it.method}</span></td>
-		<td>
+		<td class="is-hide-mobile"><span class="method-badge" data-method={it.method}>{it.method}</span></td>
+		<td class="is-hide-mobile">
 			{#if it.lastRunAt}
 				<span class="cell-time" title={format.datetime(it.lastRunAt)}>{format.fromNow(it.lastRunAt)}</span>
 			{:else}

--- a/src/routes/(auth)/(project)/scoped-token/+page.svelte
+++ b/src/routes/(auth)/(project)/scoped-token/+page.svelte
@@ -76,7 +76,7 @@
 					<th>Label</th>
 					<th>Permissions</th>
 					<th>Expires</th>
-					<th>Created</th>
+					<th class="is-hide-mobile">Created</th>
 					<th class="is-collapse is-align-right"></th>
 				</tr>
 			</thead>
@@ -105,7 +105,7 @@
 						<td>
 							<span class="cell-time" title={format.datetime(it.expiresAt)}>{format.fromNow(it.expiresAt) || '—'}</span>
 						</td>
-						<td>
+						<td class="is-hide-mobile">
 							<span class="cell-time" title={format.datetime(it.createdAt)}>{format.fromNow(it.createdAt) || '—'}</span>
 						</td>
 						<td>

--- a/src/routes/(auth)/(project)/waf/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/+page.svelte
@@ -89,9 +89,9 @@
 				<tr>
 					<th>Location</th>
 					<th>Status</th>
-					<th>Description</th>
-					<th>Rules</th>
-					<th>Limits</th>
+					<th class="is-hide-mobile">Description</th>
+					<th class="is-hide-mobile">Rules</th>
+					<th class="is-hide-mobile">Limits</th>
 					<th>Matches (24h)</th>
 					<th class="is-collapse is-align-right"></th>
 				</tr>
@@ -120,15 +120,15 @@
 								</span>
 							{/if}
 						</td>
-						<td>
+						<td class="is-hide-mobile">
 							{#if fw.description}
 								{fw.description}
 							{:else}
 								<span class="text-content/40">—</span>
 							{/if}
 						</td>
-						<td>{fw.rules?.length ?? 0}</td>
-						<td>{fw.limits?.length ?? 0}</td>
+						<td class="is-hide-mobile">{fw.rules?.length ?? 0}</td>
+						<td class="is-hide-mobile">{fw.limits?.length ?? 0}</td>
 						<td>
 							<!-- Reserve the loaded size in every state so the row/column keeps
 							     its dimensions while the async sparkline fills in (no layout shift). -->

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -951,7 +951,34 @@
 		overflow-x: auto;
 		overflow-y: visible;
 		border-radius: 0.25rem;
+
+		/* Scroll affordance — edge shadows that show ONLY while the table is
+		   clipped horizontally, so narrow screens reveal there are more columns
+		   to scroll to. Classic pure-CSS technique: the two "cover" layers
+		   (background-attachment: local) ride flush against the content edges
+		   and mask the shadow when there is nothing more to scroll that way; the
+		   two radial "shadow" layers (background-attachment: scroll) are pinned
+		   to the container and surface once a cover scrolls out of view. No JS
+		   and no scroll-driven animation, so support is universal. The cover
+		   color tracks the panel background (base-300, the list-panel level) and
+		   the shadow tracks the line token, so both follow light/dark. */
+		--table-edge-bg: hsl(var(--hsl-base-300));
+		background:
+			linear-gradient(to right, var(--table-edge-bg) 30%, transparent) 0 0,
+			linear-gradient(to left, var(--table-edge-bg) 30%, transparent) 100% 0,
+			radial-gradient(farthest-side at 0 50%, hsl(var(--hsl-line)), transparent) 0 0,
+			radial-gradient(farthest-side at 100% 50%, hsl(var(--hsl-line)), transparent) 100% 0;
+		background-repeat: no-repeat;
+		background-size: 2.5rem 100%, 2.5rem 100%, 0.875rem 100%, 0.875rem 100%;
+		background-attachment: local, local, scroll, scroll;
 	}
+
+	/* Keep the scroll-shadow "cover" color matched to the panel the table sits
+	   on. Nearly every list table is on the base-300 panel (the default above),
+	   but a few embedded tables sit on other levels; without these the cover
+	   band would be a faintly wrong shade at the table's edges. */
+	.panel.is-level-200 .table-container { --table-edge-bg: hsl(var(--hsl-base-200)); }
+	.panel.is-level-400 .table-container { --table-edge-bg: hsl(var(--hsl-base-400)); }
 
 	.table {
 		width: 100%;
@@ -1041,6 +1068,42 @@
 	.table .is-align-left { text-align: left; }
 	.table .is-align-center { text-align: center; }
 	.table .is-align-right { text-align: right; }
+
+	/* On narrow screens, let cells wrap instead of forcing a wide horizontal
+	   scroll: most list tables are an identity column plus a few short
+	   attributes, so wrapping keeps them readable in place. Long unbreakable
+	   tokens (URLs, image digests, permission strings) get overflow-wrap so they
+	   break rather than blow the row out; headers wrap too so they don't pin the
+	   table to its old width. Any table that stays wider than the viewport (the
+	   genuinely wide ones — audit-log, waf, cache) still gets the scroll
+	   affordance on .table-container above. */
+	@media (max-width: 48rem) {
+		.table th,
+		.table td {
+			white-space: normal;
+		}
+
+		.table td {
+			/* break-word, NOT anywhere: anywhere lets the table-layout shrink a
+			   column to 1ch (it counts every char as a min-content break point),
+			   which stacks names like "website-preview" into a vertical column of
+			   single letters. break-word keeps the column at least as wide as its
+			   longest word and only breaks a token that still can't fit. */
+			overflow-wrap: break-word;
+		}
+
+		/* Progressive column-hiding: the genuinely wide tables tag their
+		   lowest-value columns — both the <th> and the matching body <td>s — with
+		   .is-hide-mobile so the column drops below this breakpoint while the
+		   table stays a real, comparable table (no restack, native semantics
+		   intact). Each such page keeps an escape hatch to the hidden fields (a
+		   row/identity link to a detail page), except flat logs where only a
+		   redundant column is dropped. Full-width colspan rows (empty/error/
+		   load-more) keep their original span and are never tagged. */
+		.table .is-hide-mobile {
+			display: none;
+		}
+	}
 
 	/* Table-cell vocabulary — shared chips/pills/badges used across the list
 	 * pages so every table speaks the same visual language. Introduced with


### PR DESCRIPTION
## Problem

Console list tables fell back to **horizontal scroll** on narrow screens — `.table-container { overflow-x: auto }` + `white-space: nowrap` cells, with no card/wrap breakpoint and no scroll affordance. On a phone you got a clipped table with columns off-screen and no hint they were there.

We deliberately **kept it a table** rather than switching to cards: this is a power-user/admin console where cross-row comparison ("which deployment is the outlier", "which route is misconfigured") is the table's whole job — cards destroy that. The fix makes the table behave better on mobile instead of replacing it.

## Phase 1 — global, one CSS change reaches all ~37 tables

- Below `48rem`, relax `white-space: nowrap → normal` (+ `overflow-wrap: break-word`) so cells wrap in place instead of forcing a wide horizontal scroll. `break-word` (not `anywhere`) is deliberate — `anywhere` lets the table layout collapse a flexible column to 1ch, stacking names like `website-preview` into a vertical column of single letters.
- Add a **pure-CSS scroll-shadow** affordance on `.table-container` (layered-background technique, no JS, no `animation-timeline`) so any table still wider than the viewport shows an edge shadow that appears only while clipped. Cover color tracks the panel background per level; shadow tracks the line token — both follow light/dark.

## Phase 2 — progressive column-hiding on the genuinely wide tables

A new `.table .is-hide-mobile { display: none }` utility (in the same `48rem` media query) is applied to the lowest-value `<th>`/`<td>` pairs. The table stays a real, comparable table — no restack, no `data-label` duplication, native semantics intact — and **all columns return above 48rem**.

| Page | Hidden < 48rem | Escape hatch for hidden fields |
| --- | --- | --- |
| deployment | Resources, Last deployed | name → metrics/detail page |
| route | Location, Config | row click → manage page |
| waf | Description, Rules, Limits | Location link + Manage button |
| cache | Description, Overrides, Decisions | Location link + Manage button |
| scheduler | Method, Last run | name → detail page |
| audit-log | Channel only | none (flat log) — drops only a redundant column |
| scoped-token | Created only | none (flat list) — keeps Permissions; drops a low-value timestamp |

`scheduler` goes through a **backward-compatible `ListTable` extension**: its `columns` prop now accepts `string | { label, hideMobile }`; the other 8 `ListTable` callers are unchanged.

## Verification

- `bun lint` and `bun check` both clean (0 errors).
- Rendered at **375px** (light + dark) and **1280px** across deployment, route, audit-log, waf, cache, scoped-token, scheduler, disk via `bun dev:mock` + Playwright. Confirmed: cells wrap, previously-clipped columns become visible, wide tables drop their low-value columns, scroll cue appears only when clipped, and every hidden column returns on desktop.
- Ran `/scrutinize`: all hide-pairings balanced (header/body aligned), colspan empty/error rows untouched, `ListTable` type change safe for all callers, scroll-shadow layering canonical. Fixed one finding (cover color now tracks panel level for the one embedded table on `is-level-200`).

## Screenshots

**Before** — 375px, `nowrap` → horizontal scroll, columns clipped off-screen (deployment's Resources is cut, waf's Description barely visible):

![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/291-before.png)

**After** — 375px, Phase 2: cells wrap and the low-value columns drop (deployment keeps Deployment/Replicas/Location; waf keeps Location/Status/Matches), with the scroll cue on the right edge:

![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/291-after.png)

**Desktop (≥48rem)** — every hidden column returns; deployment shows all 5, waf all 6 + Manage, scheduler all:

![desktop](https://raw.githubusercontent.com/deploys-app/console/screenshots/291-desktop.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9FhPEapaKr4VugQBEdisj