### PR TITLE
feat(auth): show unauthorized page on session expiry instead of auto-redirect

### DIFF
--- a/src/routes/(auth)/+layout.server.ts
+++ b/src/routes/(auth)/+layout.server.ts
@@ -1,0 +1,10 @@
+import type { LayoutServerLoad } from './$types'
+
+// Expose whether a session cookie is present. The token is httpOnly so the
+// universal +layout.ts can't read it — but it needs to tell two unauthorized
+// cases apart: a first-time visitor with no session (bounce straight to
+// sign-in) vs an expired session whose token the API now rejects (show the
+// "Sign in to continue" page so the user re-authenticates deliberately).
+export const load: LayoutServerLoad = ({ locals }) => {
+	return { hasToken: !!locals.token }
+}

--- a/src/routes/(auth)/+layout.ts
+++ b/src/routes/(auth)/+layout.ts
@@ -12,20 +12,20 @@ export const load: LayoutLoad = async ({ fetch, url, data }) => {
 	])
 	if (!me.ok) {
 		if (me.error?.unauth) {
-			if (data.hasToken) {
-				// Expired session: we hold a token the API now rejects. Surface a 401
-				// so the root +error.svelte shows a "Sign in to continue" page and the
-				// user re-authenticates deliberately. $page.url is preserved, which the
-				// error page turns into the `?redirect=` so sign-in lands back here.
+			const next = url.pathname + url.search
+			const isRoot = next === '/'
+			// On a deep link an expired session (a token the API now rejects) gets the
+			// "Sign in to continue" page so re-auth returns the user to where they
+			// were. But the bare root is just a router (it redirects to /project once
+			// you're in) — there's nothing to preserve and no value in an interstitial
+			// — so `/` always bounces straight to sign-in, expired token or not. A
+			// first-time visitor with no session anywhere is likewise redirected.
+			if (data.hasToken && !isRoot) {
 				error(401, 'unauthorized')
 			}
-			// First-time visitor with no session — bounce straight to sign-in rather
-			// than show an interstitial they never landed on. Remember the path so
-			// the OAuth round-trip returns them here.
-			const next = url.pathname + url.search
-			redirect(302, next && next !== '/'
-				? `/auth/signin?redirect=${encodeURIComponent(next)}`
-				: '/auth/signin')
+			redirect(302, isRoot
+				? '/auth/signin'
+				: `/auth/signin?redirect=${encodeURIComponent(next)}`)
 		}
 		error(500, me.error?.message)
 	}

--- a/src/routes/(auth)/+layout.ts
+++ b/src/routes/(auth)/+layout.ts
@@ -1,8 +1,8 @@
-import { redirect, error } from '@sveltejs/kit'
+import { error } from '@sveltejs/kit'
 import api from '$lib/api'
 import type { LayoutLoad } from './$types'
 
-export const load: LayoutLoad = async ({ fetch, url }) => {
+export const load: LayoutLoad = async ({ fetch }) => {
 	const [
 		me,
 		projects
@@ -12,13 +12,11 @@ export const load: LayoutLoad = async ({ fetch, url }) => {
 	])
 	if (!me.ok) {
 		if (me.error?.unauth) {
-			// Remember where the user was headed so the OAuth round-trip can land
-			// them back here instead of dumping them on the dashboard. The path is
-			// same-origin by construction; signin/callback re-validate it.
-			const next = url.pathname + url.search
-			redirect(302, next && next !== '/'
-				? `/auth/signin?redirect=${encodeURIComponent(next)}`
-				: '/auth/signin')
+			// Don't bounce straight to the OAuth provider — surface a 401 so the
+			// root +error.svelte can show a "session expired" page with an explicit
+			// "Sign in" button. The current URL is preserved as $page.url, which the
+			// error page turns into the `?redirect=` so sign-in lands back here.
+			error(401, 'unauthorized')
 		}
 		error(500, me.error?.message)
 	}

--- a/src/routes/(auth)/+layout.ts
+++ b/src/routes/(auth)/+layout.ts
@@ -1,8 +1,8 @@
-import { error } from '@sveltejs/kit'
+import { redirect, error } from '@sveltejs/kit'
 import api from '$lib/api'
 import type { LayoutLoad } from './$types'
 
-export const load: LayoutLoad = async ({ fetch }) => {
+export const load: LayoutLoad = async ({ fetch, url, data }) => {
 	const [
 		me,
 		projects
@@ -12,11 +12,20 @@ export const load: LayoutLoad = async ({ fetch }) => {
 	])
 	if (!me.ok) {
 		if (me.error?.unauth) {
-			// Don't bounce straight to the OAuth provider — surface a 401 so the
-			// root +error.svelte can show a "session expired" page with an explicit
-			// "Sign in" button. The current URL is preserved as $page.url, which the
-			// error page turns into the `?redirect=` so sign-in lands back here.
-			error(401, 'unauthorized')
+			if (data.hasToken) {
+				// Expired session: we hold a token the API now rejects. Surface a 401
+				// so the root +error.svelte shows a "Sign in to continue" page and the
+				// user re-authenticates deliberately. $page.url is preserved, which the
+				// error page turns into the `?redirect=` so sign-in lands back here.
+				error(401, 'unauthorized')
+			}
+			// First-time visitor with no session — bounce straight to sign-in rather
+			// than show an interstitial they never landed on. Remember the path so
+			// the OAuth round-trip returns them here.
+			const next = url.pathname + url.search
+			redirect(302, next && next !== '/'
+				? `/auth/signin?redirect=${encodeURIComponent(next)}`
+				: '/auth/signin')
 		}
 		error(500, me.error?.message)
 	}

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	// This is the app's only error boundary. It renders for any error thrown from
+	// a load function — most importantly the 401 raised by (auth)/+layout.ts when
+	// the session has expired. Instead of bouncing straight to the OAuth provider,
+	// we show a "session expired" page with an explicit "Sign in" button so the
+	// user chooses when to re-authenticate (no surprise full-page redirect).
+	//
+	// The (auth) layout failed to load, so its chrome and global stylesheet aren't
+	// mounted here — import the stylesheet directly so this page is themed.
+	import '$style/app.css'
+	import { page } from '$app/stores'
+
+	const isUnauth = $derived($page.status === 401)
+
+	// Preserve where the user was so sign-in lands them back here. The URL is
+	// same-origin by construction; /auth/signin + /auth/callback re-validate it.
+	const next = $derived($page.url.pathname + $page.url.search)
+	const signinHref = $derived(
+		next && next !== '/'
+			? `/auth/signin?redirect=${encodeURIComponent(next)}`
+			: '/auth/signin'
+	)
+</script>
+
+<div class="error-page">
+	<div class="panel is-level-300 error-card">
+		<img class="logo" src="/images/logo.webp" alt="Deploys.app" draggable="false">
+
+		{#if isUnauth}
+			<div class="empty-state">
+				<i class="fa-solid fa-lock empty-icon"></i>
+				<!-- A missing token and an expired token both surface as a 401, so the
+				     copy must read true for a returning user AND a first-time visitor. -->
+				<p class="empty-title">Sign in to continue</p>
+				<p class="empty-sub">Your session isn't active. Sign in to access the console.</p>
+				<!-- A plain link to the server sign-in endpoint (not client-routed):
+				     data-sveltekit-reload forces a real navigation so the GET handler
+				     runs and starts the OAuth flow. -->
+				<a class="button is-icon-left mt-2" href={signinHref} data-sveltekit-reload>
+					<i class="fa-solid fa-right-to-bracket"></i>
+					Sign in
+				</a>
+			</div>
+		{:else}
+			<div class="empty-state">
+				<i class="fa-solid fa-triangle-exclamation empty-icon error-icon"></i>
+				<p class="empty-title">Something went wrong</p>
+				<p class="empty-sub">{$page.error?.message || 'An unexpected error occurred.'}</p>
+				<p class="error-status">Error {$page.status}</p>
+				<a class="button is-variant-secondary is-icon-left mt-2" href={next} data-sveltekit-reload>
+					<i class="fa-solid fa-rotate-right"></i>
+					Try again
+				</a>
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.error-page {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 100vh;
+		/* dvh after vh so it wins where supported (iOS Safari toolbar). */
+		min-height: 100dvh;
+		padding: 1.5rem;
+	}
+
+	.error-card {
+		width: 100%;
+		max-width: 26rem;
+		text-align: center;
+	}
+
+	.logo {
+		height: 2rem;
+		margin: 0 auto;
+		-webkit-user-select: none;
+		user-select: none;
+	}
+
+	/* Override the empty-state icon's primary tint for the generic-error branch. */
+	.error-icon {
+		color: hsl(var(--hsl-negative) / 0.7);
+	}
+
+	.error-status {
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-content) / 0.45);
+	}
+</style>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -11,6 +11,8 @@
 	import { page } from '$app/stores'
 
 	const isUnauth = $derived($page.status === 401)
+	// A 404 won't change on retry, so the "Try again" action is hidden for it.
+	const isNotFound = $derived($page.status === 404)
 
 	// Preserve where the user was so sign-in lands them back here. The URL is
 	// same-origin by construction; /auth/signin + /auth/callback re-validate it.
@@ -27,8 +29,8 @@
 		{#if isUnauth}
 			<div class="empty-state">
 				<i class="fa-solid fa-lock empty-icon"></i>
-				<!-- A missing token and an expired token both surface as a 401, so the
-				     copy must read true for a returning user AND a first-time visitor. -->
+				<!-- Reached only for an expired/rejected session (a first-time visitor
+				     with no token is redirected straight to sign-in by the layout). -->
 				<p class="empty-title">Sign in to continue</p>
 				<p class="empty-sub">Your session isn't active. Sign in to access the console.</p>
 				<!-- A plain link to the server sign-in endpoint (not client-routed):
@@ -38,6 +40,14 @@
 					<i class="fa-solid fa-right-to-bracket"></i>
 					Sign in
 				</a>
+			</div>
+		{:else if isNotFound}
+			<div class="empty-state">
+				<i class="fa-solid fa-compass empty-icon error-icon"></i>
+				<p class="empty-title">Page not found</p>
+				<p class="empty-sub">The page you're looking for doesn't exist or may have moved.</p>
+				<p class="error-status">Error 404</p>
+				<!-- No "Try again": retrying a 404 hits the same dead URL. -->
 			</div>
 		{:else}
 			<div class="empty-state">

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -24,8 +24,6 @@
 
 <div class="error-page">
 	<div class="panel is-level-300 error-card">
-		<img class="logo" src="/images/logo.webp" alt="Deploys.app" draggable="false">
-
 		{#if isUnauth}
 			<div class="empty-state">
 				<i class="fa-solid fa-lock empty-icon"></i>
@@ -71,13 +69,6 @@
 		width: 100%;
 		max-width: 26rem;
 		text-align: center;
-	}
-
-	.logo {
-		height: 2rem;
-		margin: 0 auto;
-		-webkit-user-select: none;
-		user-select: none;
 	}
 
 	/* Override the empty-state icon's primary tint for the generic-error branch. */

--- a/tests/auth.spec.js
+++ b/tests/auth.spec.js
@@ -104,10 +104,10 @@ test.describe('signed-in user', () => {
 		expect(resp?.status()).toBeGreaterThanOrEqual(500)
 	})
 
-	test('shows the unauthorized page (not a redirect) when the session token is rejected', async ({ page }) => {
+	test('shows the unauthorized page (not a redirect) on a deep link when the session token is rejected', async ({ page }) => {
 		// `test` fixture is signed in (token cookie present), but the API rejects it
-		// — an expired session. Unlike a first-time visitor, this surfaces the
-		// "Sign in to continue" page with a manual Sign in link, not an auto-redirect.
+		// — an expired session. On a deep link this surfaces the "Sign in to
+		// continue" page with a manual Sign in link, not an auto-redirect.
 		await setMocks({
 			'me.get': { ok: false, error: { message: 'api: unauthorized' } }
 		})
@@ -118,5 +118,18 @@ test.describe('signed-in user', () => {
 		const href = new URL(await signin.getAttribute('href') ?? '', 'http://localhost')
 		expect(href.pathname).toBe('/auth/signin')
 		expect(href.searchParams.get('redirect')).toBe('/project')
+	})
+
+	test('auto-redirects to /auth/signin from "/" even with an expired token (no interstitial)', async ({ page }) => {
+		// The bare root is just a router, so it always bounces to sign-in — an
+		// expired session here gets the redirect, not the "Sign in to continue" page.
+		await setMocks({
+			'me.get': { ok: false, error: { message: 'api: unauthorized' } }
+		})
+		const resp = await page.request.get('/', { maxRedirects: 0 })
+		expect([301, 302, 303, 307, 308]).toContain(resp.status())
+		const loc = new URL(resp.headers().location, 'http://localhost')
+		expect(loc.pathname).toBe('/auth/signin')
+		expect(loc.searchParams.get('redirect')).toBeNull()
 	})
 })

--- a/tests/auth.spec.js
+++ b/tests/auth.spec.js
@@ -1,26 +1,22 @@
 import { test, unauthedTest, expect, setMocks } from './helpers.js'
 
 unauthedTest.describe('unauthenticated access', () => {
-	unauthedTest('shows the unauthorized page (no auto-redirect) with a Sign in link that remembers the path', async ({ page }) => {
-		// No more auto-bounce to the OAuth provider: the load throws a 401 and the
-		// root +error.svelte renders a page where the user clicks "Sign in" itself.
-		const resp = await page.goto('/?project=test-project')
-		expect(resp?.status()).toBe(401)
-		const signin = page.getByRole('link', { name: 'Sign in' })
-		await expect(signin).toBeVisible()
-		const href = new URL(await signin.getAttribute('href') ?? '', 'http://localhost')
-		expect(href.pathname).toBe('/auth/signin')
-		expect(href.searchParams.get('redirect')).toBe('/?project=test-project')
+	unauthedTest('auto-redirects a first-time visitor (no token) to /auth/signin, remembering the path', async ({ page }) => {
+		// A fresh visitor with no session cookie is bounced straight to sign-in —
+		// no interstitial. (The unauthorized page is only for an expired session.)
+		const resp = await page.request.get('/?project=test-project', { maxRedirects: 0 })
+		expect([301, 302, 303, 307, 308]).toContain(resp.status())
+		const loc = new URL(resp.headers().location, 'http://localhost')
+		expect(loc.pathname).toBe('/auth/signin')
+		expect(loc.searchParams.get('redirect')).toBe('/?project=test-project')
 	})
 
-	unauthedTest('shows the unauthorized page from the project list as well', async ({ page }) => {
-		const resp = await page.goto('/project')
-		expect(resp?.status()).toBe(401)
-		const signin = page.getByRole('link', { name: 'Sign in' })
-		await expect(signin).toBeVisible()
-		const href = new URL(await signin.getAttribute('href') ?? '', 'http://localhost')
-		expect(href.pathname).toBe('/auth/signin')
-		expect(href.searchParams.get('redirect')).toBe('/project')
+	unauthedTest('auto-redirects a first-time visitor from the project list as well', async ({ page }) => {
+		const resp = await page.request.get('/project', { maxRedirects: 0 })
+		expect([301, 302, 303, 307, 308]).toContain(resp.status())
+		const loc = new URL(resp.headers().location, 'http://localhost')
+		expect(loc.pathname).toBe('/auth/signin')
+		expect(loc.searchParams.get('redirect')).toBe('/project')
 	})
 
 	unauthedTest('/auth/signin redirects to the OAuth provider', async ({ page }) => {
@@ -106,5 +102,21 @@ test.describe('signed-in user', () => {
 		})
 		const resp = await page.goto('/project')
 		expect(resp?.status()).toBeGreaterThanOrEqual(500)
+	})
+
+	test('shows the unauthorized page (not a redirect) when the session token is rejected', async ({ page }) => {
+		// `test` fixture is signed in (token cookie present), but the API rejects it
+		// — an expired session. Unlike a first-time visitor, this surfaces the
+		// "Sign in to continue" page with a manual Sign in link, not an auto-redirect.
+		await setMocks({
+			'me.get': { ok: false, error: { message: 'api: unauthorized' } }
+		})
+		const resp = await page.goto('/project')
+		expect(resp?.status()).toBe(401)
+		const signin = page.getByRole('link', { name: 'Sign in' })
+		await expect(signin).toBeVisible()
+		const href = new URL(await signin.getAttribute('href') ?? '', 'http://localhost')
+		expect(href.pathname).toBe('/auth/signin')
+		expect(href.searchParams.get('redirect')).toBe('/project')
 	})
 })

--- a/tests/auth.spec.js
+++ b/tests/auth.spec.js
@@ -1,20 +1,26 @@
 import { test, unauthedTest, expect, setMocks } from './helpers.js'
 
 unauthedTest.describe('unauthenticated access', () => {
-	unauthedTest('redirects to /auth/signin (remembering the path) when there is no token', async ({ page }) => {
-		const resp = await page.request.get('/?project=test-project', { maxRedirects: 0 })
-		expect([301, 302, 303, 307, 308]).toContain(resp.status())
-		const loc = new URL(resp.headers().location, 'http://localhost')
-		expect(loc.pathname).toBe('/auth/signin')
-		expect(loc.searchParams.get('redirect')).toBe('/?project=test-project')
+	unauthedTest('shows the unauthorized page (no auto-redirect) with a Sign in link that remembers the path', async ({ page }) => {
+		// No more auto-bounce to the OAuth provider: the load throws a 401 and the
+		// root +error.svelte renders a page where the user clicks "Sign in" itself.
+		const resp = await page.goto('/?project=test-project')
+		expect(resp?.status()).toBe(401)
+		const signin = page.getByRole('link', { name: 'Sign in' })
+		await expect(signin).toBeVisible()
+		const href = new URL(await signin.getAttribute('href') ?? '', 'http://localhost')
+		expect(href.pathname).toBe('/auth/signin')
+		expect(href.searchParams.get('redirect')).toBe('/?project=test-project')
 	})
 
-	unauthedTest('redirects to /auth/signin from the project list as well', async ({ page }) => {
-		const resp = await page.request.get('/project', { maxRedirects: 0 })
-		expect([301, 302, 303, 307, 308]).toContain(resp.status())
-		const loc = new URL(resp.headers().location, 'http://localhost')
-		expect(loc.pathname).toBe('/auth/signin')
-		expect(loc.searchParams.get('redirect')).toBe('/project')
+	unauthedTest('shows the unauthorized page from the project list as well', async ({ page }) => {
+		const resp = await page.goto('/project')
+		expect(resp?.status()).toBe(401)
+		const signin = page.getByRole('link', { name: 'Sign in' })
+		await expect(signin).toBeVisible()
+		const href = new URL(await signin.getAttribute('href') ?? '', 'http://localhost')
+		expect(href.pathname).toBe('/auth/signin')
+		expect(href.searchParams.get('redirect')).toBe('/project')
 	})
 
 	unauthedTest('/auth/signin redirects to the OAuth provider', async ({ page }) => {


### PR DESCRIPTION
## What

- **Session expiry** no longer auto-redirects to the `auth.deploys.app` OAuth provider. On a deep link it shows a **"Sign in to continue"** page with an explicit **Sign in** button the user clicks themselves.
- **First-time visitors** (no session at all) are still **auto-redirected** straight to sign-in — no interstitial they never landed on.
- The **bare root `/`** always redirects to sign-in when unauthorized — expired token or not — since it's just a router (it redirects to `/project` once you're in), so there's nothing to preserve there.
- The console gains its first **error boundary** (`+error.svelte`), so generic **5xx** and **404** now get real pages instead of SvelteKit's raw fallback. **404 has no "Try again"** (retrying a dead URL just 404s again).

## Why

Previously `(auth)/+layout.ts` did `redirect(302, '/auth/signin')` on any unauthorized `me.get`, bouncing the user to an external OAuth domain with no warning. For an **expired** session on a page they were using, that's jarring and gives no control; for a **first-time** visitor or the bare entry point, an interstitial is just a needless extra click. This PR splits those cases.

## How

- **`src/routes/(auth)/+layout.server.ts`** (new) — exposes `hasToken` (the token cookie is httpOnly, so the universal load can't read it).
- **`src/routes/(auth)/+layout.ts`** — on an unauthorized `me.get`:
  - **deep link + token present but rejected** (expired session) → `error(401)` → the unauthorized page (preserves the path as `?redirect=`).
  - **bare root `/`** (expired or no token) → `redirect(302, '/auth/signin')`.
  - **no token** (first-time) → `redirect(302)` to `/auth/signin`, remembering the path.
- **`src/routes/+error.svelte`** (new) — the root error boundary. It imports `$style/app.css` directly (the failed `(auth)` layout doesn't mount, so its stylesheet isn't loaded). Branches:
  - **401** → "Sign in to continue" + a **Sign in** link. Real navigation (`data-sveltekit-reload`) to the `/auth/signin` endpoint, preserving the current page as `?redirect=` so the callback returns the user where they were.
  - **404** → "Page not found", **no retry button**.
  - **other** → "Something went wrong" + the error message + **Try again**.

### Notes
- **No redirect loop:** the `(auth)` layout never mounts on the error page, so `api.setOnUnauth` is never registered — the runtime `onUnauth → location.reload()` handler can't re-fire. Expiry mid-session → reload → SSR re-runs the load → `error(401)` → page.
- **Open-redirect safe:** `redirect` is same-origin by construction, `encodeURIComponent`'d, and re-sanitized server-side by `sanitizeRedirect`.
- Adversarial multi-lens review of the original change: no blockers.
- **Full Playwright suite (290) + `bun lint` + `bun check` all green.** `auth.spec.js` covers: first-time redirect, deep-link expired-session 401 page, `/`-always-redirects (expired), and the existing sign-in/callback flows.

## Screenshots

**Expired session on a deep link — "Sign in to continue"** (light / dark):

| ![signin-light](https://raw.githubusercontent.com/deploys-app/console/screenshots/292-after-light.png) | ![signin-dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/292-after-dark.png) |
| --- | --- |

**404 — "Page not found" (no Try again)** (light / dark):

| ![notfound-light](https://raw.githubusercontent.com/deploys-app/console/screenshots/292-notfound-light.png) | ![notfound-dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/292-notfound-dark.png) |
| --- | --- |

**Generic 5xx fallback** (has Try again):

![generic-error](https://raw.githubusercontent.com/deploys-app/console/screenshots/292-generic-error.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)