### PR TITLE
fix(metrics): refetch client-side charts/lists on project or detail-param change

### DIFF
--- a/src/lib/deployment/HistoryLogs.svelte
+++ b/src/lib/deployment/HistoryLogs.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte'
+	import { untrack } from 'svelte'
 	import { SvelteSet } from 'svelte/reactivity'
 	import api from '$lib/api'
 	import { podPrefixStripper } from '$lib/deployment/podName'
@@ -56,7 +56,10 @@
 			forbidden = false
 			nextCursor = ''
 			capped = false
-			const ms = RANGES.find((r) => r.value === range)?.ms ?? 3_600_000
+			// `range` is read untracked so the deployment-keyed effect below isn't
+			// also triggered by range changes — those reload via setRange.
+			const rangeVal = untrack(() => range)
+			const ms = RANGES.find((x) => x.value === rangeVal)?.ms ?? 3_600_000
 			windowSince = new Date(Date.now() - ms).toISOString()
 		} else {
 			if (!nextCursor || loadingMore) return
@@ -116,7 +119,14 @@
 	})
 	const visibleCount = $derived(filteredIds ? filteredIds.size : lines.length)
 
-	onMount(() => {
+	// Reload the history when the deployment identity changes. This component is
+	// the History tab of /deployment/(detail)/logs and is rendered with no {#key},
+	// so navigating between deployments (?name=/?location= change, same route)
+	// reuses it WITHOUT remounting — an onMount-only load would strand the
+	// previous deployment's log lines. loadHistory(true) reads
+	// deployment.project/location/name synchronously, so the effect tracks them
+	// (range is untracked; setRange reloads on a range change).
+	$effect(() => {
 		loadHistory(true)
 	})
 </script>

--- a/src/routes/(auth)/(project)/cache/+page.svelte
+++ b/src/routes/(auth)/(project)/cache/+page.svelte
@@ -9,7 +9,7 @@
 	import RangeSwitch from '$lib/components/RangeSwitch.svelte'
 	import { RANGE_SECONDS, RANGE_LABEL } from '$lib/metrics'
 	import { formatBytes, formatNumber } from '$lib/charts/util'
-	import { onMount } from 'svelte'
+	import { onMount, untrack } from 'svelte'
 	import api from '$lib/api'
 	import * as format from '$lib/format'
 
@@ -44,19 +44,31 @@
 	const to = Math.floor(Date.now() / 1000)
 	const from = to - 24 * 60 * 60
 
-	onMount(() => {
-		Promise.all(zones.map(async (z: Api.CacheZone) => {
-			metrics[z.location] = { loading: true, total: 0, points: [] }
+	// Refetch the per-zone sparklines when the project changes. A project switch
+	// navigates to /cache via goto (overrideRedirect) WITHOUT remounting this
+	// page, so an onMount fetch would keep showing the previous project's
+	// decisions — track `project` in an $effect instead. `zones` is read through
+	// untrack so the 3s cache.list poll (which replaces the zones array while a
+	// zone is pending) doesn't re-trigger a fetch storm; on a project switch
+	// `project` and `zones` update together, so the untracked read still sees the
+	// new project's zones.
+	$effect(() => {
+		const p = project
+		untrack(() => {
+			for (const k of Object.keys(metrics)) delete metrics[k]
+			Promise.all(zones.map(async (z: Api.CacheZone) => {
+				metrics[z.location] = { loading: true, total: 0, points: [] }
 
-			const res = await api.invoke<Api.CacheMetricsResult>('cache.metrics',
-				{ project, location: z.location, timeRange: '1d' }, fetch)
+				const res = await api.invoke<Api.CacheMetricsResult>('cache.metrics',
+					{ project: p, location: z.location, timeRange: '1d' }, fetch)
 
-			metrics[z.location] = {
-				loading: false,
-				total: res.result?.total ?? 0,
-				points: aggregate(res.result?.series ?? [])
-			}
-		}))
+				metrics[z.location] = {
+					loading: false,
+					total: res.result?.total ?? 0,
+					points: aggregate(res.result?.series ?? [])
+				}
+			}))
+		})
 	})
 
 	// Collapse the per-(override, action, result) series into one total-decisions
@@ -93,14 +105,25 @@
 
 	async function fetchResultMetrics () {
 		resultLoading = true
+		// `range` is read untracked so the project-keyed effect below isn't also
+		// triggered by range changes — those refetch via selectRange.
+		const r = untrack(() => range)
 		const res = await api.invoke<Api.CacheResultMetricsResult>('cache.resultMetrics',
-			{ project, timeRange: range }, fetch)
+			{ project, timeRange: r }, fetch)
 		resultFetchedAt = Math.floor(Date.now() / 1000)
 		resultMetrics = res.ok ? res.result : { series: [] }
 		resultLoading = false
 	}
 
-	onMount(fetchResultMetrics)
+	// Refetch the project cache-performance chart when the project changes. Same
+	// reason as the sparklines: a project switch reuses this component, so onMount
+	// would never re-run. fetchResultMetrics reads `project` synchronously, so the
+	// effect tracks it (range is untracked and refetched via selectRange; the
+	// Requests/Bandwidth `view` toggle just reformats the already-fetched series
+	// via $derived and must NOT refetch).
+	$effect(() => {
+		fetchResultMetrics()
+	})
 
 	function selectRange (v: string) {
 		if (v === range) return

--- a/src/routes/(auth)/(project)/cache/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/cache/metrics/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types'
 	import type { LineSeries } from '$lib/charts/util'
-	import { onMount } from 'svelte'
+	import { untrack } from 'svelte'
 	import { page } from '$app/stores'
 	import { replaceState } from '$app/navigation'
 	import api from '$lib/api'
@@ -47,8 +47,11 @@
 
 	async function fetchMetrics () {
 		loading = true
+		// `range` is read untracked so the project+location-keyed effect below
+		// isn't also triggered by range changes — those refetch via selectRange.
+		const r = untrack(() => range)
 		try {
-			const res = await api.invoke<Api.CacheMetricsResult>('cache.metrics', { project, location, timeRange: range }, fetch)
+			const res = await api.invoke<Api.CacheMetricsResult>('cache.metrics', { project, location, timeRange: r }, fetch)
 			if (!res.ok) {
 				modal.error({ error: res.error })
 				return
@@ -80,7 +83,14 @@
 		fetchMetrics()
 	}
 
-	onMount(() => {
+	// Fetch on mount and refetch whenever the project or location changes. A
+	// project switch unmounts this detail page (overrideRedirect '/cache'), but
+	// the cache list links here per location, so /cache/metrics?location=A ->
+	// ?location=B reuses this component WITHOUT remounting — an onMount-only fetch
+	// would leave location A's tiles/chart/table on a B header. fetchMetrics reads
+	// project + location synchronously, so the effect tracks them (range is read
+	// untracked and refetched via selectRange).
+	$effect(() => {
 		fetchMetrics()
 		return () => clearTimeout(refreshTimer)
 	})

--- a/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/metrics/+page.svelte
@@ -61,12 +61,16 @@
 		reloadTimeout = null
 		fetching = true
 
+		// `range` is read untracked so the deployment-keyed effect below isn't
+		// also triggered by range changes — those refetch via setRange.
+		const range = untrack(() => filter.range)
+
 		try {
 			const resp = await api.invoke<Api.DeploymentMetricsResult>('deployment.metrics', {
 				project: deployment.project,
 				location: deployment.location,
 				name: deployment.name,
-				timeRange: filter.range
+				timeRange: range
 			}, fetch)
 			if (!resp.ok) return
 
@@ -113,12 +117,23 @@
 	}
 
 	onMount(() => {
-		fetchMetrics()
 		const ticker = setInterval(() => { now = Date.now() }, 1000)
 		return () => {
 			reloadTimeout && clearTimeout(reloadTimeout)
 			clearInterval(ticker)
 		}
+	})
+
+	// Refetch all 5 charts when the deployment identity changes. A project switch
+	// unmounts this (detail) page (overrideRedirect '/deployment'), but the tab
+	// bar / list link here per deployment, so /deployment/metrics?name=A ->
+	// ?name=B (or a ?location= change) reuses this component WITHOUT remounting —
+	// an onMount-only fetch would leave deployment A's charts up until the next
+	// ~60s reload tick. fetchMetrics reads deployment.project/location/name
+	// synchronously, so the effect tracks them (range is untracked; setRange
+	// refetches on a range change). clearFirst blanks the charts during the swap.
+	$effect(() => {
+		fetchMetrics(true)
 	})
 
 	function relTime (t: number): string {

--- a/src/routes/(auth)/(project)/disk/(detail)/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/disk/(detail)/metrics/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores'
 	import api from '$lib/api'
-	import { onMount, tick } from 'svelte'
+	import { onMount, tick, untrack } from 'svelte'
 	import Chart from '$lib/components/Chart.svelte'
 	import Select from '$lib/components/Select.svelte'
 	import type { PageData } from './$types'
@@ -35,12 +35,16 @@
 		reloadTimeout && clearTimeout(reloadTimeout)
 		reloadTimeout = null
 
+		// `range` is read untracked so the disk-keyed effect below isn't also
+		// triggered by range changes — those refetch via the Select's onchange.
+		const range = untrack(() => filter.range)
+
 		try {
 			const resp = await api.invoke<Api.DiskMetricsResult>('disk.metrics', {
 				project: disk.project,
 				location: disk.location,
 				name: disk.name,
-				timeRange: filter.range
+				timeRange: range
 			}, fetch)
 			if (!resp.ok) {
 				return
@@ -62,11 +66,21 @@
 	}
 
 	onMount(() => {
-		fetchMetrics()
-
 		return () => {
 			reloadTimeout && clearTimeout(reloadTimeout)
 		}
+	})
+
+	// Refetch the chart when the disk identity changes. A project switch unmounts
+	// this (detail) page (overrideRedirect '/disk'), but the disk list links here
+	// per disk, so /disk/metrics?name=A -> ?name=B (or a ?location= change) reuses
+	// this component WITHOUT remounting — an onMount-only fetch would leave disk
+	// A's Usage/Size series up until the next ~60s reload tick. fetchMetrics reads
+	// disk.project/location/name synchronously, so the effect tracks them (range
+	// is untracked; the Select refetches on a range change). clearFirst blanks the
+	// chart during the swap.
+	$effect(() => {
+		fetchMetrics(true)
 	})
 </script>
 

--- a/src/routes/(auth)/(project)/errors/+page.svelte
+++ b/src/routes/(auth)/(project)/errors/+page.svelte
@@ -125,20 +125,22 @@
 	)
 
 	onMount(() => {
-		loadIssues()
 		const ticker = setInterval(() => { now = Date.now() }, 1000)
 		return () => clearInterval(ticker)
 	})
 
-	// Reload when the status filter or sort changes (after the first mount).
-	// Reading both here is what subscribes the effect to their changes.
+	// Load on mount and reload whenever the project, status filter, or sort
+	// changes. `project` MUST be in the key: a project switch navigates to
+	// /errors via goto (overrideRedirect) WITHOUT remounting this page, so an
+	// onMount-only load would strand the previous project's issues in the list.
+	// Reading the three values here is what subscribes the effect to them; the
+	// key guard de-dupes the no-op re-run after this effect writes trackedListKey.
 	let trackedListKey = $state<string | null>(null)
 	$effect(() => {
-		const key = `${status} ${sort}`
+		const key = `${project} ${status} ${sort}`
 		if (trackedListKey === key) return
-		const first = trackedListKey === null
 		trackedListKey = key
-		if (!first) loadIssues()
+		loadIssues()
 	})
 </script>
 

--- a/src/routes/(auth)/(project)/waf/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/+page.svelte
@@ -4,7 +4,7 @@
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import Sparkline from '$lib/components/Sparkline.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
-	import { onMount } from 'svelte'
+	import { onMount, untrack } from 'svelte'
 	import api from '$lib/api'
 	import * as format from '$lib/format'
 
@@ -39,19 +39,31 @@
 	const to = Math.floor(Date.now() / 1000)
 	const from = to - 24 * 60 * 60
 
-	onMount(() => {
-		Promise.all(firewalls.map(async (fw: Api.WafZone) => {
-			metrics[fw.location] = { loading: true, total: 0, points: [] }
+	// Refetch the per-zone sparklines when the project changes. A project switch
+	// navigates to /waf via goto (overrideRedirect) WITHOUT remounting this page,
+	// so an onMount fetch would keep showing the previous project's matches —
+	// worse, `metrics` is keyed by location only, so a shared location id would
+	// render the OLD project's count. Track `project` in an $effect instead;
+	// `firewalls` is read through untrack so the 3s waf.list poll (which replaces
+	// the array while a zone is pending) doesn't re-trigger a fetch storm. Reset
+	// the map first so a location the new project lacks can't show a stale entry.
+	$effect(() => {
+		const p = project
+		untrack(() => {
+			for (const k of Object.keys(metrics)) delete metrics[k]
+			Promise.all(firewalls.map(async (fw: Api.WafZone) => {
+				metrics[fw.location] = { loading: true, total: 0, points: [] }
 
-			const res = await api.invoke<Api.WafMetricsResult>('waf.metrics',
-				{ project, location: fw.location, timeRange: '1d' }, fetch)
+				const res = await api.invoke<Api.WafMetricsResult>('waf.metrics',
+					{ project: p, location: fw.location, timeRange: '1d' }, fetch)
 
-			metrics[fw.location] = {
-				loading: false,
-				total: res.result?.total ?? 0,
-				points: aggregate(res.result?.series ?? [])
-			}
-		}))
+				metrics[fw.location] = {
+					loading: false,
+					total: res.result?.total ?? 0,
+					points: aggregate(res.result?.series ?? [])
+				}
+			}))
+		})
 	})
 
 	// Collapse the per-(rule, action) series into one total-matches line: sum

--- a/src/routes/(auth)/(project)/waf/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/metrics/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types'
 	import type { LineSeries } from '$lib/charts/util'
-	import { onMount } from 'svelte'
+	import { untrack } from 'svelte'
 	import { page } from '$app/stores'
 	import { replaceState } from '$app/navigation'
 	import api from '$lib/api'
@@ -48,8 +48,11 @@
 
 	async function fetchMetrics () {
 		loading = true
+		// `range` is read untracked so the project+location-keyed effect below
+		// isn't also triggered by range changes — those refetch via selectRange.
+		const r = untrack(() => range)
 		try {
-			const args = { project, location, timeRange: range }
+			const args = { project, location, timeRange: r }
 			const [res, limitRes] = await Promise.all([
 				api.invoke<Api.WafMetricsResult>('waf.metrics', args, fetch),
 				hasLimits
@@ -89,7 +92,15 @@
 		fetchMetrics()
 	}
 
-	onMount(() => {
+	// Fetch on mount and refetch whenever the project or location changes. A
+	// project switch unmounts this detail page (overrideRedirect '/waf'), but the
+	// WAF list links here per location, so /waf/metrics?location=A -> ?location=B
+	// reuses this component WITHOUT remounting — an onMount-only fetch would leave
+	// location A's tiles/charts/tables on a B header (and for 7d/30d no refresh
+	// timer ever corrects it). fetchMetrics reads project + location synchronously,
+	// so the effect tracks them (range is read untracked and refetched via
+	// selectRange).
+	$effect(() => {
 		fetchMetrics()
 		return () => clearTimeout(refreshTimer)
 	})

--- a/tests/cache.spec.js
+++ b/tests/cache.spec.js
@@ -76,6 +76,41 @@ test.describe('cache list', () => {
 		await expect(main.getByText('No cache zones yet')).toBeVisible()
 		await expect(main.getByText('Configure cache to start overriding edge caching in a location.')).toBeVisible()
 	})
+
+	// Regression: switching project is a same-route SPA navigation (goto to
+	// /cache?project=…) that REUSES this page component, so onMount never re-runs.
+	// The performance chart + per-zone sparklines, fetched client-side, must
+	// refetch for the new project — they used to keep the previous project's data.
+	test('refetches the chart + sparklines on project switch', async ({ page }) => {
+		const twoProjects = [
+			{ id: 'p1', project: 'project-a', name: 'Project A' },
+			{ id: 'p2', project: 'project-b', name: 'Project B' }
+		]
+		await setMocks({
+			'project.list': { ok: true, result: { items: twoProjects } },
+			'cache.list': { ok: true, result: { project: 'project-a', items: [cacheZone({ location: 'gke' })] } },
+			'cache.metrics': { ok: true, result: { series: [], total: 0 } },
+			'cache.resultMetrics': { ok: true, result: { series: [] } }
+		})
+
+		await page.goto('/cache?project=project-a')
+
+		const calls = async (fn, project) => (await getRequestLog())
+			.filter((r) => r.path === fn && JSON.parse(r.body ?? '{}').project === project).length
+
+		// Initial load fetches both client-side series for project-a.
+		await expect.poll(() => calls('/cache.resultMetrics', 'project-a')).toBeGreaterThan(0)
+		await expect.poll(() => calls('/cache.metrics', 'project-a')).toBeGreaterThan(0)
+
+		// Switch project through the sidebar modal — same-route SPA nav.
+		await page.locator('.project-box').click()
+		await page.locator('.modal.is-active').getByRole('link', { name: 'Project B' }).click()
+		await expect(page).toHaveURL(/project=project-b/)
+
+		// Both client-side fetches must re-issue for project-b (the bug: they didn't).
+		await expect.poll(() => calls('/cache.resultMetrics', 'project-b')).toBeGreaterThan(0)
+		await expect.poll(() => calls('/cache.metrics', 'project-b')).toBeGreaterThan(0)
+	})
 })
 
 test.describe('cache create', () => {


### PR DESCRIPTION
## The bug

Reported: **the cache performance chart doesn't refresh when you switch project.**

Root cause (traced): switching project is a *client-side* navigation — `ModalSelectProject` does `goto(overrideRedirect + '?project=…')`. SvelteKit **reuses** the page component (only `load()` re-runs and `data`/`$derived` update); **`onMount` never fires again**. Every page that fetched project-dependent data *client-side in `onMount`* (charts, sparklines, lists) therefore kept showing the **previous project's** data. The same applies to detail pages when `?location=`/`?name=` changes between two instances of the same route (metrics/logs tabs, list links) — the component is reused, so `onMount` doesn't re-run.

You asked me to recheck all pages, so I audited **every** page that fetches in `onMount` (29 of them).

## The fix

Replace the one-shot `onMount` fetches with **params-keyed `$effect`s**, mirroring the existing `ProjectMetrics`/`UsageMetrics` reference idiom already in the repo: the effect reads the identifying params synchronously (so it re-runs when they change), while `range` is read via `untrack` so the range control stays the single source of range refetches (no double-fetch). `intervalInvalidate` polls stay in `onMount` — they refresh `load()`-sourced data and aren't part of this bug.

### Confirmed live bugs fixed (8)

| File | Stale data | Triggered by |
| --- | --- | --- |
| `cache/+page` **(reported)** | performance chart + per-zone sparklines | project switch |
| `errors/+page` | project-wide issue list | project switch |
| `cache/metrics` | KPI tiles + chart + top-overrides table | location switch |
| `waf/metrics` | tiles + charts + tables (7d/30d never self-healed) | location switch |
| `waf/+page` | per-zone match sparklines (location-keyed map; also reset) | project switch |
| `deployment/(detail)/metrics` | all 5 charts (self-healed only after ≤60s) | deployment/location switch |
| `disk/(detail)/metrics` | Usage/Size chart (≤60s self-heal) | disk/location switch |
| `HistoryLogs` | log-history list | deployment switch |

The audit also flagged `deployment/(detail)/errors` as **latent-only** (not reachable today — every in-app link mounts it fresh); left out to keep this scoped to live bugs. `ProjectMetrics`/`UsageMetrics` were already correct (the pattern this PR follows).

## Verification

No visual change — this is a data-refresh-timing fix, so there's no before/after screenshot. Verified at runtime instead:

**Client-side project switch on `/cache` now refetches for the new project** (request log):
```
1. {"project":"acme","timeRange":"1d"}       ← initial load
2. {"project":"staging","timeRange":"1d"}     ← after switching project (was missing = the bug)
3. {"project":"staging","timeRange":"6h"}     ← range toggle: exactly ONE refetch, no double-fire
```
- Per-zone `cache.metrics` sparklines refetch too (1 → 2).
- **No `effect_update_depth` / infinite-loop** errors on any of the 8 pages (smoke-tested each).
- New regression test in `cache.spec.js` (switch project via the sidebar modal → assert both client-side fetches re-issue for the new project). `bun lint` + `bun check` green; full `cache.spec.js` 12/12, and `waf`/`deployment`/`disk` specs 47/47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)