### PR TITLE
errors: fetch the first page server-side in load

### DIFF
--- a/src/routes/(auth)/(project)/errors/+page.svelte
+++ b/src/routes/(auth)/(project)/errors/+page.svelte
@@ -33,20 +33,29 @@
 		return `/deployment/errors?${q.toString()}`
 	}
 
+	// Seed the first page from the server-side load (+page.ts) so the list is
+	// present on first paint. The status/sort defaults below MUST match
+	// INITIAL_STATUS/INITIAL_SORT in +page.ts, so the seeded view matches what
+	// the load fetched. This is an intentional one-time seed.
+	// svelte-ignore state_referenced_locally
+	const initial = data.initial
+	const initialError = initial.ok ? null : classifyListError(initial)
+
 	let status = $state<StatusFilter>('open')
 	let sort = $state<Api.ErrorSort>('lastSeen')
 	let query = $state('')
-	let issues = $state<Api.ErrorIssue[]>([])
-	let nextCursor = $state<string | undefined>(undefined)
+	let issues = $state<Api.ErrorIssue[]>(initial.ok ? initial.result.issues ?? [] : [])
+	let nextCursor = $state<string | undefined>(initial.ok ? (initial.result.nextCursor || undefined) : undefined)
 	let loading = $state(false)
 	let loadingMore = $state(false)
 	let loadMoreError = $state(false)
 	// Distinguish "no data yet" from the various terminal states so we never flash
-	// the empty state before the first fetch resolves.
-	let loaded = $state(false)
-	let forbidden = $state(false)
-	let unavailable = $state(false)
-	let errorMessage = $state('')
+	// the empty state before the first fetch resolves. Seeded true since the
+	// initial fetch already resolved server-side.
+	let loaded = $state(true)
+	let forbidden = $state(initialError?.kind === 'forbidden')
+	let unavailable = $state(initialError?.kind === 'unavailable')
+	let errorMessage = $state(initialError?.kind === 'error' ? initialError.message : '')
 	let now = $state(Date.now())
 
 	const visibleIssues = $derived.by(() => {
@@ -129,13 +138,17 @@
 		return () => clearInterval(ticker)
 	})
 
-	// Load on mount and reload whenever the project, status filter, or sort
-	// changes. `project` MUST be in the key: a project switch navigates to
-	// /errors via goto (overrideRedirect) WITHOUT remounting this page, so an
-	// onMount-only load would strand the previous project's issues in the list.
-	// Reading the three values here is what subscribes the effect to them; the
-	// key guard de-dupes the no-op re-run after this effect writes trackedListKey.
-	let trackedListKey = $state<string | null>(null)
+	// Reload whenever the project, status filter, or sort changes. `project` MUST
+	// be in the key: a project switch navigates to /errors via goto
+	// (overrideRedirect) WITHOUT remounting this page, so an unkeyed effect would
+	// strand the previous project's issues in the list.
+	//
+	// trackedListKey is primed with the seeded view (current project + the
+	// INITIAL_STATUS/INITIAL_SORT defaults), so the effect's first run is a no-op
+	// instead of re-fetching what the server already returned. Reading the three
+	// values here is what subscribes the effect to them.
+	// svelte-ignore state_referenced_locally
+	let trackedListKey = $state<string>(`${data.project} ${status} ${sort}`)
 	$effect(() => {
 		const key = `${project} ${status} ${sort}`
 		if (trackedListKey === key) return

--- a/src/routes/(auth)/(project)/errors/+page.ts
+++ b/src/routes/(auth)/(project)/errors/+page.ts
@@ -1,10 +1,26 @@
+import api from '$lib/api'
 import type { PageLoad } from './$types'
 
-export const load: PageLoad = async ({ parent }) => {
+// Initial filter/sort must match the component's defaults so the server-side
+// fetch is exactly the view the page renders before any filter change.
+const INITIAL_STATUS: Api.ErrorStatusFilter = 'open'
+const INITIAL_SORT: Api.ErrorSort = 'lastSeen'
+
+export const load: PageLoad = async ({ parent, fetch }) => {
 	const { project } = await parent()
+	// Fetch the first page during load — like the other resource list pages — so
+	// the list is present on first paint instead of flashing a client-side
+	// "Loading errors…" after mount. Subsequent (project/status/sort) reloads and
+	// load-more are still owned by the client effect in +page.svelte.
+	const initial = await api.invoke<Api.ErrorListResult>('error.list', {
+		project,
+		status: INITIAL_STATUS,
+		sort: INITIAL_SORT
+	}, fetch)
 	return {
 		project,
 		menu: 'errors',
-		overrideRedirect: '/errors'
+		overrideRedirect: '/errors',
+		initial
 	}
 }


### PR DESCRIPTION
## What

The project-wide **Errors** list now fetches its first page **server-side in `load()`**, like the other resource list pages (`deployment`, `disk`, `route`, `audit-log`), instead of fetching client-side after mount.

## Why

The page fetched its first page from the client (`error.list` invoked by the keyed `$effect` after mount). So:

- it flashed a **"Loading errors…"** pane on every fresh navigation, and
- the issue list was **absent from the server-rendered HTML** — inconsistent with every other list page.

## How

- **`+page.ts`** — `load` now calls `error.list` (with the default `status: open`, `sort: lastSeen`) and returns it as `data.initial`.
- **`+page.svelte`** — seeds `issues` / `nextCursor` / `loaded` / the terminal states (`forbidden` / `unavailable` / `errorMessage`, via the existing `classifyListError`) from `data.initial`, so the list is present on first paint.
- The client `$effect` still owns **every subsequent reload** (project / status / sort) and load-more. `trackedListKey` is primed with the seeded view, so the effect's first run is a **no-op** instead of re-fetching what the server already returned.

No API, permission, or schema change. The `status`/`sort` defaults in `+page.svelte` and `+page.ts` are kept in lockstep so the seed matches the rendered view.

### Tradeoff (noted)

On a **project switch** (an infrequent action — `goto('/errors?project=…')` reuses this page without remounting), `load` re-fetches the default view *and* the keyed effect refetches with the current filters, i.e. one redundant `error.list`. Correctness is preserved (no stale list); the common paths — first paint, filter/sort change, load-more — stay single-fetch.

## Verification

- `bun check` and `bun lint` — both clean.
- Server-rendered HTML for `/errors?project=…` now contains the issue rows (verified the raw response before JS runs); **no "Loading errors…"** text in the SSR output.
- Rendered page (mock):

![errors](https://raw.githubusercontent.com/deploys-app/console/screenshots/307-after.png)
