### PR TITLE
feat(cache): full-width hit/miss/stale/bypass chart on /cache

### DIFF
--- a/src/lib/components/CacheResultChart.svelte
+++ b/src/lib/components/CacheResultChart.svelte
@@ -1,0 +1,312 @@
+<script lang="ts">
+	import dayjs from 'dayjs'
+	import { niceScale } from '$lib/charts/util'
+
+	/**
+	 * A stacked-column view of edge response-cache outcomes over time, one stack
+	 * segment per result (HIT / STALE / MISS / BYPASS). Data arrives pre-bucketed
+	 * onto a shared time grid so the segments align. `formatY` formats the y-axis
+	 * and tooltip values, so the same chart renders request counts or byte volume
+	 * depending on the caller's view toggle. Pure SVG — colors come from design
+	 * tokens via CSS `var()`, so a theme toggle recolors the bars instantly.
+	 * (Mirrors WafActivityChart, generalized off the WAF-action coupling.)
+	 */
+
+	interface ResultSeries {
+		result: string
+		name: string
+		color: string
+		data: [number, number][] // [unixMs, value]
+	}
+
+	interface Props {
+		series: ResultSeries[] // bottom-to-top stacking order
+		from: number // x-extreme start, unix ms
+		to: number // x-extreme end, unix ms
+		formatY?: (v: number) => string
+	}
+
+	const { series, from, to, formatY = (v: number) => v.toLocaleString() }: Props = $props()
+
+	const PAD = { top: 14, right: 12, bottom: 26, left: 56 }
+	const height = 320
+
+	let width = $state(0)
+	let svgEl = $state<SVGSVGElement | undefined>()
+	let hover = $state<number | null>(null)
+
+	function track (node: HTMLElement) {
+		const ro = new ResizeObserver((entries) => {
+			width = entries[0].contentRect.width
+		})
+		ro.observe(node)
+		return { destroy: () => ro.disconnect() }
+	}
+
+	// Shared, sorted bucket x-positions across every result series.
+	const xs = $derived.by(() => {
+		const set = new Set(series.flatMap((s) => s.data.map((d) => d[0])))
+		return [...set].sort((a, b) => a - b)
+	})
+
+	// Per-result value lookup keyed by bucket x.
+	const lookups = $derived(series.map((s) => new Map(s.data.map((d) => d))))
+
+	const maxStack = $derived.by(() => {
+		let m = 0
+		for (const x of xs) {
+			let sum = 0
+			for (const map of lookups) sum += map.get(x) ?? 0
+			if (sum > m) m = sum
+		}
+		return m
+	})
+
+	const yInfo = $derived(niceScale(0, maxStack, 5))
+
+	const plot = $derived({
+		x0: PAD.left,
+		x1: Math.max(PAD.left + 1, width - PAD.right),
+		y0: PAD.top,
+		y1: height - PAD.bottom
+	})
+
+	const xScale = $derived((v: number) =>
+		plot.x0 + ((v - from) / (to - from || 1)) * (plot.x1 - plot.x0))
+
+	const yScale = $derived((v: number) =>
+		plot.y1 - ((v - yInfo.min) / (yInfo.max - yInfo.min)) * (plot.y1 - plot.y0))
+
+	const colW = $derived.by(() => {
+		const step = xs.length > 1 ? (plot.x1 - plot.x0) / xs.length : (plot.x1 - plot.x0) * 0.4
+		return Math.max(2, Math.min(step * 0.72, 44))
+	})
+
+	// One stack per bucket: an array of {result, color, name, value, y, h} segments.
+	const columns = $derived(xs.map((x, xi) => {
+		let cum = 0
+		const segs = series.map((s, si) => {
+			const v = lookups[si].get(x) ?? 0
+			const yTop = yScale(cum + v)
+			const yBase = yScale(cum)
+			cum += v
+			return { result: s.result, color: s.color, name: s.name, value: v, y: yTop, h: Math.max(0, yBase - yTop) }
+		})
+		return { x, xi, cx: xScale(x), total: cum, segs }
+	}))
+
+	const timeFmt = $derived.by(() => {
+		const span = to - from
+		const day = 86400000
+		if (span <= 2 * day) return (v: number) => dayjs(v).format('HH:mm')
+		if (span <= 8 * day) return (v: number) => dayjs(v).format('ddd HH:mm')
+		return (v: number) => dayjs(v).format('MMM D')
+	})
+
+	const xTicks = $derived.by(() => {
+		const count = 5
+		return Array.from({ length: count }, (_, i) => {
+			const v = from + ((to - from) * i) / (count - 1)
+			return { px: xScale(v), label: timeFmt(v), anchor: i === 0 ? 'start' : i === count - 1 ? 'end' : 'middle' }
+		})
+	})
+
+	const tip = $derived.by(() => {
+		if (hover == null || !columns[hover]) return null
+		const col = columns[hover]
+		const rows = col.segs.filter((s) => s.value > 0)
+		if (!rows.length) return null
+		return { px: col.cx, header: dayjs(col.x).format('MMM D, HH:mm'), total: col.total, rows }
+	})
+
+	function onMove (e: PointerEvent) {
+		if (!columns.length || !svgEl) return
+		const rect = svgEl.getBoundingClientRect()
+		const px = e.clientX - rect.left
+		let best = 0
+		let bestD = Infinity
+		for (let i = 0; i < columns.length; i++) {
+			const d = Math.abs(columns[i].cx - px)
+			if (d < bestD) { bestD = d; best = i }
+		}
+		hover = best
+	}
+
+	// Touch: capture the pointer on press so a horizontal drag keeps reading
+	// columns even when the finger strays outside the SVG, and reveal the nearest
+	// column on a plain tap. `touch-action: pan-y` leaves vertical page scroll to
+	// the browser, which fires pointercancel and clears the readout on a scroll.
+	function onDown (e: PointerEvent) {
+		if (e.pointerType !== 'mouse') svgEl?.setPointerCapture?.(e.pointerId)
+		onMove(e)
+	}
+
+	function onUp (e: PointerEvent) {
+		if (e.pointerType !== 'mouse') hover = null
+	}
+</script>
+
+<div class="chart" style:height={`${height}px`} use:track>
+	{#if width > 0}
+		<svg
+			bind:this={svgEl}
+			class="surface"
+			{width}
+			{height}
+			viewBox={`0 0 ${width} ${height}`}
+			role="img"
+			onpointerdown={onDown}
+			onpointermove={onMove}
+			onpointerup={onUp}
+			onpointercancel={() => (hover = null)}
+			onpointerleave={() => (hover = null)}>
+			<!-- gridlines + y labels -->
+			{#each yInfo.ticks as t (t)}
+				{@const gy = yScale(t)}
+				<line class="grid" x1={plot.x0} x2={plot.x1} y1={gy} y2={gy} />
+				<text class="axis-label" x={plot.x0 - 8} y={gy} text-anchor="end" dominant-baseline="middle">{formatY(t)}</text>
+			{/each}
+
+			<!-- x labels -->
+			{#each xTicks as t (t.px)}
+				<text class="axis-label" x={t.px} y={height - 8} text-anchor={t.anchor}>{t.label}</text>
+			{/each}
+
+			<!-- stacked columns; parent <g> animates once on mount -->
+			<g class="cols">
+				{#each columns as col (col.x)}
+					<g class="col" class:is-dim={hover != null && hover !== col.xi}>
+						{#each col.segs as seg (seg.result)}
+							{#if seg.h > 0}
+								<rect x={col.cx - colW / 2} y={seg.y} width={colW} height={seg.h} rx="1" style:fill={seg.color} />
+							{/if}
+						{/each}
+					</g>
+				{/each}
+			</g>
+		</svg>
+
+		{#if tip}
+			<div
+				class="tooltip"
+				style:left={`${tip.px}px`}
+				style:top={`${PAD.top}px`}
+				style:transform={tip.px > width / 2 ? 'translateX(calc(-100% - 10px))' : 'translateX(10px)'}>
+				<div class="tip-head">{tip.header}</div>
+				{#each tip.rows as row (row.result)}
+					<div class="tip-row">
+						<span class="tip-dot" style:background={row.color}></span>
+						<span class="tip-name">{row.name}</span>
+						<span class="tip-val">{formatY(row.value)}</span>
+					</div>
+				{/each}
+				<div class="tip-row tip-total">
+					<span class="tip-name">Total</span>
+					<span class="tip-val">{formatY(tip.total)}</span>
+				</div>
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.chart {
+		position: relative;
+		width: 100%;
+	}
+
+	.surface {
+		display: block;
+		/* let the page scroll vertically; horizontal drags read the chart */
+		touch-action: pan-y;
+	}
+
+	.grid {
+		stroke: hsl(var(--hsl-line) / 0.55);
+		stroke-width: 1;
+		shape-rendering: crispEdges;
+	}
+
+	.axis-label {
+		fill: hsl(var(--hsl-content) / 0.5);
+		font-size: 0.6875rem;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.col {
+		transition: opacity 0.12s ease;
+	}
+
+	.col.is-dim {
+		opacity: 0.4;
+	}
+
+	.tooltip {
+		position: absolute;
+		z-index: 5;
+		min-width: 9rem;
+		padding: 0.5rem 0.625rem;
+		border-radius: 0.5rem;
+		background: hsl(var(--hsl-base-300));
+		border: 1px solid hsl(var(--hsl-line));
+		box-shadow: 0 4px 12px hsl(220 20% 10% / 0.12), 0 12px 28px hsl(220 20% 10% / 0.16);
+		pointer-events: none;
+		font-size: 0.75rem;
+	}
+
+	.tip-head {
+		margin-bottom: 0.375rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.6);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.tip-row {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		line-height: 1.6;
+	}
+
+	.tip-dot {
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 9999px;
+		flex-shrink: 0;
+	}
+
+	.tip-name {
+		color: hsl(var(--hsl-content) / 0.8);
+		margin-right: auto;
+	}
+
+	.tip-val {
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+		padding-left: 0.75rem;
+	}
+
+	.tip-total {
+		margin-top: 0.25rem;
+		padding-top: 0.25rem;
+		border-top: 1px solid hsl(var(--hsl-line) / 0.7);
+	}
+
+	.tip-total .tip-name {
+		color: hsl(var(--hsl-content) / 0.6);
+		font-weight: 600;
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		.cols {
+			transform-box: fill-box;
+			transform-origin: center bottom;
+			animation: grow 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+		}
+
+		@keyframes grow {
+			from { opacity: 0; transform: scaleY(0.6); }
+			to { opacity: 1; transform: scaleY(1); }
+		}
+	}
+</style>

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -631,6 +631,43 @@ function cacheMetrics (timeRange?: string) {
 	return { series, total }
 }
 
+// Fills the project cache-performance chart (cache.resultMetrics) with per-result
+// requests + bytes over the requested window on an even 48-bucket grid, so the
+// stacked HIT/STALE/MISS/BYPASS columns align. BYPASS carries requests but no
+// cache bytes (bypassed responses are origin-served), matching production.
+function cacheResultMetrics (timeRange?: string) {
+	const now = Math.floor(Date.now() / 1000)
+	const windowSeconds = wafRangeSeconds[timeRange ?? '1d'] ?? wafRangeSeconds['1d']
+	const buckets = 48
+	const step = Math.max(60, Math.floor(windowSeconds / buckets))
+
+	const make = (result: Api.CacheResultSeries['result'], reqScale: number, byteScale: number) => {
+		const requests: [number, number][] = []
+		const bytes: [number, number][] = []
+		let requestsTotal = 0
+		let bytesTotal = 0
+		for (let i = 0; i < buckets; i++) {
+			const ts = now - windowSeconds + i * step
+			const r = Math.floor(reqScale * (0.5 + Math.random()))
+			requests.push([ts, r])
+			requestsTotal += r
+			const b = Math.floor(byteScale * (0.5 + Math.random()))
+			bytes.push([ts, b])
+			bytesTotal += b
+		}
+		return { result, requests, bytes, requestsTotal, bytesTotal }
+	}
+
+	return {
+		series: [
+			make('HIT', 820, 5_200_000),
+			make('STALE', 130, 720_000),
+			make('MISS', 240, 1_500_000),
+			make('BYPASS', 95, 0) // bypass: requests only, no cache bytes
+		]
+	}
+}
+
 // Locations (besides the seed LOCATION_ID) that have had cache configured in
 // this dev session, mapped to { description, polls }. Mirrors wafConfigured —
 // the simulated deployer flips a freshly created zone from pending → success
@@ -1840,6 +1877,7 @@ const handlers: Record<string, (args: any) => object> = {
 		if (location === LOCATION_ID) return ok(cacheMetrics(args?.timeRange))
 		return ok({ series: [], total: 0 })
 	},
+	'cache.resultMetrics': (args) => ok(cacheResultMetrics(args?.timeRange)),
 	'cache.delete': (args) => {
 		if (args?.location) cacheConfigured.delete(args.location)
 		return ok({})

--- a/src/routes/(auth)/(project)/cache/+page.svelte
+++ b/src/routes/(auth)/(project)/cache/+page.svelte
@@ -4,6 +4,10 @@
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import Sparkline from '$lib/components/Sparkline.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import CacheResultChart from '$lib/components/CacheResultChart.svelte'
+	import RangeSwitch from '$lib/components/RangeSwitch.svelte'
+	import { RANGE_SECONDS, RANGE_LABEL } from '$lib/metrics'
+	import { formatBytes, formatNumber } from '$lib/charts/util'
 	import { onMount } from 'svelte'
 	import api from '$lib/api'
 	import * as format from '$lib/format'
@@ -67,6 +71,74 @@
 			.map(([ts, v]) => ([Number(ts), v] as [number, number]))
 			.sort((a, b) => a[0] - b[0])
 	}
+
+	// Project-wide edge response-cache outcomes (hit/miss/stale/bypass), summed
+	// across every location, as a full-width stacked chart. The Requests/Bandwidth
+	// toggle reuses the same chart with a different value series + formatter.
+	const RESULT_ORDER = ['HIT', 'STALE', 'MISS', 'BYPASS'] as const // bottom-to-top
+	const RESULT_LABEL: Record<string, string> = { HIT: 'Hit', STALE: 'Stale', MISS: 'Miss', BYPASS: 'Bypass' }
+	const RESULT_COLOR: Record<string, string> = {
+		HIT: 'hsl(var(--hsl-positive))',
+		STALE: 'hsl(var(--hsl-warning))',
+		MISS: 'hsl(var(--hsl-primary))',
+		BYPASS: 'hsl(var(--hsl-content) / 0.35)'
+	}
+
+	let range = $state('1d')
+	let view = $state<'requests' | 'bandwidth'>('requests')
+	let resultMetrics = $state<Api.CacheResultMetricsResult | null>(null)
+	let resultLoading = $state(true)
+	let resultFetchedAt = $state(Math.floor(Date.now() / 1000))
+
+	async function fetchResultMetrics () {
+		resultLoading = true
+		const res = await api.invoke<Api.CacheResultMetricsResult>('cache.resultMetrics',
+			{ project, timeRange: range }, fetch)
+		resultFetchedAt = Math.floor(Date.now() / 1000)
+		resultMetrics = res.ok ? res.result : { series: [] }
+		resultLoading = false
+	}
+
+	onMount(fetchResultMetrics)
+
+	function selectRange (v: string) {
+		if (v === range) return
+		range = v
+		fetchResultMetrics()
+	}
+
+	const seriesByResult = $derived(new Map((resultMetrics?.series ?? []).map((s) => [s.result, s])))
+
+	const chartSeries = $derived(RESULT_ORDER.map((result) => {
+		const s = seriesByResult.get(result)
+		const pts = (view === 'requests' ? s?.requests : s?.bytes) ?? []
+		return {
+			result,
+			name: RESULT_LABEL[result],
+			color: RESULT_COLOR[result],
+			data: pts.map(([ts, v]) => [ts * 1000, v] as [number, number])
+		}
+	}))
+
+	const fmtY = $derived(view === 'bandwidth' ? formatBytes : formatNumber)
+	const chartFrom = $derived((resultFetchedAt - (RANGE_SECONDS[range] ?? 86400)) * 1000)
+	const chartTo = $derived(resultFetchedAt * 1000)
+
+	// Cache hit ratio for the active view: cache-served (HIT + STALE) over all
+	// outcomes. STALE counts as served-from-cache (the body comes from the store).
+	const ratio = $derived.by(() => {
+		let served = 0
+		let all = 0
+		for (const s of resultMetrics?.series ?? []) {
+			const v = view === 'requests' ? (s.requestsTotal ?? 0) : (s.bytesTotal ?? 0)
+			all += v
+			if (s.result === 'HIT' || s.result === 'STALE') served += v
+		}
+		return all > 0 ? served / all : 0
+	})
+
+	const hasResultData = $derived((resultMetrics?.series ?? []).some((s) =>
+		(view === 'requests' ? (s.requestsTotal ?? 0) : (s.bytesTotal ?? 0)) > 0))
 </script>
 
 <div class="page-head">
@@ -80,6 +152,40 @@
 		<i class="fa-solid fa-plus"></i>
 		Configure cache
 	</GuardedButton>
+</div>
+
+<div class="panel is-level-300 cache-perf">
+	<div class="perf-head">
+		<div>
+			<h6 class="perf-title"><strong>Cache performance</strong></h6>
+			<p class="perf-sub">Edge cache outcomes across all locations · {RANGE_LABEL[range] ?? range}</p>
+		</div>
+		<div class="perf-controls">
+			<div class="seg" role="group" aria-label="Metric">
+				<button type="button" class="seg-btn" class:is-active={view === 'requests'}
+					aria-pressed={view === 'requests'} onclick={() => (view = 'requests')}>Requests</button>
+				<button type="button" class="seg-btn" class:is-active={view === 'bandwidth'}
+					aria-pressed={view === 'bandwidth'} onclick={() => (view = 'bandwidth')}>Bandwidth</button>
+			</div>
+			<RangeSwitch value={range} onselect={selectRange} />
+		</div>
+	</div>
+
+	{#if resultLoading}
+		<div class="perf-empty"><i class="fa-solid fa-spinner-third fa-spin"></i></div>
+	{:else if !hasResultData}
+		<div class="perf-empty">No cache activity in the {RANGE_LABEL[range] ?? range}.</div>
+	{:else}
+		<div class="legend">
+			{#each RESULT_ORDER as r (r)}
+				<span class="legend-item">
+					<span class="legend-dot" style:background={RESULT_COLOR[r]}></span>{RESULT_LABEL[r]}
+				</span>
+			{/each}
+			<span class="legend-ratio">Hit ratio <strong>{(ratio * 100).toFixed(1)}%</strong></span>
+		</div>
+		<CacheResultChart series={chartSeries} from={chartFrom} to={chartTo} formatY={fmtY} />
+	{/if}
 </div>
 
 <div class="panel is-level-300">
@@ -193,5 +299,105 @@
 
 	.matches-link:hover {
 		color: hsl(var(--hsl-primary));
+	}
+
+	.cache-perf {
+		margin-bottom: 1rem;
+	}
+
+	.perf-head {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 1rem;
+		flex-wrap: wrap;
+		margin-bottom: 0.75rem;
+	}
+
+	.perf-title {
+		color: hsl(var(--hsl-content) / 0.85);
+	}
+
+	.perf-sub {
+		margin-top: 0.125rem;
+		font-size: 0.8125rem;
+		color: hsl(var(--hsl-content) / 0.5);
+	}
+
+	.perf-controls {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		flex-wrap: wrap;
+	}
+
+	/* Segmented Requests|Bandwidth toggle — mirrors RangeSwitch styling. */
+	.seg {
+		display: inline-flex;
+		padding: 0.1875rem;
+		gap: 0.125rem;
+		border-radius: 0.625rem;
+		background: hsl(var(--hsl-base-200));
+		border: 1px solid hsl(var(--hsl-line) / 0.7);
+	}
+
+	.seg-btn {
+		padding: 0.3125rem 0.6875rem;
+		border-radius: 0.4375rem;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.6);
+		transition: color var(--timing-fastest) ease, background var(--timing-fastest) ease;
+	}
+
+	.seg-btn:hover {
+		color: hsl(var(--hsl-content) / 0.9);
+	}
+
+	.seg-btn.is-active {
+		color: hsl(var(--hsl-primary-content));
+		background: hsl(var(--hsl-primary));
+	}
+
+	.perf-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 320px;
+		color: hsl(var(--hsl-content) / 0.45);
+		font-size: 0.875rem;
+	}
+
+	.legend {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		flex-wrap: wrap;
+		margin-bottom: 0.5rem;
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-content) / 0.7);
+	}
+
+	.legend-item {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+	}
+
+	.legend-dot {
+		width: 0.625rem;
+		height: 0.625rem;
+		border-radius: 3px;
+		flex-shrink: 0;
+	}
+
+	.legend-ratio {
+		margin-left: auto;
+		color: hsl(var(--hsl-content) / 0.55);
+	}
+
+	.legend-ratio strong {
+		color: hsl(var(--hsl-content));
+		font-variant-numeric: tabular-nums;
 	}
 </style>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -923,6 +923,19 @@ declare namespace Api {
         total: number
     }
 
+    export type CacheResultSeries = {
+        result: 'HIT' | 'MISS' | 'STALE' | 'BYPASS'
+        // [unixSeconds, value], time-ordered
+        requests: [number, number][]
+        bytes: [number, number][]
+        requestsTotal: number
+        bytesTotal: number
+    }
+
+    export type CacheResultMetricsResult = {
+        series: CacheResultSeries[]
+    }
+
     export type DropboxItem = {
         downloadUrl: string
         filename: string

--- a/tests/cache.spec.js
+++ b/tests/cache.spec.js
@@ -54,7 +54,7 @@ test.describe('cache list', () => {
 		await page.goto('/cache?project=test-project')
 
 		const main = page.locator('.content-wrapper')
-		await expect(main.getByRole('heading', { name: 'Cache' })).toBeVisible()
+		await expect(main.getByRole('heading', { name: 'Cache', exact: true })).toBeVisible()
 		await expect(main.getByRole('link', { name: 'gke', exact: true })).toBeVisible()
 		await expect(main.getByRole('link', { name: 'sgp', exact: true })).toBeVisible()
 		await expect(main.getByText('prod edge')).toBeVisible()


### PR DESCRIPTION
## What

Adds a **Cache performance** chart to the top of the project cache page (`/cache`): a full-width stacked **HIT / STALE / MISS / BYPASS** column chart, summed across all of the project's locations, with a **Requests | Bandwidth** toggle, a 1h–30d range switch, and a hit-ratio readout.

- **Requests** view ← `parapet_cache_total` (counts, all four results).
- **Bandwidth** view ← `parapet_cache_egress_bytes` (bytes; BYPASS is 0 — bypassed responses are origin-served).

via the new `cache.resultMetrics` RPC (sums across locations). Degrades to an empty-state until the apiserver/edge ship.

## Implementation

- New `CacheResultChart.svelte` generalizes `WafActivityChart`'s stacked-column SVG engine with a per-series `color` and a `formatY` prop, so the same chart renders request counts (`formatNumber`) or byte volume (`formatBytes`) per the toggle — no chart dependency, theme-reactive CSS-var colors.
- `api.d.ts` type + `mock.ts` fixture added.

## Dependencies

- api: deploys-app/api#113 (`cache.resultMetrics` types)
- apiserver: `cache-result-metrics` (RPC + table) — opens after api#113 merges.
- collector + parapet (moonrhythm/parapet-ingress-controller#173) feed the data.

## Screenshots

**Before** — `/cache` was just the zone table:

![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/299-before.png)

**After** — full-width chart above the table, with the Requests | Bandwidth toggle:

| Requests | Bandwidth |
| --- | --- |
| ![requests](https://raw.githubusercontent.com/deploys-app/console/screenshots/299-after-requests.png) | ![bandwidth](https://raw.githubusercontent.com/deploys-app/console/screenshots/299-after-bandwidth.png) |

Note the y-axis switches to binary byte units under Bandwidth, and the hit ratio recomputes per view (requests-weighted vs bytes-weighted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_011d4bVuGLnCbcJD9ZvastPH