### PR TITLE
deployment: AlloyDB sidecar + cloudSqlProxy IAM/private-IP in deploy form

### DIFF
--- a/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/(detail)/detail/+page.svelte
@@ -737,6 +737,11 @@
 										<span class="sidecars__label">Cloud SQL Proxy</span>
 										{s.cloudSqlProxy.instance}{#if s.cloudSqlProxy.port}:{s.cloudSqlProxy.port}{/if}
 									</li>
+								{:else if s.alloyDbProxy}
+									<li>
+										<span class="sidecars__label">AlloyDB Proxy</span>
+										{s.alloyDbProxy.instance}{#if s.alloyDbProxy.port}:{s.alloyDbProxy.port}{/if}
+									</li>
 								{/if}
 							{/each}
 						</ul>

--- a/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/deploy/+page.svelte
@@ -12,13 +12,29 @@
 
 	// Editable sidecar shape used by the form. Mirrors Api.SidecarForm but keeps
 	// `type` as a plain string so the <Select> two-way binding (value:
-	// string | number) type-checks.
+	// string | number) type-checks. Carries a config slot per variant so the
+	// form can switch between types without losing partial input.
 	interface FormSidecar {
 		type: string
 		cloudSqlProxy: {
 			instance: string
 			port: number | null
 			credentials: string
+			autoIamAuthn: boolean
+			privateIp: boolean
+		}
+		alloyDbProxy: {
+			instance: string
+			port: number | null
+			credentials: string
+		}
+	}
+
+	function newFormSidecar (type = ''): FormSidecar {
+		return {
+			type,
+			cloudSqlProxy: { instance: '', port: null, credentials: '', autoIamAuthn: false, privateIp: false },
+			alloyDbProxy: { instance: '', port: null, credentials: '' }
 		}
 	}
 
@@ -116,20 +132,25 @@
 		form.envGroups = [...(deployment.envGroups || [])]
 		form.mountData = Object.entries(deployment.mountData || {}).map(([k, v]) => ({ k, v }))
 		form.sidecars = (deployment.sidecars || []).map((s): FormSidecar => {
+			const sc = newFormSidecar()
 			if (s.cloudSqlProxy) {
-				return {
-					type: 'cloudSqlProxy',
-					cloudSqlProxy: {
-						instance: s.cloudSqlProxy.instance ?? '',
-						port: s.cloudSqlProxy.port ?? null,
-						credentials: s.cloudSqlProxy.credentials ?? ''
-					}
+				sc.type = 'cloudSqlProxy'
+				sc.cloudSqlProxy = {
+					instance: s.cloudSqlProxy.instance ?? '',
+					port: s.cloudSqlProxy.port ?? null,
+					credentials: s.cloudSqlProxy.credentials ?? '',
+					autoIamAuthn: s.cloudSqlProxy.autoIamAuthn ?? false,
+					privateIp: s.cloudSqlProxy.privateIp ?? false
+				}
+			} else if (s.alloyDbProxy) {
+				sc.type = 'alloyDbProxy'
+				sc.alloyDbProxy = {
+					instance: s.alloyDbProxy.instance ?? '',
+					port: s.alloyDbProxy.port ?? null,
+					credentials: s.alloyDbProxy.credentials ?? ''
 				}
 			}
-			return {
-				type: '',
-				cloudSqlProxy: { instance: '', port: null, credentials: '' }
-			}
+			return sc
 		})
 		requireGoogleLogin = deployment.access?.requireGoogleLogin ?? false
 		allowedEmails = [...(deployment.access?.allowedEmails || [])]
@@ -273,7 +294,20 @@
 						cloudSqlProxy: {
 							instance: s.cloudSqlProxy.instance,
 							port: s.cloudSqlProxy.port,
-							credentials: s.cloudSqlProxy.credentials
+							// autoIamAuthn and credentials are mutually exclusive; never
+							// send a stale credential when IAM auth is selected.
+							credentials: s.cloudSqlProxy.autoIamAuthn ? '' : s.cloudSqlProxy.credentials,
+							autoIamAuthn: s.cloudSqlProxy.autoIamAuthn,
+							privateIp: s.cloudSqlProxy.privateIp
+						}
+					}
+				}
+				if (s.type === 'alloyDbProxy') {
+					return {
+						alloyDbProxy: {
+							instance: s.alloyDbProxy.instance,
+							port: s.alloyDbProxy.port,
+							credentials: s.alloyDbProxy.credentials
 						}
 					}
 				}
@@ -287,13 +321,7 @@
 		if (form.sidecars.length >= sidecarMax) {
 			return
 		}
-		form.sidecars = [
-			...form.sidecars,
-			{
-				type: 'cloudSqlProxy',
-				cloudSqlProxy: { instance: '', port: null, credentials: '' }
-			}
-		]
+		form.sidecars = [...form.sidecars, newFormSidecar('cloudSqlProxy')]
 	}
 
 	function removeSidecar (i: number) {
@@ -845,7 +873,10 @@
 							id="input-sidecar-type-{i}"
 							bind:value={sidecar.type}
 							placeholder="Select Type"
-							options={[{ value: 'cloudSqlProxy', label: 'Cloud SQL Proxy' }]} />
+							options={[
+								{ value: 'cloudSqlProxy', label: 'Cloud SQL Proxy' },
+								{ value: 'alloyDbProxy', label: 'AlloyDB Proxy' }
+							]} />
 					</div>
 					{#if sidecar.type === 'cloudSqlProxy'}
 						<div class="field">
@@ -861,9 +892,46 @@
 							</div>
 						</div>
 						<div class="field">
-							<label for="input-sidecar-credentials-{i}">Credentials</label>
+							<div class="checkbox">
+								<input id="input-sidecar-private-ip-{i}" type="checkbox" bind:checked={sidecar.cloudSqlProxy.privateIp}>
+								<label for="input-sidecar-private-ip-{i}">Private IP</label>
+							</div>
+						</div>
+						<div class="field">
+							<div class="checkbox">
+								<input id="input-sidecar-auto-iam-{i}" type="checkbox" bind:checked={sidecar.cloudSqlProxy.autoIamAuthn}>
+								<label for="input-sidecar-auto-iam-{i}">Automatic IAM authentication</label>
+							</div>
+						</div>
+						{#if sidecar.cloudSqlProxy.autoIamAuthn}
+							<p class="text-content/60 text-sm">
+								Uses the deployment's IAM identity to connect — bind a workload identity and leave credentials empty.
+							</p>
+						{:else}
+							<div class="field">
+								<label for="input-sidecar-credentials-{i}">Credentials</label>
+								<div class="input">
+									<input id="input-sidecar-credentials-{i}" placeholder="Credentials JSON" bind:value={sidecar.cloudSqlProxy.credentials}>
+								</div>
+							</div>
+						{/if}
+					{:else if sidecar.type === 'alloyDbProxy'}
+						<div class="field">
+							<label for="input-sidecar-alloydb-instance-{i}">Instance</label>
 							<div class="input">
-								<input id="input-sidecar-credentials-{i}" placeholder="Credentials JSON" bind:value={sidecar.cloudSqlProxy.credentials}>
+								<input id="input-sidecar-alloydb-instance-{i}" placeholder="projects/p/locations/l/clusters/c/instances/i" bind:value={sidecar.alloyDbProxy.instance} required>
+							</div>
+						</div>
+						<div class="field">
+							<label for="input-sidecar-alloydb-port-{i}">Port</label>
+							<div class="input">
+								<input class="-no-arrow" id="input-sidecar-alloydb-port-{i}" placeholder="5432" type="number" bind:value={sidecar.alloyDbProxy.port}>
+							</div>
+						</div>
+						<div class="field">
+							<label for="input-sidecar-alloydb-credentials-{i}">Credentials</label>
+							<div class="input">
+								<input id="input-sidecar-alloydb-credentials-{i}" placeholder="Credentials JSON" bind:value={sidecar.alloyDbProxy.credentials}>
 							</div>
 						</div>
 					{/if}

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -297,13 +297,22 @@ declare namespace Api {
         instance: string
         port: number
         credentials: string
+        autoIamAuthn?: boolean
+        privateIp?: boolean
+    }
+
+    export type AlloyDbProxySidecar = {
+        instance: string
+        port: number
+        credentials: string
     }
 
     export type Sidecar = {
         cloudSqlProxy?: CloudSqlProxySidecar
+        alloyDbProxy?: AlloyDbProxySidecar
     }
 
-    export type SidecarType = '' | 'cloudSqlProxy'
+    export type SidecarType = '' | 'cloudSqlProxy' | 'alloyDbProxy'
 
     /**
      * Editable form shape for a sidecar. Carries a discriminator plus a
@@ -313,6 +322,13 @@ declare namespace Api {
     export type SidecarForm = {
         type: SidecarType
         cloudSqlProxy: {
+            instance: string
+            port: number | null
+            credentials: string
+            autoIamAuthn: boolean
+            privateIp: boolean
+        }
+        alloyDbProxy: {
             instance: string
             port: number | null
             credentials: string

--- a/tests/deployment.spec.js
+++ b/tests/deployment.spec.js
@@ -1,6 +1,7 @@
 import { test, expect, setMocks } from './helpers.js'
 import {
 	defaultLocation,
+	sampleAlloyDbProxySidecar,
 	sampleCloudSqlProxySidecar,
 	sampleDeployment,
 	sampleStaticDeployment,
@@ -74,13 +75,7 @@ test.describe('deployment detail — sidecars', () => {
 					...sampleDeployment,
 					sidecars: [
 						sampleCloudSqlProxySidecar,
-						{
-							cloudSqlProxy: {
-								instance: 'my-project:asia-southeast1:replica',
-								port: 3307,
-								credentials: ''
-							}
-						}
+						sampleAlloyDbProxySidecar
 					]
 				}
 			},
@@ -92,10 +87,15 @@ test.describe('deployment detail — sidecars', () => {
 		// Sidecars render in a `.spec` row (label + value list), not a table row.
 		const row = page.locator('.spec').filter({ hasText: 'Sidecars' })
 		await expect(row).toBeVisible()
+		await expect(row.getByText('Cloud SQL Proxy')).toBeVisible()
 		await expect(row.getByText('my-project:us-central1:my-db')).toBeVisible()
 		await expect(row.getByText(':3306')).toBeVisible()
-		await expect(row.getByText('my-project:asia-southeast1:replica')).toBeVisible()
-		await expect(row.getByText(':3307')).toBeVisible()
+		// The AlloyDB variant renders with its own label and instance:port.
+		await expect(row.getByText('AlloyDB Proxy')).toBeVisible()
+		await expect(
+			row.getByText('projects/my-project/locations/us-central1/clusters/main/instances/primary')
+		).toBeVisible()
+		await expect(row.getByText(':5432')).toBeVisible()
 	})
 })
 
@@ -154,6 +154,48 @@ test.describe('deployment deploy — sidecars', () => {
 			'my-project:us-central1:my-db'
 		)
 		await expect(main.locator('#input-sidecar-port-0')).toHaveValue('3306')
+	})
+
+	test('hydrates an existing AlloyDB proxy sidecar with its own fields', async ({ page }) => {
+		await setMocks({
+			'deployment.get': {
+				ok: true,
+				result: {
+					...sampleDeployment,
+					sidecars: [sampleAlloyDbProxySidecar]
+				}
+			},
+			'location.get': { ok: true, result: defaultLocation }
+		})
+
+		await page.goto('/deployment/deploy?project=test-project&location=gke&name=web')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('Sidecar #1')).toBeVisible()
+		// AlloyDB uses its own instance/port inputs, not the Cloud SQL ones.
+		await expect(main.locator('#input-sidecar-alloydb-instance-0')).toHaveValue(
+			'projects/my-project/locations/us-central1/clusters/main/instances/primary'
+		)
+		await expect(main.locator('#input-sidecar-alloydb-port-0')).toHaveValue('5432')
+		await expect(main.locator('#input-sidecar-instance-0')).toHaveCount(0)
+	})
+
+	test('cloudSqlProxy autoIamAuthn hides the credentials field', async ({ page }) => {
+		await setMocks({
+			'deployment.get': {
+				ok: true,
+				result: { ...sampleDeployment, sidecars: [sampleCloudSqlProxySidecar] }
+			},
+			'location.get': { ok: true, result: defaultLocation }
+		})
+
+		await page.goto('/deployment/deploy?project=test-project&location=gke&name=web')
+
+		const main = page.locator('.content-wrapper')
+		// Credentials visible by default, hidden once IAM auth is enabled.
+		await expect(main.locator('#input-sidecar-credentials-0')).toBeVisible()
+		await main.locator('#input-sidecar-auto-iam-0').check()
+		await expect(main.locator('#input-sidecar-credentials-0')).toHaveCount(0)
 	})
 })
 

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -211,6 +211,14 @@ export const sampleCloudSqlProxySidecar = {
 	}
 }
 
+export const sampleAlloyDbProxySidecar = {
+	alloyDbProxy: {
+		instance: 'projects/my-project/locations/us-central1/clusters/main/instances/primary',
+		port: 5432,
+		credentials: ''
+	}
+}
+
 // A Static (bucket-native static web) deployment: no container image/port — it
 // references a content-addressed release via `site` (site://…@<release-sha>) and
 // `siteManifestDigest`.


### PR DESCRIPTION
Surfaces the two new managed-sidecar capabilities that just merged in the api contract (api#115, api#116) in the deploy form and deployment detail view.

## Changes
- **New `AlloyDB Proxy` sidecar type** — pick it from the Type dropdown; instance / port (default 5432) / credentials.
- **Cloud SQL Proxy gains two toggles** — **Private IP** (`--private-ip`) and **Automatic IAM authentication** (`--auto-iam-authn`). Selecting IAM auth hides the Credentials field and clears it on submit, so the API's mutually-exclusive `autoIamAuthn` + `credentials` rule can never be violated from the UI.
- **Detail view** renders the AlloyDB variant with its own label + `instance:port`.
- `api.d.ts` types extended (`AlloyDbProxySidecar`, new `cloudSqlProxy` flags, `SidecarType` / `SidecarForm`).

## Tests
Added Playwright coverage for AlloyDB hydration (its own `#input-sidecar-alloydb-*` fields) and the `autoIamAuthn`-hides-credentials behavior; the existing add/remove/cap and Cloud SQL hydration tests are unchanged. `bun check` + `bun lint` green; sidecar specs pass.

## Screenshots

Both sidecar types in the deploy form — Cloud SQL Proxy with the new **Private IP** + **Automatic IAM authentication** toggles (credentials hidden when IAM auth is on), and the new **AlloyDB Proxy** variant:

![deploy form](https://raw.githubusercontent.com/deploys-app/console/screenshots/304-deploy-form.png)

Cloud SQL Proxy with IAM auth **off** — the Credentials field is shown:

![cloudsql credentials](https://raw.githubusercontent.com/deploys-app/console/screenshots/304-cloudsql-credentials.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)