### PR TITLE
feat(cache): add cache purge to the cache page

### DIFF
--- a/src/lib/components/CachePurgeModal.svelte
+++ b/src/lib/components/CachePurgeModal.svelte
@@ -1,0 +1,229 @@
+<script lang="ts">
+	import Select from '$lib/components/Select.svelte'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+
+	/**
+	 * Purge edge-cached content for one of the project's domains. The edge cache
+	 * keys on the request host, so a purge is addressed by domain (+ optional
+	 * path), exactly like the domain detail page's purge controls — this modal
+	 * just brings the same capability to the cache hub and lets the user pick any
+	 * domain in one place. Domains are loaded lazily on open() (most cache-page
+	 * visitors never purge), so the page loader stays untouched and a forbidden
+	 * domain.list never breaks the page.
+	 *
+	 * Backed by the domain.purgeCache RPC ({ project, domain, file?, prefix? }):
+	 * no field → purge everything, prefix → purge a path prefix, file → purge one
+	 * exact path.
+	 */
+
+	interface Props {
+		project: string
+	}
+
+	const { project }: Props = $props()
+
+	type Scope = 'everything' | 'prefix' | 'file'
+
+	let isActive = $state(false)
+	let loading = $state(false)
+	let submitting = $state(false)
+	let domains = $state<Api.Domain[]>([])
+	let loadError = $state<Api.Error | undefined>()
+
+	let domain = $state('')
+	let scope = $state<Scope>('everything')
+	let path = $state('')
+
+	// Wildcard domains can't be purged — the edge purge targets an exact host —
+	// so only non-wildcard domains are selectable, matching the domain detail
+	// page, which disables purge for wildcards.
+	const purgeable = $derived(domains.filter((d) => !d.wildcard))
+	const options = $derived(purgeable.map((d) => ({ value: d.domain, label: d.domain })))
+
+	const needsPath = $derived(scope !== 'everything')
+	const canPurge = $derived(!!domain && (!needsPath || path.trim() !== ''))
+
+	export async function open (): Promise<void> {
+		isActive = true
+		submitting = false
+		scope = 'everything'
+		path = ''
+		domain = ''
+		loadError = undefined
+		domains = []
+		loading = true
+
+		const resp = await api.invoke<Api.List<Api.Domain>>('domain.list', { project }, fetch)
+		loading = false
+		if (!resp.ok) {
+			loadError = resp.error
+			return
+		}
+		domains = resp.result?.items ?? []
+		// Preselect the first purgeable domain so "Purge everything" is one click.
+		domain = purgeable[0]?.domain ?? ''
+	}
+
+	function close () {
+		if (submitting) return
+		isActive = false
+	}
+
+	function selectScope (s: Scope) {
+		scope = s
+		if (s === 'everything') path = ''
+	}
+
+	async function purge () {
+		if (!canPurge || submitting) return
+
+		const args: { project: string, domain: string, file?: string, prefix?: string } = { project, domain }
+		const trimmed = path.trim()
+		if (scope === 'prefix') args.prefix = trimmed
+		if (scope === 'file') args.file = trimmed
+
+		submitting = true
+		try {
+			const resp = await api.invoke('domain.purgeCache', args, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+			isActive = false
+			const what = scope === 'everything'
+				? 'all cached content'
+				: scope === 'prefix'
+					? `path prefix "${trimmed}"`
+					: `exact path "${trimmed}"`
+			modal.success({ content: `Purged ${what} on "${domain}".` })
+		} finally {
+			submitting = false
+		}
+	}
+</script>
+
+<div class="modal" onclick={close} class:is-active={isActive} aria-hidden={!isActive}>
+	<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+	<div class="modal-panel" onclick={(e) => e.stopPropagation()}>
+		<div class="modal-close" onclick={close} onkeypress={close} tabindex="0" role="button">✕</div>
+		<h4><strong>Purge cache</strong></h4>
+		<p class="page-sub mt-1">
+			Drop edge-cached content so the next request refetches from origin. Purges
+			are immediate and global across all locations.
+		</p>
+
+		{#if loading}
+			<div class="state"><i class="fa-solid fa-spinner-third fa-spin"></i></div>
+		{:else if loadError}
+			<div class="state is-error">Couldn't load domains. Close and try again.</div>
+		{:else if purgeable.length === 0}
+			<div class="state">
+				No purgeable domains. Add a custom domain to this project first —
+				wildcard domains can't be purged.
+				<a class="link" href={`/domain?project=${project}`}>Manage domains</a>
+			</div>
+		{:else}
+			<div class="field mt-4">
+				<label for="purge-domain">Domain</label>
+				<Select id="purge-domain" bind:value={domain} {options} placeholder="Select domain" required />
+			</div>
+
+			<div class="field mt-4">
+				<span class="label">Scope</span>
+				<div class="seg" role="group" aria-label="Purge scope">
+					<button type="button" class="seg-btn" class:is-active={scope === 'everything'}
+						aria-pressed={scope === 'everything'} onclick={() => selectScope('everything')}>Everything</button>
+					<button type="button" class="seg-btn" class:is-active={scope === 'prefix'}
+						aria-pressed={scope === 'prefix'} onclick={() => selectScope('prefix')}>Path prefix</button>
+					<button type="button" class="seg-btn" class:is-active={scope === 'file'}
+						aria-pressed={scope === 'file'} onclick={() => selectScope('file')}>Exact path</button>
+				</div>
+			</div>
+
+			{#if needsPath}
+				<div class="field mt-4">
+					<label for="purge-path">{scope === 'prefix' ? 'Path prefix' : 'Exact path'}</label>
+					<div class="input">
+						<input id="purge-path" bind:value={path}
+							placeholder={scope === 'prefix' ? '/static/' : '/static/app.js'}
+							onkeydown={(e) => { if (e.key === 'Enter' && canPurge) purge() }}>
+					</div>
+					<p class="hint">
+						{scope === 'prefix'
+							? 'Every cached path that starts with this prefix is dropped.'
+							: 'Only this exact cached path is dropped.'}
+					</p>
+				</div>
+			{/if}
+
+			<div class="actions mt-6">
+				<button class="button is-variant-tertiary" onclick={close} disabled={submitting}>Cancel</button>
+				<button class="button is-variant-negative" class:is-loading={submitting}
+					onclick={purge} disabled={!canPurge || submitting}>Purge</button>
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.modal-panel {
+		width: 100%;
+		max-width: 32rem;
+	}
+
+	.state {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.5rem;
+		min-height: 6rem;
+		margin-top: 1rem;
+		color: hsl(var(--hsl-content) / 0.6);
+		font-size: 0.875rem;
+	}
+
+	.state.is-error {
+		color: hsl(var(--hsl-negative) / 0.85);
+	}
+
+	.hint {
+		margin-top: 0.375rem;
+		font-size: 0.8125rem;
+		color: hsl(var(--hsl-content) / 0.55);
+	}
+
+	/* Segmented scope toggle — mirrors the cache page's Requests|Bandwidth seg. */
+	.seg {
+		display: inline-flex;
+		padding: 0.1875rem;
+		gap: 0.125rem;
+		border-radius: 0.625rem;
+		background: hsl(var(--hsl-base-200));
+		border: 1px solid hsl(var(--hsl-line) / 0.7);
+	}
+
+	.seg-btn {
+		padding: 0.3125rem 0.6875rem;
+		border-radius: 0.4375rem;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: hsl(var(--hsl-content) / 0.6);
+		transition: color var(--timing-fastest) ease, background var(--timing-fastest) ease;
+	}
+
+	.seg-btn:hover {
+		color: hsl(var(--hsl-content) / 0.9);
+	}
+
+	.seg-btn.is-active {
+		color: hsl(var(--hsl-primary-content));
+		background: hsl(var(--hsl-primary));
+	}
+
+	.actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 1rem;
+	}
+</style>

--- a/src/routes/(auth)/(project)/cache/+page.svelte
+++ b/src/routes/(auth)/(project)/cache/+page.svelte
@@ -5,6 +5,7 @@
 	import Sparkline from '$lib/components/Sparkline.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import CacheResultChart from '$lib/components/CacheResultChart.svelte'
+	import CachePurgeModal from '$lib/components/CachePurgeModal.svelte'
 	import RangeSwitch from '$lib/components/RangeSwitch.svelte'
 	import { RANGE_SECONDS, RANGE_LABEL } from '$lib/metrics'
 	import { formatBytes, formatNumber } from '$lib/charts/util'
@@ -139,6 +140,8 @@
 
 	const hasResultData = $derived((resultMetrics?.series ?? []).some((s) =>
 		(view === 'requests' ? (s.requestsTotal ?? 0) : (s.bytesTotal ?? 0)) > 0))
+
+	let purgeModal = $state<CachePurgeModal>()
 </script>
 
 <div class="page-head">
@@ -148,11 +151,19 @@
 			{zones.length} {zones.length === 1 ? 'cache zone' : 'cache zones'}
 		</p>
 	</div>
-	<GuardedButton permission="cache.set" class="button is-icon-left" href={`/cache/create?project=${project}`}>
-		<i class="fa-solid fa-plus"></i>
-		Configure cache
-	</GuardedButton>
+	<div class="head-actions">
+		<GuardedButton permission="domain.purgecache" class="button is-variant-secondary is-icon-left" onclick={() => purgeModal?.open()}>
+			<i class="fa-solid fa-broom"></i>
+			Purge cache
+		</GuardedButton>
+		<GuardedButton permission="cache.set" class="button is-icon-left" href={`/cache/create?project=${project}`}>
+			<i class="fa-solid fa-plus"></i>
+			Configure cache
+		</GuardedButton>
+	</div>
 </div>
+
+<CachePurgeModal bind:this={purgeModal} {project} />
 
 <div class="panel is-level-300 cache-perf">
 	<div class="perf-head">
@@ -279,6 +290,13 @@
 </div>
 
 <style>
+	.head-actions {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+	}
+
 	/* Hold a fixed box across the loading / loaded / empty states: min-height
 	   matches the Sparkline's height (28px) and min-width its count + chart, so
 	   the row doesn't grow taller or the column wider when the chart loads. */

--- a/tests/cache.spec.js
+++ b/tests/cache.spec.js
@@ -1,5 +1,5 @@
 import { test, expect, setMocks, getRequestLog } from './helpers.js'
-import { defaultLocation } from './fixtures/mocks.js'
+import { defaultLocation, sampleDomain } from './fixtures/mocks.js'
 
 // A cache-capable location (the default fixture location has no `cache` feature).
 const cacheLocation = { ...defaultLocation, id: 'gke', features: { cache: true } }
@@ -240,5 +240,85 @@ test.describe('cache override editor', () => {
 		// must be omitted from the payload.
 		expect(body.overrides[0].ttl).toBeUndefined()
 		expect(body.overrides[0].policy).toBeUndefined()
+	})
+})
+
+test.describe('cache purge', () => {
+	// The cache page renders fine with no zones; purge is driven entirely by the
+	// project's domains, fetched lazily when the modal opens.
+	const baseMocks = {
+		'cache.list': { ok: true, result: { project: 'test-project', items: [] } },
+		'cache.resultMetrics': { ok: true, result: { series: [] } }
+	}
+
+	test('purges everything for the preselected domain', async ({ page }) => {
+		await setMocks({
+			...baseMocks,
+			'domain.list': { ok: true, result: { items: [sampleDomain] } },
+			'domain.purgeCache': { ok: true, result: {} }
+		})
+
+		await page.goto('/cache?project=test-project')
+		await page.getByRole('button', { name: 'Purge cache' }).click()
+
+		// The modal loads domains and preselects the first purgeable one, so
+		// "Everything" is a one-click purge.
+		const modal = page.locator('.modal.is-active')
+		await expect(modal.getByRole('heading', { name: 'Purge cache' })).toBeVisible()
+		await modal.getByRole('button', { name: 'Purge', exact: true }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/domain.purgeCache')
+		}).toBe(true)
+
+		const req = (await getRequestLog()).find((r) => r.path === '/domain.purgeCache')
+		const body = JSON.parse(req?.body ?? '{}')
+		expect(body.domain).toBe('example.com')
+		// "Everything" sends neither file nor prefix.
+		expect(body.file).toBeUndefined()
+		expect(body.prefix).toBeUndefined()
+	})
+
+	test('purges a path prefix', async ({ page }) => {
+		await setMocks({
+			...baseMocks,
+			'domain.list': { ok: true, result: { items: [sampleDomain] } },
+			'domain.purgeCache': { ok: true, result: {} }
+		})
+
+		await page.goto('/cache?project=test-project')
+		await page.getByRole('button', { name: 'Purge cache' }).click()
+
+		const modal = page.locator('.modal.is-active')
+		await modal.getByRole('button', { name: 'Path prefix' }).click()
+		await modal.locator('#purge-path').fill('/static/')
+		await modal.getByRole('button', { name: 'Purge', exact: true }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/domain.purgeCache')
+		}).toBe(true)
+
+		const req = (await getRequestLog()).find((r) => r.path === '/domain.purgeCache')
+		const body = JSON.parse(req?.body ?? '{}')
+		expect(body.domain).toBe('example.com')
+		expect(body.prefix).toBe('/static/')
+		expect(body.file).toBeUndefined()
+	})
+
+	test('excludes wildcard domains and shows the empty state', async ({ page }) => {
+		await setMocks({
+			...baseMocks,
+			// Only a wildcard domain exists — the edge purge can't target it.
+			'domain.list': { ok: true, result: { items: [{ ...sampleDomain, domain: '*.example.com', wildcard: true }] } }
+		})
+
+		await page.goto('/cache?project=test-project')
+		await page.getByRole('button', { name: 'Purge cache' }).click()
+
+		const modal = page.locator('.modal.is-active')
+		await expect(modal.getByText('No purgeable domains.')).toBeVisible()
+		await expect(modal.getByRole('button', { name: 'Purge', exact: true })).toHaveCount(0)
 	})
 })


### PR DESCRIPTION
## What

Adds a **Purge cache** function to the cache page. A new button in the page header opens a modal that lets you pick one of the project's domains and purge:

- **Everything** — drop all edge-cached content for the domain
- **Path prefix** — drop every cached path under a prefix (e.g. `/static/`)
- **Exact path** — drop a single cached path

Backed by the existing `domain.purgeCache` RPC (`{ project, domain, file?, prefix? }`) — the same capability that already lives on the domain detail page, now reachable from the cache hub with a domain picker.

## Design notes

- **Lazy domain load.** Domains are fetched (`domain.list`) only when the modal opens — most cache-page visitors never purge — so the page loader is untouched and a forbidden `domain.list` can't break the page.
- **Wildcard domains excluded.** The edge purge targets an exact host, so wildcard domains aren't selectable (matches the domain detail page, which disables purge for wildcards). When a project has no purgeable domains the modal shows an empty state linking to domain management.
- **Permission-gated.** The button is a `GuardedButton` requiring `domain.purgecache`; denied users see the disabled control + deny tooltip.
- **Self-contained component** `CachePurgeModal.svelte` following the in-page Svelte modal pattern (like `RegistryGcModal`).

## Tests

Three Playwright tests in `cache.spec.js`: purge-everything (preselected domain, no file/prefix in payload), purge-prefix (prefix in payload), and wildcard-only → empty state. `bun lint` + `bun check` green; full `cache.spec.js` passes serially (11/11).

## Screenshots

| Cache page (new button) | Purge — Everything | Purge — Path prefix |
| --- | --- | --- |
| ![page](https://raw.githubusercontent.com/deploys-app/console/screenshots/301-page.png) | ![everything](https://raw.githubusercontent.com/deploys-app/console/screenshots/301-everything.png) | ![prefix](https://raw.githubusercontent.com/deploys-app/console/screenshots/301-prefix.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
