### PR TITLE
billing: Individual/Company type, Head Office, receipt numbers

### DIFF
--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -179,6 +179,7 @@ const billingAccounts = [
 	{
 		id: 'ba_mock_1',
 		name: 'Acme Billing',
+		type: 'company',
 		taxId: '0123456789012',
 		taxName: 'Acme Co., Ltd.',
 		taxAddress: '1 Mockingbird Lane, Bangkok 10110',
@@ -1238,10 +1239,20 @@ const mockPayment = {
 	promptPay: '0812345678'
 }
 
+// receiptNumberFor mirrors the server: a paid invoice carries a receipt number
+// (DPLY-RC-YYYYMM-NNNN) keyed to its payment month; unpaid invoices have none.
+function receiptNumberFor (inv: (typeof invoices)[number]): string {
+	if (inv.status !== 'paid' || !inv.paidAt) {
+		return ''
+	}
+	return `DPLY-RC-${inv.paidAt.slice(0, 7).replace('-', '')}-0001`
+}
+
 function invoiceListItem (inv: (typeof invoices)[number]) {
 	return {
 		id: inv.id,
 		number: inv.number,
+		receiptNumber: receiptNumberFor(inv),
 		currency: inv.currency,
 		periodStart: inv.periodStart,
 		periodEnd: inv.periodEnd,
@@ -1326,7 +1337,10 @@ const handlers: Record<string, (args: any) => object> = {
 		}
 	}),
 	'billing.listInvoices': () => list(invoices.map(invoiceListItem)),
-	'billing.getInvoice': (args) => ok({ ...(invoices.find((i) => i.id === args?.invoiceId) ?? invoices[0]), payment: mockPayment }),
+	'billing.getInvoice': (args) => {
+		const inv = invoices.find((i) => i.id === args?.invoiceId) ?? invoices[0]
+		return ok({ ...inv, receiptNumber: receiptNumberFor(inv), taxEntityType: 'company', payment: mockPayment })
+	},
 	'billing.downloadInvoice': (args) => {
 		const inv = invoices.find((i) => i.id === args?.invoiceId) ?? invoices[0]
 		return ok({

--- a/src/routes/(auth)/billing/create/+page.svelte
+++ b/src/routes/(auth)/billing/create/+page.svelte
@@ -11,6 +11,7 @@
 
 	const form = $state(untrack(() => ({
 		name: billingAccount?.name || '',
+		type: billingAccount?.type || 'individual',
 		taxId: billingAccount?.taxId || '',
 		taxName: billingAccount?.taxName || '',
 		taxAddress: billingAccount?.taxAddress || ''
@@ -31,6 +32,7 @@
 			const resp = await api.invoke(fn, {
 				id: billingAccount?.id || undefined,
 				name: form.name,
+				type: form.type,
 				taxId: form.taxId,
 				taxName: form.taxName,
 				taxAddress: form.taxAddress
@@ -83,6 +85,17 @@
 		</div>
 
 		<h4 class="mb-3">Billing Information</h4>
+
+		<div class="field">
+			<label for="input-type">Entity type</label>
+			<div class="select">
+				<select id="input-type" bind:value={form.type}>
+					<option value="individual">Individual</option>
+					<option value="company">Company</option>
+				</select>
+			</div>
+			<p class="text-sm text-content/60 mt-1">A company has “Head Office (สำนักงานใหญ่)” printed on its tax invoices and receipts.</p>
+		</div>
 
 		<div class="field">
 			<label for="input-tax_id">Tax ID</label>

--- a/src/routes/(auth)/billing/detail/+page.svelte
+++ b/src/routes/(auth)/billing/detail/+page.svelte
@@ -94,6 +94,8 @@
 		<dl class="info-list">
 			<dt>Account name</dt>
 			<dd>{billingAccount.name}</dd>
+			<dt>Entity type</dt>
+			<dd>{billingAccount.type === 'company' ? 'Company' : 'Individual'}</dd>
 			<dt>Tax ID</dt>
 			<dd>{billingAccount.taxId}</dd>
 			<dt>Name</dt>

--- a/src/routes/(auth)/billing/invoice/+page.svelte
+++ b/src/routes/(auth)/billing/invoice/+page.svelte
@@ -190,11 +190,19 @@
 				<div>{invoice.taxId}</div>
 				<div class="key">Address</div>
 				<div class="whitespace-pre-line">{invoice.taxAddress}</div>
+				{#if invoice.taxEntityType === 'company'}
+					<div class="key">Branch</div>
+					<div>Head Office (สำนักงานใหญ่)</div>
+				{/if}
 			</div>
 		</div>
 		<div>
 			<h6 class="mb-3"><strong>Details</strong></h6>
 			<div class="meta">
+				{#if invoice.status === 'paid' && invoice.receiptNumber}
+					<div class="key">Receipt no.</div>
+					<div>{invoice.receiptNumber}</div>
+				{/if}
 				<div class="key">Issued at</div>
 				<div>{format.datetime(invoice.issuedAt)}</div>
 				<div class="key">Paid at</div>

--- a/src/routes/(auth)/billing/invoices/+page.svelte
+++ b/src/routes/(auth)/billing/invoices/+page.svelte
@@ -46,6 +46,7 @@
 			<thead>
 				<tr>
 					<th>Number</th>
+					<th>Receipt no.</th>
 					<th>Period</th>
 					<th class="is-align-right">Total</th>
 					<th>Status</th>
@@ -58,14 +59,15 @@
 						<td>
 							<a class="link" href={`/billing/invoice?id=${it.id}`}>{it.number}</a>
 						</td>
+						<td>{it.receiptNumber || '—'}</td>
 						<td>{period(it.periodStart, it.periodEnd)}</td>
 						<td class="is-align-right">{money(it.total, it.currency)}</td>
 						<td><InvoiceStatusBadge status={it.status} /></td>
 						<td>{format.datetime(it.issuedAt)}</td>
 					</tr>
 				{/each}
-				<NoDataRow span={5} list={invoices} {error} />
-				<ErrorRow span={5} {error} />
+				<NoDataRow span={6} list={invoices} {error} />
+				<ErrorRow span={6} {error} />
 			</tbody>
 		</table>
 	</div>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -58,9 +58,14 @@ declare namespace Api {
         createdAt: string
     }
 
+    export type BillingAccountType = 'individual' | 'company'
+
     export type BillingAccount = {
         id: string
         name: string
+        // type is the legal entity type. A company prints the "Head Office"
+        // (สำนักงานใหญ่) designation on its tax documents; individual does not.
+        type: BillingAccountType
         taxId: string
         taxName: string
         taxAddress: string
@@ -631,6 +636,9 @@ declare namespace Api {
     export type InvoiceListItem = {
         id: string
         number: string
+        // receiptNumber is the receipt's own running number (DPLY-RC-YYYYMM-NNNN),
+        // assigned when the invoice is marked paid; empty until then.
+        receiptNumber: string
         currency: string
         periodStart: string
         periodEnd: string
@@ -660,6 +668,9 @@ declare namespace Api {
         id: string
         billingAccountId: string
         number: string
+        // receiptNumber is the receipt's own running number (DPLY-RC-YYYYMM-NNNN),
+        // assigned when paid and distinct from number; empty until paid.
+        receiptNumber: string
         currency: string
         periodStart: string
         periodEnd: string
@@ -671,6 +682,9 @@ declare namespace Api {
         taxId: string
         taxName: string
         taxAddress: string
+        // taxEntityType is the buyer's entity type snapshotted at issue time.
+        // 'company' prints the Head Office line on the bill-to block.
+        taxEntityType: BillingAccountType
         issuedAt: string
         paidAt: string
         voidedAt: string

--- a/tests/billing.spec.js
+++ b/tests/billing.spec.js
@@ -24,6 +24,41 @@ test.describe('billing accounts', () => {
 		await expect(main.getByRole('link', { name: 'Create account' })).toHaveAttribute('href', '/billing/create')
 	})
 
+	test('shows the entity type on the account detail', async ({ page }) => {
+		await setMocks({
+			'billing.get': { ok: true, result: sampleBillingAccount } // type: company
+		})
+
+		await page.goto('/billing/detail?id=ba-1')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('Entity type')).toBeVisible()
+		await expect(main.getByText('Company', { exact: true })).toBeVisible()
+	})
+
+	test('shows receipt numbers in the invoices list', async ({ page }) => {
+		await setMocks({
+			'billing.get': { ok: true, result: sampleBillingAccount },
+			'billing.listInvoices': {
+				ok: true,
+				result: {
+					items: [
+						{ ...sampleInvoice, id: 'inv-1', status: 'paid', receiptNumber: 'DPLY-RC-202605-0001' },
+						{ ...sampleInvoice, id: 'inv-2', number: 'INV-2024-002', status: 'open', receiptNumber: '' }
+					]
+				}
+			}
+		})
+
+		await page.goto('/billing/invoices?id=ba-1')
+
+		const main = page.locator('.content-wrapper')
+		const paidRow = main.locator('table tbody tr', { hasText: 'INV-2024-001' })
+		await expect(paidRow.getByText('DPLY-RC-202605-0001')).toBeVisible()
+		const openRow = main.locator('table tbody tr', { hasText: 'INV-2024-002' })
+		await expect(openRow.locator('td').nth(1)).toHaveText('—')
+	})
+
 	test('empty state when no billing accounts', async ({ page }) => {
 		await page.goto('/billing')
 		const main = page.locator('.content-wrapper')
@@ -46,6 +81,42 @@ test.describe('invoice detail', () => {
 
 		const apiRow = page.locator('table tbody tr', { hasText: 'API service' })
 		await expect(apiRow.locator('td').nth(2)).toHaveText('1.70 USD')
+	})
+
+	test('shows the Head Office line on a company invoice', async ({ page }) => {
+		await setMocks({
+			'billing.getInvoice': { ok: true, result: sampleInvoice }, // taxEntityType: company
+			'billing.get': { ok: true, result: sampleBillingAccount }
+		})
+
+		await page.goto('/billing/invoice?id=inv-1')
+
+		await expect(page.getByText('Head Office (สำนักงานใหญ่)')).toBeVisible()
+	})
+
+	test('omits the Head Office line for an individual invoice', async ({ page }) => {
+		await setMocks({
+			'billing.getInvoice': { ok: true, result: { ...sampleInvoice, taxEntityType: 'individual' } },
+			'billing.get': { ok: true, result: sampleBillingAccount }
+		})
+
+		await page.goto('/billing/invoice?id=inv-1')
+
+		await expect(page.getByText('Head Office (สำนักงานใหญ่)')).toHaveCount(0)
+	})
+
+	test('shows the receipt number on a paid invoice', async ({ page }) => {
+		await setMocks({
+			'billing.getInvoice': {
+				ok: true,
+				result: { ...sampleInvoice, status: 'paid', paidAt: '2026-05-03T00:00:00Z', receiptNumber: 'DPLY-RC-202605-0001' }
+			},
+			'billing.get': { ok: true, result: sampleBillingAccount }
+		})
+
+		await page.goto('/billing/invoice?id=inv-1')
+
+		await expect(page.getByText('DPLY-RC-202605-0001')).toBeVisible()
 	})
 
 	test('shows how-to-pay payment details on an open invoice', async ({ page }) => {

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -350,6 +350,7 @@ export const sampleEmailDomain = {
 export const sampleBillingAccount = {
 	id: 'ba-1',
 	name: 'Personal',
+	type: 'company',
 	taxId: '',
 	taxName: '',
 	taxAddress: '',
@@ -360,6 +361,7 @@ export const sampleInvoice = {
 	id: 'inv-1',
 	billingAccountId: 'ba-1',
 	number: 'INV-2024-001',
+	receiptNumber: '',
 	currency: 'USD',
 	periodStart: '2024-01-01T00:00:00Z',
 	periodEnd: '2024-02-01T00:00:00Z',
@@ -371,6 +373,7 @@ export const sampleInvoice = {
 	taxId: '',
 	taxName: 'Acme Co',
 	taxAddress: '',
+	taxEntityType: 'company',
 	issuedAt: now,
 	paidAt: '0001-01-01T00:00:00Z',
 	voidedAt: '0001-01-01T00:00:00Z',


### PR DESCRIPTION
## What

Surfaces the accounting feedback (deploys-app/api#117, apiserver#217) in the console.

- **Billing account create/edit** gains an **Entity type** selector (Individual / Company), with a note that a company prints "Head Office (สำนักงานใหญ่)" on its tax documents; the value is sent on `billing.create` / `billing.update`.
- **Billing account detail** shows the entity type.
- **Invoice page** shows a **"Head Office (สำนักงานใหญ่)"** branch line in the Bill-to block when the invoice's snapshotted entity type is `company`, and the **receipt number** (`DPLY-RC-YYYYMM-NNNN`) in Details for a paid invoice.
- **Invoices list** gains a **Receipt no.** column.

Types (`BillingAccount.type`, `Invoice.receiptNumber`/`taxEntityType`, `InvoiceListItem.receiptNumber`), the dev mock, and the Playwright fixtures are updated; new e2e tests cover the Head Office line (company vs individual), the receipt number on a paid invoice, the entity-type row, and the receipt column. `lint` + `check` + billing e2e (18) green.

## Screenshots



### Billing account create/edit — Entity type selector
![create](https://raw.githubusercontent.com/deploys-app/console/screenshots/309-create-form.png)

### Billing account detail — Entity type
![detail](https://raw.githubusercontent.com/deploys-app/console/screenshots/309-account-detail.png)

### Invoice — Head Office (สำนักงานใหญ่) bill-to + Receipt no.
![invoice](https://raw.githubusercontent.com/deploys-app/console/screenshots/309-invoice.png)

### Invoices list — Receipt no. column
![invoices](https://raw.githubusercontent.com/deploys-app/console/screenshots/309-invoices-list.png)
