### PR TITLE
feat(deployment metrics): Requests/Egress charts show totals, not rate

### DIFF
--- a/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
@@ -331,10 +331,14 @@
 		<Chart title="Memory (bytes)" unit="bytes" series={memory} range={filter.range} />
 	{/if}
 	<!-- Static deployments have no pods, but the static-gateway reports their
-	     per-site request rate, so Requests applies to them too. -->
+	     per-site request count, so Requests applies to them too. -->
 	{#if deployment.type === 'WebService' || deployment.type === 'Static'}
-		<Chart title="Request (rps)" unit="rps" series={request} range={filter.range} />
+		<!-- Total requests served in each time bucket (collector now records
+		     per-minute counts, summed per bucket), not a per-second rate. -->
+		<Chart title="Requests" unit="requests" series={request} range={filter.range} />
 	{/if}
+	<!-- Total bytes egressed in each time bucket (per-minute byte counts summed
+	     per bucket), not a per-second rate. -->
 	<Chart title="Egress (bytes)" unit="bytes" series={egress} range={filter.range} />
 	<!-- Static deploys serve from object storage; show each site's stored bytes
 	     (project-wide storage is on the project Metrics page). -->

--- a/tests/deployment.spec.js
+++ b/tests/deployment.spec.js
@@ -397,9 +397,9 @@ test.describe('deployment detail — static', () => {
 		await page.goto('/deployment/metrics?project=test-project&location=gke&name=website')
 
 		const main = page.locator('.content-wrapper')
-		// The static-gateway reports per-site request rate, so Requests applies;
+		// The static-gateway reports per-site request counts, so Requests applies;
 		// CPU/Memory don't (no pods). Egress stays.
-		await expect(main.getByText('Request (rps)')).toBeVisible()
+		await expect(main.getByText('Requests', { exact: true })).toBeVisible()
 		await expect(main.getByText('Egress (bytes)')).toBeVisible()
 		await expect(main.getByText('vCPU (second)')).toHaveCount(0)
 		await expect(main.getByText('Memory (bytes)')).toHaveCount(0)


### PR DESCRIPTION
## What

Relabels the deployment **Requests** chart from "Request (rps)" to "Requests" and corrects the rate-implying comments. The chart now plots **total requests / bytes per time bucket** instead of an instantaneous per-second rate.

## Why

This is the console half of the metrics-totals change. The collector now records per-minute counts (`increase()[1m]`, deploys-app/collector#13) and the apiserver sums them per bucket (deploys-app/apiserver#206), so the value is a total, not a rate — "(rps)" was misleading. "Egress (bytes)" is now an honest byte total.

Behaviour note: per-bucket totals scale with the selected range's bucket width (inherent to plotting an extensive quantity over time).

## Screenshots

Note the chart title: **"Request (rps)" → "Requests"**.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/293-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/293-after.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_011d4bVuGLnCbcJD9ZvastPH