### PR TITLE
fix: render Select dropdown above clipping ancestors (#295)

### DIFF
--- a/src/lib/components/Select.svelte
+++ b/src/lib/components/Select.svelte
@@ -52,9 +52,32 @@
 	// works, and re-arm on blur for the next focus.
 	let autofillGuard = $state(true)
 
+	let boxEl = $state<HTMLDivElement | undefined>()
 	let triggerEl = $state<HTMLButtonElement | undefined>()
 	let inputEl = $state<HTMLInputElement | undefined>()
 	let listEl = $state<HTMLDivElement | undefined>()
+
+	// The menu is positioned with `position: fixed` (anchored to the trigger via
+	// getBoundingClientRect) so it floats above any clipping ancestor — e.g. a
+	// modal panel with `overflow-y: auto` would otherwise trap and scroll it.
+	let menuStyle = $state('')
+
+	function positionMenu () {
+		if (!boxEl) return
+		const r = boxEl.getBoundingClientRect()
+		const gap = 6 // matches the old `top: calc(100% + 0.35rem)` offset
+		const margin = 8 // breathing room from the viewport edge
+		const maxH = 288 // 18rem cap, same as the CSS max-height
+		const below = window.innerHeight - r.bottom - gap - margin
+		const above = r.top - gap - margin
+		// Flip above only when there's too little room below and more room above.
+		const placeAbove = below < 160 && above > below
+		const avail = Math.max(120, Math.min(maxH, placeAbove ? above : below))
+		const vertical = placeAbove
+			? `bottom: ${window.innerHeight - r.top + gap}px`
+			: `top: ${r.bottom + gap}px`
+		menuStyle = `position: fixed; left: ${r.left}px; width: ${r.width}px; max-height: ${avail}px; ${vertical};`
+	}
 
 	// Editable mode filters the visible options by case-insensitive substring of
 	// the typed value. Non-editable mode always shows the full list.
@@ -235,9 +258,23 @@
 		const el = listEl.querySelector(`#${CSS.escape(optionId(activeIndex))}`)
 		if (el instanceof HTMLElement) el.scrollIntoView({ block: 'nearest' })
 	})
+
+	// While the menu is open, keep it pinned to the trigger as the page (or an
+	// ancestor such as a scrollable modal panel) scrolls or the window resizes.
+	$effect(() => {
+		if (!open) return
+		positionMenu()
+		const reposition = () => positionMenu()
+		window.addEventListener('scroll', reposition, true)
+		window.addEventListener('resize', reposition)
+		return () => {
+			window.removeEventListener('scroll', reposition, true)
+			window.removeEventListener('resize', reposition)
+		}
+	})
 </script>
 
-<div class="select-box {className}" class:is-disabled={disabled} use:clickOutside={close}>
+<div bind:this={boxEl} class="select-box {className}" class:is-disabled={disabled} use:clickOutside={close}>
 	{#if editable}
 		<div class="select-trigger select-trigger-editable" class:is-open={open}>
 			<!-- A combobox, not a real text field — suppress browser and
@@ -302,7 +339,7 @@
 	{/if}
 
 	{#if open}
-		<div bind:this={listEl} id={listboxId} class="select-menu" role="listbox" tabindex="-1">
+		<div bind:this={listEl} id={listboxId} class="select-menu" role="listbox" tabindex="-1" style={menuStyle}>
 			{#each visibleOptions as opt, i (i)}
 				{#if opt.separator}
 					<div class="select-sep" role="separator"></div>
@@ -523,11 +560,10 @@
 	}
 
 	.select-menu {
-		position: absolute;
-		top: calc(100% + 0.35rem);
-		left: 0;
-		z-index: 20;
-		width: 100%;
+		/* Positioned as `position: fixed` via an inline style (see positionMenu)
+		 * so the menu floats above clipping ancestors like a scrollable modal
+		 * panel. z-index sits above the modal layer (.modal is z-index 50). */
+		z-index: 100;
 		max-height: 18rem;
 		overflow-y: auto;
 		padding: 0.25rem;

--- a/src/lib/components/Select.svelte
+++ b/src/lib/components/Select.svelte
@@ -560,9 +560,14 @@
 	}
 
 	.select-menu {
-		/* Positioned as `position: fixed` via an inline style (see positionMenu)
-		 * so the menu floats above clipping ancestors like a scrollable modal
-		 * panel. z-index sits above the modal layer (.modal is z-index 50). */
+		/* `position: fixed` (with left/top/width/max-height supplied inline by
+		 * positionMenu) so the menu floats above clipping ancestors like a
+		 * scrollable modal panel. Declaring it here too — not just inline — keeps
+		 * the menu out of flow on its very first paint, before the positioning
+		 * effect runs; otherwise it would briefly be `static` inside .select-box
+		 * and inflate the trigger's measured height, mispositioning the first
+		 * open. z-index sits above the modal layer (.modal is z-index 50). */
+		position: fixed;
 		z-index: 100;
 		max-height: 18rem;
 		overflow-y: auto;


### PR DESCRIPTION
## Summary

Fixes #295 — the auth dropdown on the deployment routes "Create route" modal was rendering **inside** the modal (clipped/scrolled within it) instead of floating over it.

### Cause

`Select.svelte`'s menu was `position: absolute`. When the component is used inside `.modal-panel` (which has `overflow-y: auto`), the absolutely-positioned menu is clipped by that scroll container, so the open dropdown got trapped inside the modal rather than overlaying it.

### Fix

Position the menu with `position: fixed`, anchored to the trigger via `getBoundingClientRect()`, so it escapes any clipping/overflow ancestor:

- Compute `left` / `width` / vertical placement from the trigger's bounding rect and apply it as an inline style.
- Reposition on `scroll` (capture phase, so it tracks scrollable panels like the modal) and on `resize`.
- Flip the menu above the trigger when there isn't enough room below, capping `max-height` to the available space.
- Raise the menu `z-index` to `100`, above the `.modal` layer (`z-index: 50`).

This is a fix in the shared `Select` component, so it benefits every dropdown rendered inside a scrollable/clipping container, not just this modal.

### Testing

- `bun lint` — passes (0 errors)
- `bun check` — passes (0 errors)

> **Screenshots:** The repo guidelines ask for before/after screenshots on UI changes, but this sandboxed environment blocks the Playwright browser download (egress policy returns HTTP 400 for `cdn.playwright.dev` / `storage.googleapis.com`), so I couldn't capture them here. Happy to add them on a machine with browser access — the affected screen is **Deployment → Routes → Create route → "Protect with" dropdown**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqfizSKChDpGF881cBfCts)_