### PR TITLE
test: run Playwright suite on parallel workers

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,11 +10,20 @@ const useBuild = !!process.env.PLAYWRIGHT_USE_BUILD
 const devCommand = `bun run dev --port ${PORT} --strictPort --host 127.0.0.1`
 const buildCommand = 'bun ./build'
 
+// Tests are isolated per-test on the mock server (each carries a `mock_key`
+// cookie → `x-mock-key` header that buckets its mock state), so they run
+// concurrently. Default to half the runner's cores in CI; `PW_WORKERS`
+// overrides with an absolute number or a percentage like '50%'.
+const pwWorkers = process.env.PW_WORKERS
+const workers = pwWorkers
+	? (pwWorkers.endsWith('%') ? pwWorkers : Number(pwWorkers))
+	: (process.env.CI ? '50%' : undefined)
+
 export default defineConfig({
 	testDir: './tests',
 	testMatch: '**/*.spec.js',
-	fullyParallel: false,
-	workers: 1,
+	fullyParallel: true,
+	workers,
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 1 : 0,
 	reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',

--- a/src/routes/api/[fn]/+server.ts
+++ b/src/routes/api/[fn]/+server.ts
@@ -4,7 +4,7 @@ import { mockInvoke } from '$lib/server/mock'
 
 const endpoint = env.API_ENDPOINT || 'https://api.deploys.app'
 
-export const POST: RequestHandler = async ({ locals, params, request }) => {
+export const POST: RequestHandler = async ({ locals, params, request, cookies }) => {
 	// dev mock: short-circuit to static fixtures, no token required
 	if (env.MOCK_API) {
 		const args = await request.json().catch(() => ({}))
@@ -27,6 +27,13 @@ export const POST: RequestHandler = async ({ locals, params, request }) => {
 		})
 	}
 
+	// Test-only seam: the e2e harness sets a per-test `mock_key` cookie so the mock
+	// server (tests/mock-server.js) can isolate each test's responses + request-log
+	// into its own bucket — which is what lets the suite run on parallel workers.
+	// No-op in production: the cookie is never set there, so no header is sent and
+	// the real API simply never sees `x-mock-key`.
+	const mockKey = cookies.get('mock_key')
+
 	const resp = await fetch(`${endpoint}/${params.fn}`, {
 		method: 'POST',
 		body: request.body,
@@ -35,7 +42,8 @@ export const POST: RequestHandler = async ({ locals, params, request }) => {
 			accept: 'application/json',
 			'content-type': request.headers.get('content-type') ?? 'application/json',
 			authorization: `bearer ${token}`,
-			'x-deploys-channel': 'console'
+			'x-deploys-channel': 'console',
+			...(mockKey ? { 'x-mock-key': mockKey } : {})
 		}
 	})
 	return new Response(resp.body, {

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -182,6 +182,12 @@ export const sampleDeployment = {
 	sidecars: [],
 	url: 'https://web.test-project.app.in.th',
 	internalUrl: '',
+	// Keep these signed-URL fields empty. The console fetches them DIRECTLY from
+	// the browser (DeploymentStatusIcon / LiveLogs / events page), bypassing the
+	// /api proxy — so they never carry the per-test `x-mock-key` header. Pointing
+	// one at the mock server would leak state across parallel tests. If a test
+	// needs live status/logs, route it through the proxy (or bake the key into
+	// the URL and have the mock bucket on it), not via these fields.
 	logUrl: '',
 	eventUrl: '',
 	podsUrl: '',

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,13 +1,31 @@
 import { test as base, expect } from '@playwright/test'
+import { randomUUID } from 'node:crypto'
 
 const MOCK_PORT = Number(process.env.MOCK_PORT || 9999)
 const MOCK_URL = `http://localhost:${MOCK_PORT}`
 
 /**
- * Reset the mock server to its default responses.
+ * Per-test mock-state key. The mock server (tests/mock-server.js) buckets its
+ * responses + request-log by this key so tests can run on PARALLEL workers
+ * without sharing state.
+ *
+ * It is kept module-level (not threaded through every call) on purpose: a
+ * Playwright worker runs its tests serially in a single process, so only one
+ * test is ever active per worker, and each worker is its own process with its
+ * own copy of this module. That makes a module-level "current key" race-free
+ * and lets `resetMocks` / `setMocks` / `getRequestLog` keep their original
+ * argument-free signatures — the ~290 call sites across the specs are untouched.
+ * The same key is also written to the `mock_key` cookie (see `setMockKeyCookie`)
+ * so the /api proxy forwards it as `x-mock-key` on every data request.
+ */
+let currentKey = 'default'
+function keyQuery () { return `key=${encodeURIComponent(currentKey)}` }
+
+/**
+ * Reset the current test's mock bucket to its default responses.
  */
 export async function resetMocks () {
-	const res = await fetch(`${MOCK_URL}/__reset`, { method: 'POST' })
+	const res = await fetch(`${MOCK_URL}/__reset?${keyQuery()}`, { method: 'POST' })
 	if (!res.ok) throw new Error(`failed to reset mocks: ${res.status}`)
 }
 
@@ -20,7 +38,7 @@ export async function resetMocks () {
  * @param {Record<string, unknown>} overrides
  */
 export async function setMocks (overrides) {
-	const res = await fetch(`${MOCK_URL}/__set`, {
+	const res = await fetch(`${MOCK_URL}/__set?${keyQuery()}`, {
 		method: 'POST',
 		headers: { 'content-type': 'application/json' },
 		body: JSON.stringify(overrides)
@@ -29,13 +47,13 @@ export async function setMocks (overrides) {
 }
 
 /**
- * Fetch the mock server's request log (every upstream call since the last
+ * Fetch the current test's request log (every upstream call since the last
  * reset), so a test can assert what the page sent — e.g. the `waf.set` body.
  *
  * @returns {Promise<{ path: string, method: string, body: string }[]>}
  */
 export async function getRequestLog () {
-	const res = await fetch(`${MOCK_URL}/__log`)
+	const res = await fetch(`${MOCK_URL}/__log?${keyQuery()}`)
 	if (!res.ok) throw new Error(`failed to read request log: ${res.status}`)
 	return res.json()
 }
@@ -79,20 +97,48 @@ export async function signIn (context) {
 }
 
 /**
+ * Inject the per-test `mock_key` cookie (same scope as the token cookie) so the
+ * /api proxy forwards it as `x-mock-key` and the mock server routes both SSR and
+ * client requests to this test's bucket.
+ *
+ * @param {import('@playwright/test').BrowserContext} context
+ * @param {string} key
+ */
+export async function setMockKeyCookie (context, key) {
+	await context.addCookies([
+		{
+			name: 'mock_key',
+			value: key,
+			url: 'http://localhost:4173',
+			httpOnly: true,
+			sameSite: 'Lax'
+		}
+	])
+}
+
+/**
  * Test fixture variants:
  *  - `test`            — default. Resets mocks before each test, signs in.
  *  - `unauthedTest`    — resets mocks, but does NOT inject an auth cookie.
+ *
+ * Both mint a fresh per-test key (race-free: see `currentKey` above), set it as
+ * the `mock_key` cookie, and reset that bucket — so each test starts from a
+ * clean, isolated copy of the default mocks even under parallel workers.
  */
 export const test = base.extend({
 	context: async ({ context }, use) => {
-		await resetMocks()
+		currentKey = randomUUID()
+		await setMockKeyCookie(context, currentKey)
 		await signIn(context)
+		await resetMocks()
 		await use(context)
 	}
 })
 
 export const unauthedTest = base.extend({
 	context: async ({ context }, use) => {
+		currentKey = randomUUID()
+		await setMockKeyCookie(context, currentKey)
 		await resetMocks()
 		await use(context)
 	}

--- a/tests/mock-server.js
+++ b/tests/mock-server.js
@@ -6,11 +6,21 @@
  * `API_ENDPOINT=http://localhost:9999`, so every `/api/<fn>` proxy call
  * lands here.
  *
- * Tests configure responses per-test via two control endpoints:
- *   POST /__reset            — restore default responses
- *   POST /__set              — body: { "<path>": <response>, ... }
+ * Per-test isolation (so the suite can run on PARALLEL workers):
+ * every test gets its own state "bucket" keyed by a per-test id. The id is
+ * minted in tests/helpers.js and travels two ways —
+ *   - control endpoints (/__reset, /__set, /__log) carry it as `?key=<id>`;
+ *   - data requests carry it as the `x-mock-key` header, which the
+ *     /api/[fn] proxy forwards from the per-test `mock_key` cookie.
+ * A bucket holds its own `responses` map + `requestLog`, so concurrent tests
+ * never see or clobber each other's mocks. A data request with NO key fails
+ * loudly (400) rather than silently sharing state — that turns any future
+ * wiring gap into an obvious failure instead of a flaky heisenbug.
  *
- * Tests run with `workers: 1` so that the single shared mock state is safe.
+ * Control endpoints:
+ *   POST /__reset?key=<id>   — restore default responses for that bucket
+ *   POST /__set?key=<id>     — body: { "<path>": <response>, ... }
+ *   GET  /__log?key=<id>     — read that bucket's request log
  */
 
 import http from 'node:http'
@@ -18,8 +28,18 @@ import { defaultMocks } from './fixtures/mocks.js'
 
 const PORT = Number(process.env.MOCK_PORT || 9999)
 
-let responses = defaultMocks()
-const requestLog = []
+/** @type {Map<string, { responses: Record<string, any>, requestLog: { path: string, method: string, body: string }[] }>} */
+const buckets = new Map()
+
+/** Get (lazily creating) the state bucket for a test key. */
+function bucket (key) {
+	let b = buckets.get(key)
+	if (!b) {
+		b = { responses: defaultMocks(), requestLog: [] }
+		buckets.set(key, b)
+	}
+	return b
+}
 
 function readBody (req) {
 	return new Promise((resolve, reject) => {
@@ -36,19 +56,20 @@ const server = http.createServer(async (req, res) => {
 		const path = url.pathname
 
 		if (path === '/__reset' && req.method === 'POST') {
-			responses = defaultMocks()
-			requestLog.length = 0
+			const key = url.searchParams.get('key') || 'default'
+			buckets.set(key, { responses: defaultMocks(), requestLog: [] })
 			res.writeHead(200, { 'content-type': 'application/json' })
 			res.end(JSON.stringify({ ok: true }))
 			return
 		}
 
 		if (path === '/__set' && req.method === 'POST') {
+			const key = url.searchParams.get('key') || 'default'
 			const body = await readBody(req)
 			const overrides = body ? JSON.parse(body) : {}
-			for (const key of Object.keys(overrides)) {
-				const k = key.startsWith('/') ? key : `/${key}`
-				responses[k] = overrides[key]
+			const { responses } = bucket(key)
+			for (const k of Object.keys(overrides)) {
+				responses[k.startsWith('/') ? k : `/${k}`] = overrides[k]
 			}
 			res.writeHead(200, { 'content-type': 'application/json' })
 			res.end(JSON.stringify({ ok: true }))
@@ -56,14 +77,16 @@ const server = http.createServer(async (req, res) => {
 		}
 
 		if (path === '/__log' && req.method === 'GET') {
+			const key = url.searchParams.get('key') || 'default'
 			res.writeHead(200, { 'content-type': 'application/json' })
-			res.end(JSON.stringify(requestLog))
+			res.end(JSON.stringify(bucket(key).requestLog))
 			return
 		}
 
 		// Stand-in for the OAuth provider's token endpoint. `AUTH_ENDPOINT` is set
 		// to `${MOCK_URL}/__auth`, so the sign-in callback exchanges its code here.
-		// Always hand back a refresh token so the callback can complete.
+		// Always hand back a refresh token so the callback can complete. Stateless
+		// (touches no bucket), so the unauthenticated sign-in path needs no key.
 		if (path === '/__auth/token' && req.method === 'POST') {
 			await readBody(req)
 			res.writeHead(200, { 'content-type': 'application/json' })
@@ -71,6 +94,21 @@ const server = http.createServer(async (req, res) => {
 			return
 		}
 
+		// Data request: must carry a per-test key (the proxy forwards the
+		// `mock_key` cookie as `x-mock-key`). A missing key means the cookie→header
+		// wiring broke — fail loud instead of silently sharing a default bucket and
+		// bleeding state across parallel tests.
+		const key = /** @type {string | undefined} */ (req.headers['x-mock-key'])
+		if (!key) {
+			res.writeHead(400, { 'content-type': 'application/json' })
+			res.end(JSON.stringify({
+				ok: false,
+				error: { message: `mock: missing x-mock-key header for ${path}` }
+			}))
+			return
+		}
+
+		const { responses, requestLog } = bucket(key)
 		const body = await readBody(req)
 		requestLog.push({ path, method: req.method, body })
 


### PR DESCRIPTION
## Why

The console e2e suite ran on a single Playwright worker (`fullyParallel: false, workers: 1`). That wasn't a resource choice — it was forced by the mock server, which kept **one global** `responses` + `requestLog`. Two workers would stomp each other's mock state. ~290 tests therefore ran strictly serially.

## What

Isolate the mock state **per-test** so the suite can fan out across workers, with **zero changes to any spec file**:

- **`tests/mock-server.js`** — state is now bucketed by a per-test key (`Map<key, {responses, requestLog}>`, lazily seeded from `defaultMocks()`). Control endpoints (`/__reset`, `/__set`, `/__log`) carry the key as `?key=`; data requests carry it as an `x-mock-key` header. A data request with **no key fails loud (400)** rather than silently sharing a default bucket — any future cookie→header wiring gap becomes an obvious failure, not a flake.
- **`tests/helpers.js`** — each test mints a fresh `randomUUID()` key (race-free: a Playwright worker runs its tests serially in its own process), writes it to a `mock_key` cookie, and routes `resetMocks`/`setMocks`/`getRequestLog` to that bucket. **Helper signatures are unchanged**, so the ~290 call sites across the specs are untouched.
- **`src/routes/api/[fn]/+server.ts`** — forwards the `mock_key` cookie as the `x-mock-key` header on the upstream fetch. **No-op in production** (the cookie is never set there, so the real API never sees the header).
- **`playwright.config.ts`** — `fullyParallel: true`, `workers: '50%'` in CI (override with `PW_WORKERS`).
- **`tests/fixtures/mocks.js`** — guardrail comment on the signed-URL fields (`logUrl`/`eventUrl`/`podsUrl`/`statusUrl`), which the browser fetches directly (bypassing the proxy) and so must stay empty.

The CI workflow (`test.yaml`) needs no change — `workers` comes from the config when `CI=true`.

## Why the cookie carries the key

The `mock_key` cookie reaches the proxy on **both** request paths: client-side `api.invoke` (the browser auto-sends same-origin cookies, exactly as the `token` cookie already does) and SSR `load()` (SvelteKit's server `fetch` forwards the incoming request's cookies). The proxy is the single funnel to the stateful mock, so stamping the header there covers 100% of mock-bound traffic. The OAuth `/__auth/token` endpoint is stateless and needs no key.

## Validation

Measured on the adapter-node build with CI settings (20-core box):

| | Result | Time |
| --- | --- | --- |
| Serial (`workers=1`, current CI) | 290 passed | **3.2 min** |
| Parallel (`workers='50%'`, this PR) | 290 passed | **~24 s** |

~8x faster on this box; the ratio scales with the runner's core count. Serial stays green (backward compatible). `bun lint` and `bun check` clean.

> Note: running locally against the **vite dev** server at 10 workers can flake on timeouts under contention — that's dev-server load, not an isolation bug (the same tests pass serially and pass at 10 workers on the production build CI uses). `PW_WORKERS` is available to dial workers down on constrained runners.

## Follow-up (not in this PR)

`tests/deployment-routes.spec.js` uses a `gotoHydrated()` helper that waits on `networkidle` for every navigation across 11 tests — the biggest per-test waster found in the audit. Worth replacing with a deterministic hydration signal in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9FhPEapaKr4VugQBEdisj