### PR TITLE
feat(search): collapse projects into a "Switch project" sub-menu

### DIFF
--- a/src/lib/search/index.ts
+++ b/src/lib/search/index.ts
@@ -11,7 +11,8 @@ export interface SearchEntry {
 	label: string // primary text (the thing you'd type)
 	sublabel?: string // secondary text (location, target, …)
 	keywords?: string // extra text folded into search only, never shown
-	href: string // navigation target
+	href?: string // navigation target (omitted for `action` entries)
+	action?: 'switch-project' // when set, selecting opens a sub-mode instead of navigating
 }
 
 const enc = encodeURIComponent
@@ -151,13 +152,31 @@ const resourceSources: ResourceSource[] = [
 ]
 
 /**
+ * The single "Switch project" command shown in the default palette. Selecting it
+ * (type "project" → Enter) opens the project sub-mode rather than listing every
+ * project inline, so a large project list never floods the results.
+ */
+export function switchProjectEntry (): SearchEntry {
+	return {
+		id: 'cmd:switch-project',
+		group: 'Commands',
+		icon: 'fa-folder-open',
+		label: 'Switch project',
+		sublabel: 'Browse and switch to another project',
+		keywords: 'change select swap switch project',
+		action: 'switch-project'
+	}
+}
+
+/**
  * Project-switch entries. Mirrors {@link ../routes/(auth)/ModalSelectProject.svelte}'s
  * `setProject` URL shape: keep the current query params, swap `project=`, and
  * honour `data.overrideRedirect` so switching from a detail page lands on the
  * section's list in the new project instead of a stale deep link.
  *
  * The current project is excluded — switching to where you already are is a
- * no-op and would just be visual noise in the palette.
+ * no-op and would just be visual noise in the palette. These populate the
+ * project sub-mode reached via {@link switchProjectEntry}.
  */
 export function projectEntries (projects: Api.Project[], currentProject: string, page: { url: { search: string }, data: { overrideRedirect?: string } }): SearchEntry[] {
 	const overrideRedirect = page.data?.overrideRedirect || ''

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -95,6 +95,60 @@ const projects = [
 		quota: { deployments: 20, deploymentMaxReplicas: 5 },
 		config: {},
 		createdAt: CREATED_AT
+	},
+	{
+		id: 'prj_mock_prod',
+		project: 'production',
+		name: 'Production',
+		billingAccount: 'ba_mock_1',
+		quota: { deployments: 100, deploymentMaxReplicas: 20 },
+		config: {},
+		createdAt: CREATED_AT
+	},
+	{
+		id: 'prj_mock_dev',
+		project: 'development',
+		name: 'Development',
+		billingAccount: 'ba_mock_1',
+		quota: { deployments: 30, deploymentMaxReplicas: 5 },
+		config: {},
+		createdAt: CREATED_AT
+	},
+	{
+		id: 'prj_mock_analytics',
+		project: 'analytics',
+		name: 'Analytics Platform',
+		billingAccount: 'ba_mock_1',
+		quota: { deployments: 40, deploymentMaxReplicas: 8 },
+		config: {},
+		createdAt: CREATED_AT
+	},
+	{
+		id: 'prj_mock_payments',
+		project: 'payments',
+		name: 'Payments Service',
+		billingAccount: 'ba_mock_1',
+		quota: { deployments: 25, deploymentMaxReplicas: 6 },
+		config: {},
+		createdAt: CREATED_AT
+	},
+	{
+		id: 'prj_mock_marketing',
+		project: 'marketing-site',
+		name: 'Marketing Site',
+		billingAccount: 'ba_mock_1',
+		quota: { deployments: 15, deploymentMaxReplicas: 4 },
+		config: {},
+		createdAt: CREATED_AT
+	},
+	{
+		id: 'prj_mock_internal',
+		project: 'internal-tools',
+		name: 'Internal Tools',
+		billingAccount: 'ba_mock_1',
+		quota: { deployments: 20, deploymentMaxReplicas: 5 },
+		config: {},
+		createdAt: CREATED_AT
 	}
 ]
 

--- a/src/routes/(auth)/SearchModal.svelte
+++ b/src/routes/(auth)/SearchModal.svelte
@@ -3,7 +3,7 @@
 	import { tick } from 'svelte'
 	import { page } from '$app/stores'
 	import { goto } from '$app/navigation'
-	import { navEntries, projectEntries, fetchResourceEntries, filterEntries } from '$lib/search'
+	import { navEntries, projectEntries, switchProjectEntry, fetchResourceEntries, filterEntries } from '$lib/search'
 
 	interface Props {
 		projects?: Api.Project[]
@@ -19,21 +19,33 @@
 	let highlighted = $state(0)
 	const rowEls = $state<HTMLElement[]>([])
 
+	// `default` shows nav + resources + the single "Switch project" command;
+	// `project` is the sub-mode listing every project to switch to.
+	let mode = $state<'default' | 'project'>('default')
+
 	let loading = $state(false)
 	let loadedProject = $state<string | null>(null)
 	let resources = $state<SearchEntry[]>([])
 
-	// Project entries are first so typing a project name highlights the switch
-	// row before any nav/resource match (intent: "I'm trying to switch project").
+	// The "Switch project" command leads (so typing "project" highlights it),
+	// then the nav sections, then the lazily-fetched resources.
 	const allEntries = $derived(project
-		? [...projectEntries(projects, project, $page), ...navEntries(project), ...resources]
+		? [switchProjectEntry(), ...navEntries(project), ...resources]
 		: [])
 
-	// Empty query → just the nav sections (showing every resource — or every
-	// project — would be a wall of rows); typing surfaces projects + nav + fetched
-	// resources together.
-	const base = $derived(search.trim() ? allEntries : (project ? navEntries(project) : []))
+	// Empty query → the switch-project command + nav sections (showing every
+	// resource would be a wall of rows); typing surfaces resources too. The
+	// project sub-mode lists every project, filtered by the same query.
+	const base = $derived.by(() => {
+		if (!project) return []
+		if (mode === 'project') return projectEntries(projects, project, $page)
+		return search.trim() ? allEntries : [switchProjectEntry(), ...navEntries(project)]
+	})
 	const filtered = $derived(filterEntries(base, search))
+
+	const placeholder = $derived(mode === 'project'
+		? 'Switch to project…'
+		: 'Search projects, deployments, domains, routes…')
 
 	// Group consecutive entries by section for display while keeping the flat
 	// index that drives keyboard highlighting.
@@ -58,6 +70,7 @@
 	export async function open () {
 		search = ''
 		highlighted = 0
+		mode = 'default'
 		isActive = true
 		await tick()
 		elSearch?.focus()
@@ -81,8 +94,30 @@
 	}
 
 	function navigate (entry: SearchEntry) {
+		// Action entries open a sub-mode in place instead of navigating away.
+		if (entry.action === 'switch-project') {
+			enterProjectMode()
+			return
+		}
+		if (!entry.href) return
 		close()
 		goto(entry.href)
+	}
+
+	// Enter the project sub-mode: clear the query so the next keystrokes filter
+	// projects, and keep focus in the search box.
+	async function enterProjectMode () {
+		mode = 'project'
+		search = ''
+		highlighted = 0
+		await tick()
+		elSearch?.focus()
+	}
+
+	function exitProjectMode () {
+		mode = 'default'
+		search = ''
+		highlighted = 0
 	}
 
 	/**
@@ -98,7 +133,18 @@
 	 */
 	function onSearchKeydown (e: KeyboardEvent) {
 		if (e.key === 'Escape') {
+			// In the project sub-mode, Escape steps back to the main palette
+			// rather than closing outright.
+			if (mode === 'project') {
+				exitProjectMode()
+				return
+			}
 			close()
+			return
+		}
+		// Backspace on an empty query in the sub-mode also steps back out.
+		if (e.key === 'Backspace' && mode === 'project' && !search) {
+			exitProjectMode()
 			return
 		}
 		if (!filtered.length) return
@@ -118,7 +164,16 @@
 <div class="modal" onclick={onBackdrop} class:is-active={isActive} aria-hidden={!isActive}>
 	<div class="modal-panel">
 		<div class="modal-close" onclick={close} onkeypress={close} tabindex="0" role="button">✕</div>
-		<h4>Search</h4>
+		{#if mode === 'project'}
+			<h4>
+				<button class="back" onclick={exitProjectMode} type="button" aria-label="Back to search">
+					<i class="fa-solid fa-arrow-left"></i>
+				</button>
+				Switch project
+			</h4>
+		{:else}
+			<h4>Search</h4>
+		{/if}
 
 		<div class="input -has-icon-left mt-4">
 			<span class="icon -is-left"><i class="fa-solid fa-magnifying-glass"></i></span>
@@ -128,7 +183,7 @@
 				onkeydown={onSearchKeydown}
 				oninput={() => highlighted = 0}
 				type="text"
-				placeholder="Search projects, deployments, domains, routes…"
+				{placeholder}
 				autocomplete="off"
 			>
 		</div>
@@ -163,7 +218,7 @@
 
 				{#if !filtered.length}
 					<div class="empty">
-						{#if loading}
+						{#if loading && mode === 'default'}
 							<i class="fa-solid fa-spinner fa-spin"></i>
 							<span>Loading resources…</span>
 						{:else}
@@ -171,7 +226,7 @@
 							<span>No matches for “{search}”.</span>
 						{/if}
 					</div>
-				{:else if loading}
+				{:else if loading && mode === 'default'}
 					<div class="loading-hint">
 						<i class="fa-solid fa-spinner fa-spin"></i> Loading more resources…
 					</div>
@@ -181,8 +236,13 @@
 
 		<div class="footer-hints">
 			<span><kbd>↑</kbd><kbd>↓</kbd> navigate</span>
-			<span><kbd>↵</kbd> open</span>
-			<span><kbd>esc</kbd> close</span>
+			{#if mode === 'project'}
+				<span><kbd>↵</kbd> switch</span>
+				<span><kbd>esc</kbd> back</span>
+			{:else}
+				<span><kbd>↵</kbd> open</span>
+				<span><kbd>esc</kbd> close</span>
+			{/if}
 		</div>
 	</div>
 </div>
@@ -192,6 +252,32 @@
 		box-shadow: 0 15px 15px 0 rgba(43, 43, 43, 0.1);
 		width: 100%;
 		max-width: 42rem;
+	}
+
+	h4 {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.back {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.5rem;
+		height: 1.5rem;
+		padding: 0;
+		font-size: 0.875rem;
+		color: hsl(var(--hsl-content) / 0.6);
+		background: none;
+		border: none;
+		border-radius: var(--radius-sm);
+		cursor: pointer;
+	}
+
+	.back:hover {
+		color: hsl(var(--hsl-content));
+		background-color: hsl(var(--hsl-base-200));
 	}
 
 	.results {

--- a/tests/search.spec.js
+++ b/tests/search.spec.js
@@ -76,21 +76,33 @@ test.describe('global search palette', () => {
 		await expect(page.locator('.modal.is-active').getByPlaceholder(/Search projects, deployments/)).toHaveCount(0)
 	})
 
-	test('typing a project name surfaces it as a "Switch project" row and Enter switches', async ({ page }) => {
+	test('"Switch project" command opens a project sub-mode where typing then Enter switches', async ({ page }) => {
 		const otherProject = { ...defaultProject, id: '2', project: 'staging', name: 'Staging' }
 		await setMocks({
 			'project.list': { ok: true, result: { items: [defaultProject, otherProject] } }
 		})
 
 		await page.goto('/deployment?project=test-project')
+		// Wait for hydration before the "/" shortcut is wired up.
+		await expect(page.locator('.content-wrapper').getByRole('heading', { name: 'Deployments' })).toBeVisible()
 		await page.keyboard.press('/')
 		const dialog = page.locator('.modal.is-active')
 		await expect(dialog).toBeVisible()
 
-		await dialog.getByPlaceholder(/Search projects, deployments/).fill('staging')
-		// The other project shows up under "Switch project" — the current project
-		// is intentionally excluded.
-		await expect(dialog.getByText('Switch project', { exact: false })).toBeVisible()
+		// Typing "project" surfaces the single "Switch project" command rather than
+		// a flat list of every project.
+		await dialog.getByPlaceholder(/Search projects, deployments/).fill('project')
+		const command = dialog.locator('.result').filter({ hasText: 'Switch project' }).first()
+		await expect(command).toBeVisible()
+
+		// Enter opens the project sub-mode: the heading and placeholder change and
+		// the input is refocused so the next keystrokes filter projects.
+		await page.keyboard.press('Enter')
+		await expect(dialog.getByRole('heading', { name: 'Switch project' })).toBeVisible()
+		const projectInput = dialog.getByPlaceholder(/Switch to project/)
+		await expect(projectInput).toBeFocused()
+
+		await projectInput.fill('staging')
 		const switchRow = dialog.locator('.result').filter({ hasText: 'Staging' }).first()
 		await expect(switchRow).toBeVisible()
 		// Current project should NOT appear (filtered out at source).
@@ -98,6 +110,28 @@ test.describe('global search palette', () => {
 
 		await switchRow.click()
 		await expect(page).toHaveURL(/[?&]project=staging\b/)
+		await expect(page.locator('.modal.is-active')).toHaveCount(0)
+	})
+
+	test('Escape steps back out of the project sub-mode before closing the palette', async ({ page }) => {
+		await page.goto('/deployment?project=test-project')
+		// Wait for hydration before the "/" shortcut is wired up.
+		await expect(page.locator('.content-wrapper').getByRole('heading', { name: 'Deployments' })).toBeVisible()
+		await page.keyboard.press('/')
+		const dialog = page.locator('.modal.is-active')
+		await expect(dialog).toBeVisible()
+
+		await dialog.getByPlaceholder(/Search projects, deployments/).fill('project')
+		await page.keyboard.press('Enter')
+		await expect(dialog.getByPlaceholder(/Switch to project/)).toBeFocused()
+
+		// First Escape returns to the main search palette (does not close).
+		await page.keyboard.press('Escape')
+		await expect(dialog).toBeVisible()
+		await expect(dialog.getByPlaceholder(/Search projects, deployments/)).toBeFocused()
+
+		// Second Escape closes the palette.
+		await page.keyboard.press('Escape')
 		await expect(page.locator('.modal.is-active')).toHaveCount(0)
 	})
 


### PR DESCRIPTION
## Problem

In the command palette, typing anything surfaced **every** project flat under a "Switch project" group. With many projects this is a wall of rows mixed in with nav/resource matches — hard to scan and hard to use.

## Change

Replace the flat project list with a single **"Switch project"** command. The flow becomes:

> type `project` → `Enter` → type the project name → `Enter`

- The default palette shows one **Switch project** command (under a new **Commands** group) alongside the nav/resource results — no project flood.
- Selecting it (or `Enter` on the highlighted command) opens a dedicated **project sub-mode**: the heading switches to "Switch project", the input clears, and keystrokes filter the project list.
- `Esc` (or `Backspace` on an empty query) steps back to the main palette instead of closing outright. A back arrow in the heading does the same.
- Footer hints adapt per mode (`↵ switch` / `esc back` in the sub-mode).

Switching still uses the exact same URL shape as before (`projectEntries` is reused for the sub-mode list, honouring `overrideRedirect`), so no behavior change to where you land.

Also expands the mock project fixtures (2 → 8) so the sub-mode is actually exercised in `bun dev:mock` and screenshots.

## Screenshots

| Before — every project flat | After — single command |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/306-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/306-after.png) |

Project sub-mode (after selecting "Switch project"), and filtering within it:

| Sub-mode | Filtered |
| --- | --- |
| ![submenu](https://raw.githubusercontent.com/deploys-app/console/screenshots/306-submenu.png) | ![filter](https://raw.githubusercontent.com/deploys-app/console/screenshots/306-submenu-filter.png) |

> Note: Font Awesome glyphs don't load in the offline mock, so row icons appear blank in these shots; they render normally in the real app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)