### PR TITLE
feat(project metrics): add Cache Egress chart

### DIFF
--- a/src/lib/components/ProjectMetrics.svelte
+++ b/src/lib/components/ProjectMetrics.svelte
@@ -10,7 +10,8 @@
 	/**
 	 * Daily project-level usage charts read from the project.metrics RPC. CPU,
 	 * memory, disk and replicas are per-day average levels; egress is the day's
-	 * total bytes (pod + cache + WAF); static storage is the day's gauge.
+	 * origin bytes (pod + WAF), cache egress is the day's edge-cache HIT bytes
+	 * (split out so cache offload is visible); static storage is the day's gauge.
 	 */
 
 	interface Props {
@@ -32,6 +33,7 @@
 	let cpu = $state<MetricSeries[]>([])
 	let memory = $state<MetricSeries[]>([])
 	let egress = $state<MetricSeries[]>([])
+	let cacheEgress = $state<MetricSeries[]>([])
 	let replica = $state<MetricSeries[]>([])
 	let disk = $state<MetricSeries[]>([])
 	let storage = $state<MetricSeries[]>([])
@@ -49,6 +51,7 @@
 			cpu = []
 			memory = []
 			egress = []
+			cacheEgress = []
 			replica = []
 			disk = []
 			storage = []
@@ -58,6 +61,7 @@
 		cpu = [{ prefix: 'CPU', lines: resp.result.cpuUsage ?? [] }]
 		memory = [{ prefix: 'Memory', lines: resp.result.memory ?? [] }]
 		egress = [{ prefix: 'Egress', lines: resp.result.egress ?? [] }]
+		cacheEgress = [{ prefix: 'Cache egress', lines: resp.result.cacheEgress ?? [] }]
 		replica = [{ prefix: 'Replicas', lines: resp.result.replica ?? [] }]
 		disk = [{ prefix: 'Disk', lines: resp.result.disk ?? [] }]
 		storage = [{ prefix: 'Storage', lines: resp.result.staticStorage ?? [] }]
@@ -94,6 +98,7 @@
 	<Chart title="CPU (vCPU)" unit="count" series={cpu} range={filter.range} />
 	<Chart title="Memory (bytes)" unit="bytes" series={memory} range={filter.range} />
 	<Chart title="Egress (bytes)" unit="bytes" series={egress} range={filter.range} />
+	<Chart title="Cache Egress (bytes)" unit="bytes" series={cacheEgress} range={filter.range} />
 	<Chart title="Replicas" unit="count" series={replica} range={filter.range} />
 	<Chart title="Disk (bytes)" unit="bytes" series={disk} range={filter.range} />
 	<Chart title="Static Storage (bytes)" unit="bytes" series={storage} range={filter.range} />

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -1207,6 +1207,7 @@ const handlers: Record<string, (args: any) => object> = {
 		memory: dailyMetricLine('memory', 805306368),
 		disk: dailyMetricLine('disk', 10737418240),
 		egress: dailyMetricLine('egress', 1073741824),
+		cacheEgress: dailyMetricLine('cache_egress', 3221225472),
 		replica: dailyMetricLine('replica', 3),
 		staticStorage: dailyMetricLine('static_storage', 1610612736)
 	}),

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -947,6 +947,7 @@ declare namespace Api {
         memory: UsageMetricsLine[]
         disk: UsageMetricsLine[]
         egress: UsageMetricsLine[]
+        cacheEgress: UsageMetricsLine[]
         replica: UsageMetricsLine[]
         staticStorage: UsageMetricsLine[]
     }


### PR DESCRIPTION
## What

Adds a **Cache Egress (bytes)** chart to the project Metrics page, reading the new `cacheEgress` series from `project.metrics`. The existing **Egress** chart now means *origin* egress (pod + WAF); cache-served bytes get their own chart.

## Why

Cache egress (edge-cache HIT bytes) was folded silently into the project Egress total, so users couldn't see how much traffic the edge cache offloads. Splitting it out makes cache effectiveness visible. The two charts sum to the same billed total as before.

## Dependencies

- api: deploys-app/api#112 (adds `CacheEgress` to `ProjectMetricsResult`)
- apiserver: `project-cache-egress-chart` (stops folding `cache_egress`, returns the new series) — opens after api#112 merges + re-pin.

Degrades gracefully: `resp.result.cacheEgress ?? []` renders an empty chart against an apiserver that doesn't yet return the series, so this can merge independently.

## Screenshots

New **"Cache Egress (bytes)"** chart appears next to Egress.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/294-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/294-after.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_011d4bVuGLnCbcJD9ZvastPH