### PR TITLE
billing: PromptPay QR in the invoice pay modal

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "console",
       "dependencies": {
         "@svelte-plugins/datepicker": "^1.0.11",
+        "qrcode-generator": "^2.0.4",
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -543,6 +544,8 @@
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
     "punycode": ["punycode@2.3.0", "", {}, "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="],
+
+    "qrcode-generator": ["qrcode-generator@2.0.4", "", {}, "sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g=="],
 
     "readdirp": ["readdirp@4.0.2", "", {}, "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA=="],
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@svelte-plugins/datepicker": "^1.0.11"
+    "@svelte-plugins/datepicker": "^1.0.11",
+    "qrcode-generator": "^2.0.4"
   }
 }

--- a/src/lib/components/PayInvoiceModal.svelte
+++ b/src/lib/components/PayInvoiceModal.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import PromptPayQR from '$lib/components/PromptPayQR.svelte'
+
 	// Max upload size, mirrors api.MaxTransferSlipSize (10 MiB). The server
 	// enforces this too; checking here gives instant feedback.
 	const MAX_SIZE = 10 * 1024 * 1024
@@ -112,6 +114,14 @@
 					<div class="pay-key">PromptPay</div>
 					<div class="tabular-nums">{invoice.payment.promptPay}</div>
 				</div>
+
+				<!-- Self-gates to nothing unless the invoice is THB with a PromptPay id,
+				     so no wrapper/spacing is rendered for non-THB invoices. -->
+				<PromptPayQR
+					promptPay={invoice.payment.promptPay}
+					amount={invoice.total}
+					currency={invoice.currency}
+				/>
 			</div>
 		{/if}
 

--- a/src/lib/components/PromptPayQR.svelte
+++ b/src/lib/components/PromptPayQR.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+	import qrcode from 'qrcode-generator'
+	import { canPromptPay, promptPayPayload } from '$lib/promptpay'
+
+	interface Props {
+		/** PromptPay id: mobile number, national/company tax ID, or e-wallet id. */
+		promptPay: string
+		/** Invoice total in THB; omit/0 for a reusable QR without an amount. */
+		amount?: number
+		/** Invoice currency — the QR only renders for THB. */
+		currency: string
+		/** Rendered pixel size of the QR (square). */
+		size?: number
+	}
+
+	const { promptPay, amount, currency, size = 200 }: Props = $props()
+
+	// Quiet zone, in modules, required around a QR for reliable scanning.
+	const MARGIN = 4
+
+	// Build the QR matrix once per input and flatten dark modules into a single
+	// SVG path (merging horizontal runs) — cheaper than one <rect> per module.
+	// Error correction level H (~30% recovery) leaves room for the centre logo.
+	const qr = $derived.by(() => {
+		if (!canPromptPay(currency, promptPay)) return null
+		try {
+			const code = qrcode(0, 'H')
+			code.addData(promptPayPayload(promptPay, amount))
+			code.make()
+			const count = code.getModuleCount()
+			const dim = count + MARGIN * 2
+			let d = ''
+			for (let r = 0; r < count; r++) {
+				let c = 0
+				while (c < count) {
+					if (!code.isDark(r, c)) { c++; continue }
+					let run = 1
+					while (c + run < count && code.isDark(r, c + run)) run++
+					d += `M${c + MARGIN} ${r + MARGIN}h${run}v1h-${run}z`
+					c += run
+				}
+			}
+			// Centre logo: a white knockout (≈28% of width) with the logo (≈20%)
+			// on top. Both well within level-H's recovery budget so the code still
+			// scans. Geometry is in module units to match the viewBox.
+			const box = Math.round(dim * 0.28)
+			const img = Math.round(dim * 0.2)
+			return {
+				dim,
+				path: d,
+				box,
+				boxPos: (dim - box) / 2,
+				img,
+				imgPos: (dim - img) / 2,
+				radius: Math.max(1, dim * 0.02)
+			}
+		} catch {
+			// An over-long / malformed payload shouldn't take down the modal.
+			return null
+		}
+	})
+</script>
+
+{#if qr}
+	<figure class="ppqr">
+		<!-- Colours are hard-coded black-on-white: a QR must never invert in dark
+		     mode, and the white card gives the quiet zone a solid backdrop. -->
+		<div class="ppqr-card">
+			<svg
+				viewBox="0 0 {qr.dim} {qr.dim}"
+				width={size}
+				height={size}
+				role="img"
+				aria-label="PromptPay QR code"
+			>
+				<rect x="0" y="0" width={qr.dim} height={qr.dim} fill="#fff" />
+				<path d={qr.path} fill="#000" />
+				<rect
+					x={qr.boxPos}
+					y={qr.boxPos}
+					width={qr.box}
+					height={qr.box}
+					rx={qr.radius}
+					fill="#fff"
+				/>
+				<image
+					href="/images/logo.webp"
+					x={qr.imgPos}
+					y={qr.imgPos}
+					width={qr.img}
+					height={qr.img}
+					preserveAspectRatio="xMidYMid meet"
+				/>
+			</svg>
+		</div>
+		<figcaption>Scan with any Thai mobile banking app</figcaption>
+	</figure>
+{/if}
+
+<style>
+	.ppqr {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.5rem;
+		margin: 1rem 0 0;
+	}
+
+	.ppqr-card {
+		background-color: #fff;
+		padding: 0.5rem;
+		border-radius: 8px;
+		border: 1px solid hsl(var(--hsl-content) / 0.15);
+		line-height: 0;
+	}
+
+	.ppqr figcaption {
+		font-size: var(--fs-1);
+		color: hsl(var(--hsl-content) / 0.6);
+	}
+</style>

--- a/src/lib/promptpay.ts
+++ b/src/lib/promptpay.ts
@@ -1,0 +1,91 @@
+/**
+ * PromptPay QR payload generation.
+ *
+ * A PromptPay QR is not an image of the phone number — it is an EMVCo
+ * "Merchant-Presented Mode" payload string (the Bank of Thailand "Standardized
+ * Thai QR" profile) that a banking app parses to prefill a transfer. This module
+ * builds that string; rendering it as a QR matrix is the caller's job
+ * (see PromptPayQR.svelte).
+ *
+ * The payload is a flat list of `[id][length][value]` blocks (2-digit id, 2-digit
+ * zero-padded length, then the value), terminated by a CRC-16 over everything
+ * including the CRC tag+length. The PromptPay target lives in template tag 29,
+ * whose sub-tag selects the identifier kind:
+ *   - 01 mobile number     (10 digits, normalised to 0066…)
+ *   - 02 national / tax ID (13 digits — citizen ID and company tax ID share this)
+ *   - 03 e-wallet ID       (15 digits)
+ *
+ * Spec: https://www.bot.or.th/content/dam/bot/fipcs/documents/FPG/2562/EngPDF/25620084.pdf
+ */
+
+const AID_PROMPTPAY = 'A000000677010111'
+
+/** CRC-16/CCITT-FALSE (poly 0x1021, init 0xFFFF) — the EMVCo QR checksum. */
+function crc16 (s: string): string {
+	let crc = 0xffff
+	for (let i = 0; i < s.length; i++) {
+		crc ^= s.charCodeAt(i) << 8
+		for (let b = 0; b < 8; b++) {
+			crc = (crc & 0x8000) ? ((crc << 1) ^ 0x1021) : (crc << 1)
+			crc &= 0xffff
+		}
+	}
+	return crc.toString(16).toUpperCase().padStart(4, '0')
+}
+
+/** Encode one EMVCo TLV block: id + zero-padded length + value. */
+function field (id: string, value: string): string {
+	return id + value.length.toString().padStart(2, '0') + value
+}
+
+/**
+ * Build the tag-29 PromptPay target sub-field from a raw identifier. The kind is
+ * chosen by digit count, matching how banking apps parse it:
+ *   15 digits → e-wallet, 13 → national/tax ID, otherwise → mobile.
+ */
+function promptPayTarget (digits: string): string {
+	if (digits.length >= 15) {
+		return field('03', digits)
+	}
+	if (digits.length === 13) {
+		return field('02', digits)
+	}
+	// Mobile: drop the leading 0, prefix country code 66, left-pad to 13.
+	const msisdn = ('0000000000000' + digits.replace(/^0/, '66')).slice(-13)
+	return field('01', msisdn)
+}
+
+/**
+ * Generate the PromptPay EMVCo payload string for an identifier (mobile number,
+ * national/company tax ID, or e-wallet id). Non-digit characters in `id` (spaces,
+ * dashes) are ignored. When `amount` is a positive number the QR is a one-time
+ * "dynamic" payload carrying that exact amount in THB; otherwise it is a reusable
+ * "static" payload the payer fills in.
+ */
+export function promptPayPayload (id: string, amount?: number): string {
+	const digits = id.replace(/\D/g, '')
+	const hasAmount = amount != null && Number.isFinite(amount) && amount > 0
+
+	// Field order mirrors the de-facto-standard promptpay-qr library (country 58
+	// before currency 53/amount 54) so the payload is byte-identical to the one
+	// every Thai banking app is known to accept.
+	const payload =
+		field('00', '01') + // payload format indicator
+		field('01', hasAmount ? '12' : '11') + // 12 = dynamic (one-time), 11 = static
+		field('29', field('00', AID_PROMPTPAY) + promptPayTarget(digits)) +
+		field('58', 'TH') + // country code
+		field('53', '764') + // currency = THB (ISO 4217)
+		(hasAmount ? field('54', amount.toFixed(2)) : '') // transaction amount
+
+	// CRC is computed over the payload plus the CRC tag id+length ("6304").
+	const withCrcTag = payload + '6304'
+	return withCrcTag + crc16(withCrcTag)
+}
+
+/**
+ * Whether a PromptPay QR can be shown for this invoice. PromptPay settles in THB
+ * only, so non-THB invoices (and invoices with no PromptPay id) get no QR.
+ */
+export function canPromptPay (currency: string, promptPay: string): boolean {
+	return currency === 'THB' && promptPay.replace(/\D/g, '').length >= 10
+}

--- a/tests/billing.spec.js
+++ b/tests/billing.spec.js
@@ -93,6 +93,35 @@ test.describe('invoice detail', () => {
 		await expect(modal.getByText('0812345678')).toBeVisible()
 	})
 
+	test('shows a PromptPay QR in the pay modal for a THB invoice', async ({ page }) => {
+		await setMocks({
+			// PromptPay settles in THB, so the QR only renders for THB invoices.
+			'billing.getInvoice': { ok: true, result: { ...sampleInvoice, currency: 'THB' } },
+			'billing.get': { ok: true, result: sampleBillingAccount }
+		})
+
+		await page.goto('/billing/invoice?id=inv-1')
+		await page.getByRole('button', { name: 'Pay' }).click()
+
+		const modal = page.locator('.modal.is-active .modal-panel')
+		await expect(modal.getByRole('img', { name: 'PromptPay QR code' })).toBeVisible()
+		await expect(modal.getByText('Scan with any Thai mobile banking app')).toBeVisible()
+	})
+
+	test('hides the PromptPay QR for a non-THB invoice', async ({ page }) => {
+		await setMocks({
+			'billing.getInvoice': { ok: true, result: sampleInvoice }, // currency: USD
+			'billing.get': { ok: true, result: sampleBillingAccount }
+		})
+
+		await page.goto('/billing/invoice?id=inv-1')
+		await page.getByRole('button', { name: 'Pay' }).click()
+
+		const modal = page.locator('.modal.is-active .modal-panel')
+		await expect(modal.getByText('Transfer to')).toBeVisible()
+		await expect(modal.getByRole('img', { name: 'PromptPay QR code' })).toHaveCount(0)
+	})
+
 	test('truncates a long slip file name instead of widening the modal', async ({ page }) => {
 		await setMocks({
 			'billing.getInvoice': { ok: true, result: sampleInvoice }, // status: open


### PR DESCRIPTION
## What

Render a scannable **PromptPay QR** in the invoice **pay modal**, so a customer can pay by scanning instead of copying the account number. The QR encodes the seller's PromptPay id **and the exact invoice amount**, and carries the deploys.app logo in the centre.

Screenshots are placeholders — added after the PR exists (filenames need the PR number).

| Light | Dark | Non-THB (gated off) |
| --- | --- | --- |
| ![light](https://raw.githubusercontent.com/deploys-app/console/screenshots/308-light.png) | ![dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/308-dark.png) | ![non-thb](https://raw.githubusercontent.com/deploys-app/console/screenshots/308-nonthb.png) |

## How

- **`src/lib/promptpay.ts`** — dependency-free EMVCo / Bank-of-Thailand "Standardized Thai QR" payload builder (CRC-16/CCITT). Picks the tag-29 sub-field by digit length, so it supports **mobile numbers, national IDs, company tax IDs, and e-wallet ids** transparently. Verified **byte-identical** to the canonical [`promptpay-qr`](https://www.npmjs.com/package/promptpay-qr) library across every id kind, static and dynamic.
- **`src/lib/components/PromptPayQR.svelte`** — encodes the matrix with `qrcode-generator` (pure-JS, the only new dependency) at **error-correction level H**, emitted as inline SVG (dark modules merged into one path, matching the console's hand-rolled-SVG chart convention). A centre logo sits on a white knockout, well within level-H's recovery budget. Colours are hard-coded black-on-white so the code **never inverts in dark mode**. The component **self-gates**: it renders nothing unless the invoice is THB with a PromptPay id (PromptPay settles in THB only).
- **`src/lib/components/PayInvoiceModal.svelte`** — drops the component in under the transfer-to details.

## Notes

- **No API / schema / permission change.** The PromptPay id and total are already on `billing.getInvoice` (`InvoicePayment.promptPay`, `Invoice.total`).
- **Amount unit:** the payload uses `total` as a decimal baht amount (matching the existing `money()` formatting on the invoice/modal). Worth a sanity check against a real production THB invoice when this deploys.
- **Reconciliation (follow-up):** this is the plain tag-29 person-to-merchant form. If finance wants the invoice number embedded for auto-reconciliation, that's a tag-30 "Bill Payment" follow-up.
- **Manual QA before relying on it:** scan the generated QR with 2–3 real Thai banking apps (bank scanners are sometimes stricter than generic QR readers), since the centre logo consumes part of the error-correction budget.

## Tests

- `bun lint` + `bun check` clean.
- Added two Playwright cases in `tests/billing.spec.js`: QR present in the modal for a THB invoice, and absent for a non-THB invoice. (Full `billing.spec` flakes locally on dev-server contention — a known, pre-existing machine issue that also hits `main`; the modal tests pass green in isolation and as a focused subset.)
