### PR TITLE
transform: edge transform management UI

### DIFF
--- a/src/lib/components/TransformOpsEditor.svelte
+++ b/src/lib/components/TransformOpsEditor.svelte
@@ -1,0 +1,280 @@
+<script lang="ts">
+	import Select from '$lib/components/Select.svelte'
+	import TagInput from '$lib/components/TagInput.svelte'
+	import {
+		phaseOpTypes,
+		opTypeLabels,
+		opTypeIcons,
+		redirectStatusOptions,
+		blankOp,
+		genOpId,
+		type OpForm
+	} from '$lib/transform/rules'
+
+	interface Props {
+		// The rule's ordered op list (bindable).
+		ops: OpForm[]
+		// The rule's phase — gates which op types are offered.
+		phase: Api.TransformPhase
+	}
+
+	let { ops = $bindable(), phase }: Props = $props()
+
+	// Op-type options for the current phase, shown in each op's type Select.
+	const typeOptions = $derived(
+		phaseOpTypes[phase].map((t) => ({ value: t, label: opTypeLabels[t] }))
+	)
+
+	function addOp () {
+		ops = [...ops, blankOp(phase, ops.map((o) => o.id))]
+	}
+
+	function removeOp (i: number) {
+		ops = ops.filter((_, k) => k !== i)
+	}
+
+	function moveOp (i: number, dir: -1 | 1) {
+		const j = i + dir
+		if (j < 0 || j >= ops.length) return
+		const next = [...ops]
+		;[next[i], next[j]] = [next[j], next[i]]
+		ops = next
+	}
+
+	function addQueryRow (op: OpForm) {
+		op.query = [...op.query, { id: genOpId(op.query.map((q) => q.id)), key: '', value: '' }]
+	}
+
+	function removeQueryRow (op: OpForm, i: number) {
+		op.query = op.query.filter((_, k) => k !== i)
+	}
+</script>
+
+<div class="grid gap-3">
+	{#each ops as op, i (op.id)}
+		<div class="op-card">
+			<div class="op-head">
+				<span class="op-icon"><i class="fa-solid {opTypeIcons[op.type]}"></i></span>
+				<div class="op-type">
+					<Select bind:value={op.type} options={typeOptions} />
+				</div>
+				<div class="op-actions">
+					<button type="button" class="icon-button" aria-label="Move operation up"
+						disabled={i === 0} onclick={() => moveOp(i, -1)}>
+						<i class="fa-solid fa-chevron-up"></i>
+					</button>
+					<button type="button" class="icon-button" aria-label="Move operation down"
+						disabled={i === ops.length - 1} onclick={() => moveOp(i, 1)}>
+						<i class="fa-solid fa-chevron-down"></i>
+					</button>
+					<button type="button" class="icon-button" aria-label="Remove operation"
+						disabled={ops.length === 1} onclick={() => removeOp(i)}>
+						<i class="fa-solid fa-trash-alt"></i>
+					</button>
+				</div>
+			</div>
+
+			<div class="op-body">
+				{#if op.type === 'set-header'}
+					<div class="grid gap-3 sm:grid-cols-2">
+						<div class="field">
+							<label for={`op-${op.id}-name`}>Header name</label>
+							<div class="input">
+								<input id={`op-${op.id}-name`} class="font-mono" bind:value={op.name} placeholder="e.g. Strict-Transport-Security">
+							</div>
+						</div>
+						<div class="field">
+							<label for={`op-${op.id}-value`}>Value</label>
+							<div class="input">
+								<input id={`op-${op.id}-value`} class="font-mono" bind:value={op.value} placeholder="e.g. max-age=63072000">
+							</div>
+						</div>
+					</div>
+				{:else if op.type === 'remove-header'}
+					<div class="field sm:max-w-md">
+						<label for={`op-${op.id}-name`}>Header name</label>
+						<div class="input">
+							<input id={`op-${op.id}-name`} class="font-mono" bind:value={op.name} placeholder="e.g. X-Powered-By">
+						</div>
+					</div>
+				{:else if op.type === 'rewrite-path'}
+					<div class="grid gap-3">
+						<div class="tabs is-variant-underline" role="tablist">
+							<button type="button" class="tab-button" class:is-active={op.pathMode === 'path'}
+								role="tab" aria-selected={op.pathMode === 'path'}
+								onclick={() => (op.pathMode = 'path')}>
+								<i class="fa-solid fa-equals mr-2"></i><span>Literal path</span>
+							</button>
+							<button type="button" class="tab-button" class:is-active={op.pathMode === 'regex'}
+								role="tab" aria-selected={op.pathMode === 'regex'}
+								onclick={() => (op.pathMode = 'regex')}>
+								<i class="fa-solid fa-asterisk mr-2"></i><span>Regex</span>
+							</button>
+						</div>
+						{#if op.pathMode === 'path'}
+							<div class="field">
+								<label for={`op-${op.id}-path`}>Replacement path</label>
+								<div class="input">
+									<input id={`op-${op.id}-path`} class="font-mono" bind:value={op.path} placeholder="e.g. /api/v2/users">
+								</div>
+							</div>
+						{:else}
+							<div class="grid gap-3 sm:grid-cols-2">
+								<div class="field">
+									<label for={`op-${op.id}-regex`}>Pattern (RE2)</label>
+									<div class="input">
+										<input id={`op-${op.id}-regex`} class="font-mono" bind:value={op.regex} placeholder="e.g. ^/api/v1/(.*)$">
+									</div>
+								</div>
+								<div class="field">
+									<label for={`op-${op.id}-replace`}>Replacement</label>
+									<div class="input">
+										<input id={`op-${op.id}-replace`} class="font-mono" bind:value={op.replace} placeholder="e.g. /api/v2/$1">
+									</div>
+								</div>
+							</div>
+						{/if}
+					</div>
+				{:else if op.type === 'rewrite-query'}
+					<div class="grid gap-3">
+						<div class="field">
+							<span class="label">Set query parameters</span>
+							{#if op.query.length}
+								<div class="grid gap-2">
+									{#each op.query as row, qi (row.id)}
+										<div class="query-row">
+											<input class="input font-mono" bind:value={row.key} placeholder="name" aria-label="Query parameter name">
+											<input class="input font-mono" bind:value={row.value} placeholder="value" aria-label="Query parameter value">
+											<button type="button" class="icon-button" aria-label="Remove query parameter" onclick={() => removeQueryRow(op, qi)}>
+												<i class="fa-solid fa-xmark"></i>
+											</button>
+										</div>
+									{/each}
+								</div>
+							{/if}
+							<button type="button" class="button is-variant-tertiary is-size-small justify-self-start mt-1" onclick={() => addQueryRow(op)}>
+								<i class="fa-solid fa-plus mr-2"></i><span>Add parameter</span>
+							</button>
+						</div>
+						<div class="field">
+							<label for={`op-${op.id}-removeq`}>Remove query parameters</label>
+							<TagInput id={`op-${op.id}-removeq`} bind:tags={op.removeQuery} placeholder="Type a parameter name, press Enter" />
+						</div>
+					</div>
+				{:else if op.type === 'redirect'}
+					<div class="grid gap-3 sm:grid-cols-2">
+						<div class="field">
+							<label for={`op-${op.id}-to`}>Redirect to</label>
+							<div class="input">
+								<input id={`op-${op.id}-to`} class="font-mono" bind:value={op.to} placeholder="e.g. https://www.acme.com$uri">
+							</div>
+							<p class="text-content/50 text-xs mt-1">
+								Use <code class="font-mono">$uri</code> for the original request URI.
+							</p>
+						</div>
+						<div class="field">
+							<label for={`op-${op.id}-status`}>Status</label>
+							<Select id={`op-${op.id}-status`} bind:value={op.status} options={redirectStatusOptions} placeholder="302 — Found" />
+						</div>
+					</div>
+				{:else if op.type === 'set-status'}
+					<div class="field sm:max-w-xs">
+						<label for={`op-${op.id}-status`}>Response status</label>
+						<div class="input">
+							<input id={`op-${op.id}-status`} class="font-mono" type="number" min="100" max="599" bind:value={op.status} placeholder="e.g. 204">
+						</div>
+					</div>
+				{:else if op.type === 'cors'}
+					<div class="grid gap-3">
+						<div class="field">
+							<label for={`op-${op.id}-origins`}>Allowed origins</label>
+							<TagInput id={`op-${op.id}-origins`} bind:tags={op.allowOrigins} placeholder="e.g. https://app.acme.com (or *)" />
+						</div>
+						<div class="grid gap-3 sm:grid-cols-2">
+							<div class="field">
+								<label for={`op-${op.id}-methods`}>Allowed methods</label>
+								<TagInput id={`op-${op.id}-methods`} bind:tags={op.allowMethods} placeholder="e.g. GET, POST" />
+							</div>
+							<div class="field">
+								<label for={`op-${op.id}-headers`}>Allowed headers</label>
+								<TagInput id={`op-${op.id}-headers`} bind:tags={op.allowHeaders} placeholder="e.g. Authorization" />
+							</div>
+						</div>
+						<div class="grid gap-3 sm:grid-cols-2">
+							<div class="field">
+								<label for={`op-${op.id}-expose`}>Exposed headers</label>
+								<TagInput id={`op-${op.id}-expose`} bind:tags={op.exposeHeaders} placeholder="e.g. X-Request-Id" />
+							</div>
+							<div class="field">
+								<label for={`op-${op.id}-maxage`}>Max age</label>
+								<div class="input">
+									<input id={`op-${op.id}-maxage`} class="font-mono" bind:value={op.maxAge} placeholder="e.g. 1h">
+								</div>
+							</div>
+						</div>
+						<label class="checkbox">
+							<input type="checkbox" bind:checked={op.allowCredentials}>
+							Allow credentials (cannot be combined with the “*” origin)
+						</label>
+					</div>
+				{/if}
+			</div>
+		</div>
+	{/each}
+
+	<button type="button" class="button is-variant-secondary justify-self-start" onclick={addOp}>
+		<i class="fa-solid fa-plus mr-2"></i><span>Add operation</span>
+	</button>
+</div>
+
+<style>
+	.op-card {
+		border: 1px solid hsl(var(--hsl-line) / 0.8);
+		border-radius: var(--radius-lg);
+		background: hsl(var(--hsl-base-200) / 0.4);
+	}
+
+	.op-head {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		padding: 0.625rem 0.75rem;
+		border-bottom: 1px solid hsl(var(--hsl-line) / 0.6);
+	}
+
+	.op-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.75rem;
+		height: 1.75rem;
+		flex-shrink: 0;
+		border-radius: 0.5rem;
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-primary));
+		background: hsl(var(--hsl-primary) / 0.12);
+	}
+
+	.op-type {
+		flex: 1;
+		min-width: 0;
+		max-width: 16rem;
+	}
+
+	.op-actions {
+		display: flex;
+		gap: 0.25rem;
+		margin-left: auto;
+	}
+
+	.op-body {
+		padding: 0.875rem 0.75rem;
+	}
+
+	.query-row {
+		display: grid;
+		grid-template-columns: 1fr 1fr auto;
+		align-items: center;
+		gap: 0.5rem;
+	}
+</style>

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -23,6 +23,7 @@ export const projectMenu: ProjectMenuItem[] = [
 	{ id: 'route', title: 'Routes', icon: 'fa-router', link: '/route' },
 	{ id: 'waf', title: 'Firewall', icon: 'fa-shield-halved', link: '/waf', preview: true },
 	{ id: 'cache', title: 'Cache', icon: 'fa-bolt', link: '/cache', preview: true },
+	{ id: 'transform', title: 'Transform', icon: 'fa-wand-magic-sparkles', link: '/transform', preview: true },
 	{ id: 'workload-identity', title: 'Workload Identities', icon: 'fa-network-wired', link: '/workload-identity' },
 	{ id: 'disk', title: 'Disks', icon: 'fa-hdd', link: '/disk' },
 	{ id: 'pull-secret', title: 'Pull Secrets', icon: 'fa-key', link: '/pull-secret' },

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -160,7 +160,7 @@ const locations = [
 		cname: 'rcf2.deploys.app.',
 		cpuAllocatable: ['100m', '250m', '500m', '1000m', '2000m'],
 		memoryAllocatable: ['128Mi', '256Mi', '512Mi', '1Gi', '2Gi'],
-		features: { workloadIdentity: true, disk: {}, waf: {}, cache: {} },
+		features: { workloadIdentity: true, disk: {}, waf: {}, cache: {}, transform: {} },
 		createdAt: CREATED_AT
 	},
 	{
@@ -170,7 +170,7 @@ const locations = [
 		cname: 'sg1.deploys.app.',
 		cpuAllocatable: ['100m', '250m', '500m', '1000m', '2000m'],
 		memoryAllocatable: ['128Mi', '256Mi', '512Mi', '1Gi', '2Gi'],
-		features: { workloadIdentity: true, disk: {}, waf: {}, cache: {} },
+		features: { workloadIdentity: true, disk: {}, waf: {}, cache: {}, transform: {} },
 		createdAt: CREATED_AT
 	}
 ]
@@ -747,6 +747,80 @@ function cacheConfiguredZone (location: string, advance = false) {
 		location,
 		description: entry.description,
 		overrides: [],
+		status,
+		action: 'create',
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL
+	}
+}
+
+// Transform — seed zone with a request redirect rule, a response security-
+// header rule, and a shadow CORS rule, so the index, manage table, and edit
+// page all have content to show.
+const transformZone = {
+	project: 'acme',
+	location: LOCATION_ID,
+	description: 'Force www + security headers',
+	transforms: [
+		{
+			id: 'force-www',
+			description: 'Force the apex host to www (301)',
+			phase: 'request',
+			filter: "request.host == 'acme.com'",
+			ops: [
+				{ type: 'redirect', to: 'https://www.acme.com$uri', status: 301 }
+			],
+			mode: '',
+			priority: 0
+		},
+		{
+			id: 'security-headers',
+			description: 'HSTS + security baseline',
+			phase: 'response',
+			ops: [
+				{ type: 'set-header', name: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+				{ type: 'set-header', name: 'X-Content-Type-Options', value: 'nosniff' },
+				{ type: 'remove-header', name: 'X-Powered-By' }
+			],
+			mode: '',
+			priority: 1
+		},
+		{
+			id: 'spa-cors',
+			description: 'CORS for the SPA (shadow)',
+			phase: 'response',
+			filter: "request.path.startsWith('/api/')",
+			ops: [
+				{ type: 'cors', allowOrigins: ['https://app.acme.com'], allowMethods: ['GET', 'POST'], allowHeaders: ['Authorization'], allowCredentials: true, maxAge: '1h' }
+			],
+			mode: 'shadow',
+			priority: 2
+		}
+	],
+	status: 'success',
+	action: 'create',
+	createdAt: CREATED_AT,
+	createdBy: USER_EMAIL
+}
+
+// Locations (besides the seed LOCATION_ID) that have had transform configured
+// in this dev session, mapped to { description, polls }. Mirrors cacheConfigured
+// — the simulated deployer flips a freshly created zone from pending → success
+// after the first list read, so the index spinner resolves on its own.
+const transformConfigured = new Map<string, { description: string, polls: number }>()
+
+function transformConfiguredZone (location: string, advance = false) {
+	const entry = transformConfigured.get(location) ?? { description: '', polls: 0 }
+	const status = entry.polls > 0 ? 'success' : 'pending'
+	if (advance) {
+		entry.polls += 1
+		transformConfigured.set(location, entry)
+	}
+	return {
+		project: 'acme',
+		location,
+		description: entry.description,
+		transforms: [],
 		status,
 		action: 'create',
 		createdAt: CREATED_AT,
@@ -1948,6 +2022,38 @@ const handlers: Record<string, (args: any) => object> = {
 	'cache.resultMetrics': (args) => ok(cacheResultMetrics(args?.timeRange)),
 	'cache.delete': (args) => {
 		if (args?.location) cacheConfigured.delete(args.location)
+		return ok({})
+	},
+
+	// The seed location starts configured and live; every other location is
+	// "transform not configured yet" (not-found) until created. A freshly created
+	// location starts as { status: 'pending', action: 'create' } and the
+	// simulated deployer flips it to 'success' after the first read (see
+	// transformConfiguredZone), so the index spinner resolves on its own.
+	'transform.list': () => {
+		const items = [{ ...transformZone, location: LOCATION_ID }]
+		for (const location of transformConfigured.keys()) {
+			items.push(transformConfiguredZone(location, true))
+		}
+		return ok({ project: 'acme', items })
+	},
+	'transform.get': (args) => {
+		const location = args?.location ?? LOCATION_ID
+		if (location === LOCATION_ID) return ok({ ...transformZone, location: LOCATION_ID })
+		if (transformConfigured.has(location)) {
+			return ok(transformConfiguredZone(location))
+		}
+		return err('api: transform zone not found')
+	},
+	'transform.set': (args) => {
+		const location = args?.location
+		if (location && location !== LOCATION_ID) {
+			transformConfigured.set(location, { description: args?.description ?? '', polls: 0 })
+		}
+		return ok({})
+	},
+	'transform.delete': (args) => {
+		if (args?.location) transformConfigured.delete(args.location)
 		return ok({})
 	},
 

--- a/src/lib/transform/rules.ts
+++ b/src/lib/transform/rules.ts
@@ -1,0 +1,363 @@
+// Shared rule/op helpers for the transform list + edit pages. Like cache
+// overrides, rule ids are auto-generated and stable for the life of a rule
+// (they appear in parapet's future metric series as rule_id), so they must
+// survive reordering. Order within a phase = match order, with `priority`
+// derived from index on every whole-zone write.
+//
+// A transform rule is a phase + an optional CEL filter + an ordered list of
+// ops of that phase. The op editor is net-new (cache only has filter+policy);
+// each op is typed and reads only its own subset of fields.
+
+import { makeGenId, withStableIds } from '$lib/form/ids'
+
+// ---- Phase × op legality matrix (mirrors api §2.3) -------------------------
+
+export const phaseLabels: Record<Api.TransformPhase, string> = {
+	request: 'Request',
+	response: 'Response'
+}
+
+// Op types legal in each phase. Header ops are phase-polymorphic (legal in
+// both); the rest are phase-specific.
+export const phaseOpTypes: Record<Api.TransformPhase, Api.TransformOpType[]> = {
+	request: ['set-header', 'remove-header', 'rewrite-path', 'rewrite-query', 'redirect'],
+	response: ['set-header', 'remove-header', 'set-status', 'cors']
+}
+
+export const opTypeLabels: Record<Api.TransformOpType, string> = {
+	'set-header': 'Set header',
+	'remove-header': 'Remove header',
+	'rewrite-path': 'Rewrite path',
+	'rewrite-query': 'Rewrite query',
+	redirect: 'Redirect',
+	'set-status': 'Set status',
+	cors: 'CORS'
+}
+
+export const opTypeIcons: Record<Api.TransformOpType, string> = {
+	'set-header': 'fa-plus',
+	'remove-header': 'fa-minus',
+	'rewrite-path': 'fa-route',
+	'rewrite-query': 'fa-link',
+	redirect: 'fa-arrow-right-arrow-left',
+	'set-status': 'fa-hashtag',
+	cors: 'fa-globe'
+}
+
+export const modeLabels: Record<string, string> = {
+	enforce: 'Enforce',
+	shadow: 'Shadow'
+}
+
+// redirect must be a 3xx; default 302.
+export const redirectStatusOptions: { value: string, label: string }[] = [
+	{ value: '301', label: '301 — Moved Permanently' },
+	{ value: '302', label: '302 — Found' },
+	{ value: '303', label: '303 — See Other' },
+	{ value: '307', label: '307 — Temporary Redirect' },
+	{ value: '308', label: '308 — Permanent Redirect' }
+]
+
+// Ops that take over the whole rule: a redirect short-circuits the chain and
+// cors is mounted as a standalone middleware, so each must be the only op in
+// its rule (api §3.4).
+export const SOLE_OP_TYPES: Api.TransformOpType[] = ['redirect', 'cors']
+
+export function isOpLegal (phase: Api.TransformPhase, type: Api.TransformOpType): boolean {
+	return phaseOpTypes[phase].includes(type)
+}
+
+// ---- Form models -----------------------------------------------------------
+
+// A single query param row for the rewrite-query editor (stable id for keying).
+export interface QueryRow {
+	id: string
+	key: string
+	value: string
+}
+
+// One op as edited in the form. Every typed field is present (zero-valued when
+// unused) so a Select can switch an op's type without losing the other fields;
+// toApiRules drops the fields irrelevant to the chosen type.
+export interface OpForm {
+	id: string
+	type: Api.TransformOpType
+	// header ops
+	name: string
+	value: string
+	// redirect
+	to: string
+	// rewrite-path — `pathMode` chooses literal vs regex
+	pathMode: 'path' | 'regex'
+	path: string
+	regex: string
+	replace: string
+	// rewrite-query
+	query: QueryRow[]
+	removeQuery: string[]
+	// redirect / set-status (edited as text, parsed on save)
+	status: string
+	// cors
+	allowOrigins: string[]
+	allowMethods: string[]
+	allowHeaders: string[]
+	exposeHeaders: string[]
+	allowCredentials: boolean
+	maxAge: string
+}
+
+export interface RuleForm {
+	id: string
+	description: string
+	phase: Api.TransformPhase
+	filter: string
+	ops: OpForm[]
+	mode: 'enforce' | 'shadow'
+}
+
+export const genRuleId = makeGenId('transform-rule-')
+export const genOpId = makeGenId('transform-op-')
+
+// Default redirect status when the user hasn't picked one (matches the api
+// default of 302).
+export const DEFAULT_REDIRECT_STATUS = '302'
+
+export function blankOp (phase: Api.TransformPhase, taken: string[] = []): OpForm {
+	return {
+		id: genOpId(taken),
+		type: phaseOpTypes[phase][0],
+		name: '',
+		value: '',
+		to: '',
+		pathMode: 'path',
+		path: '',
+		regex: '',
+		replace: '',
+		query: [],
+		removeQuery: [],
+		status: '',
+		allowOrigins: [],
+		allowMethods: [],
+		allowHeaders: [],
+		exposeHeaders: [],
+		allowCredentials: false,
+		maxAge: ''
+	}
+}
+
+function opForm (op: Api.TransformOp): OpForm {
+	const base = blankOp('request')
+	return {
+		...base,
+		type: op.type,
+		name: op.name ?? '',
+		value: op.value ?? '',
+		to: op.to ?? '',
+		pathMode: op.regex ? 'regex' : 'path',
+		path: op.path ?? '',
+		regex: op.regex ?? '',
+		replace: op.replace ?? '',
+		query: Object.entries(op.query ?? {}).map(([key, value]) => ({ id: genOpId([]), key, value })),
+		removeQuery: [...(op.removeQuery ?? [])],
+		status: op.status != null ? String(op.status) : '',
+		allowOrigins: [...(op.allowOrigins ?? [])],
+		allowMethods: [...(op.allowMethods ?? [])],
+		allowHeaders: [...(op.allowHeaders ?? [])],
+		exposeHeaders: [...(op.exposeHeaders ?? [])],
+		allowCredentials: op.allowCredentials ?? false,
+		maxAge: op.maxAge ?? ''
+	}
+}
+
+function ruleForm (rule?: Api.TransformRule): RuleForm {
+	const ops = (rule?.ops ?? []).map(opForm)
+	// Give each op a stable, unique row id.
+	const takenOpIds: string[] = []
+	for (const op of ops) {
+		if (takenOpIds.includes(op.id)) op.id = genOpId(takenOpIds)
+		takenOpIds.push(op.id)
+	}
+	const phase: Api.TransformPhase = rule?.phase ?? 'request'
+	return {
+		id: rule?.id ?? '',
+		description: rule?.description ?? '',
+		phase,
+		filter: rule?.filter ?? '',
+		ops: ops.length ? ops : [blankOp(phase, takenOpIds)],
+		mode: rule?.mode === 'shadow' ? 'shadow' : 'enforce'
+	}
+}
+
+export function newRule (taken: string[]): RuleForm {
+	return { ...ruleForm(), id: genRuleId(taken) }
+}
+
+// Map API rules to form rows: order by priority within the array order the
+// server returned (priority is ascending within a phase), and give every row a
+// unique stable id.
+export function normalizeRules (apiRules?: Api.TransformRule[]): RuleForm[] {
+	const sorted = [...(apiRules ?? [])].sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0))
+	return withStableIds(sorted, ruleForm, genRuleId)
+}
+
+// When the rule's phase changes, coerce any op whose type is no longer legal in
+// the new phase to the first legal type (header ops survive; phase-specific ops
+// fold to set-header). Mutates in place.
+export function coerceOpsToPhase (ops: OpForm[], phase: Api.TransformPhase): void {
+	for (const op of ops) {
+		if (!isOpLegal(phase, op.type)) op.type = phaseOpTypes[phase][0]
+	}
+}
+
+// Map a single form op back to the API op shape, dropping every field that
+// doesn't belong to the chosen type so the rendered yaml stays minimal.
+function toApiOp (op: OpForm): Api.TransformOp {
+	switch (op.type) {
+	case 'set-header':
+		return { type: op.type, name: op.name.trim(), value: op.value }
+	case 'remove-header':
+		return { type: op.type, name: op.name.trim() }
+	case 'rewrite-path':
+		if (op.pathMode === 'regex') {
+			return { type: op.type, regex: op.regex, replace: op.replace }
+		}
+		return { type: op.type, path: op.path.trim() }
+	case 'rewrite-query': {
+		const out: Api.TransformOp = { type: op.type }
+		const query: Record<string, string> = {}
+		for (const row of op.query) {
+			const k = row.key.trim()
+			if (k) query[k] = row.value
+		}
+		if (Object.keys(query).length) out.query = query
+		const removeQuery = op.removeQuery.map((q) => q.trim()).filter(Boolean)
+		if (removeQuery.length) out.removeQuery = removeQuery
+		return out
+	}
+	case 'redirect': {
+		const out: Api.TransformOp = { type: op.type, to: op.to.trim() }
+		const status = Number(op.status)
+		if (Number.isInteger(status) && status > 0) out.status = status
+		return out
+	}
+	case 'set-status': {
+		const out: Api.TransformOp = { type: op.type }
+		const status = Number(op.status)
+		if (Number.isInteger(status) && status > 0) out.status = status
+		return out
+	}
+	case 'cors': {
+		const out: Api.TransformOp = { type: op.type, allowOrigins: [...op.allowOrigins] }
+		if (op.allowMethods.length) out.allowMethods = [...op.allowMethods]
+		if (op.allowHeaders.length) out.allowHeaders = [...op.allowHeaders]
+		if (op.exposeHeaders.length) out.exposeHeaders = [...op.exposeHeaders]
+		if (op.allowCredentials) out.allowCredentials = true
+		if (op.maxAge.trim()) out.maxAge = op.maxAge.trim()
+		return out
+	}
+	default:
+		return { type: op.type }
+	}
+}
+
+// Map form rows back to the API rule shape. Priority follows row order within
+// the whole list (the api orders ascending within a phase, ties by id). Mode
+// 'enforce' maps to the wire's '' (the api accepts only '' | 'shadow').
+export function toApiRules (rules: RuleForm[]): Api.TransformRule[] {
+	return rules.map((r, i) => ({
+		id: r.id,
+		description: r.description,
+		phase: r.phase,
+		filter: (r.filter ?? '').trim(),
+		ops: r.ops.map(toApiOp),
+		mode: r.mode === 'shadow' ? 'shadow' : '',
+		priority: i
+	}))
+}
+
+// One-line human summary of an op for the manage table.
+export function describeOp (op: OpForm): string {
+	switch (op.type) {
+	case 'set-header':
+		return `Set ${op.name || 'header'}`
+	case 'remove-header':
+		return `Remove ${op.name || 'header'}`
+	case 'rewrite-path':
+		return op.pathMode === 'regex' ? `Rewrite path ${op.regex || ''}`.trim() : `Rewrite path → ${op.path || '/'}`
+	case 'rewrite-query':
+		return 'Rewrite query'
+	case 'redirect':
+		return `Redirect ${op.status || DEFAULT_REDIRECT_STATUS}`
+	case 'set-status':
+		return `Set status ${op.status || ''}`.trim()
+	case 'cors':
+		return 'CORS'
+	default:
+		return op.type
+	}
+}
+
+// Short summary of a rule's ops for the manage table behavior column.
+export function describeRule (rule: RuleForm): string {
+	if (rule.ops.length === 0) return 'No ops'
+	if (rule.ops.length === 1) return describeOp(rule.ops[0])
+	return `${rule.ops.length} ops`
+}
+
+// Light client-side validation mirroring the api's structural rules, enough to
+// drive a disabled Save + an inline hint. The server enforces the full set
+// (protected-header denylist, bounds, regex compile) and surfaces anything
+// else on save.
+export function validateRule (rule: RuleForm): string | null {
+	if (rule.ops.length === 0) return 'Add at least one operation.'
+
+	// redirect / cors must be the sole op in their rule.
+	const sole = rule.ops.find((o) => SOLE_OP_TYPES.includes(o.type))
+	if (sole && rule.ops.length > 1) {
+		return `A ${opTypeLabels[sole.type]} operation must be the only operation in its rule.`
+	}
+
+	for (const op of rule.ops) {
+		if (!isOpLegal(rule.phase, op.type)) {
+			return `${opTypeLabels[op.type]} is not allowed in the ${phaseLabels[rule.phase].toLowerCase()} phase.`
+		}
+		switch (op.type) {
+		case 'set-header':
+			if (!op.name.trim()) return 'Set header needs a header name.'
+			break
+		case 'remove-header':
+			if (!op.name.trim()) return 'Remove header needs a header name.'
+			break
+		case 'rewrite-path':
+			if (op.pathMode === 'regex') {
+				if (!op.regex.trim()) return 'Rewrite path needs a regex pattern.'
+				if (!op.replace.trim()) return 'Rewrite path needs a replacement.'
+			} else if (!op.path.trim()) {
+				return 'Rewrite path needs a replacement path.'
+			} else if (!op.path.trim().startsWith('/')) {
+				return 'The replacement path must start with “/”.'
+			}
+			break
+		case 'rewrite-query':
+			if (op.query.every((q) => !q.key.trim()) && op.removeQuery.every((q) => !q.trim())) {
+				return 'Rewrite query needs at least one parameter to set or remove.'
+			}
+			break
+		case 'redirect':
+			if (!op.to.trim()) return 'Redirect needs a target URL.'
+			break
+		case 'set-status': {
+			const s = Number(op.status)
+			if (!Number.isInteger(s) || s < 100 || s > 599) return 'Set status needs a status in 100–599.'
+			break
+		}
+		case 'cors':
+			if (op.allowOrigins.length === 0) return 'CORS needs at least one allowed origin.'
+			if (op.allowCredentials && op.allowOrigins.includes('*')) {
+				return 'CORS with credentials cannot allow the “*” origin.'
+			}
+			break
+		}
+	}
+	return null
+}

--- a/src/routes/(auth)/(project)/transform/+layout.ts
+++ b/src/routes/(auth)/(project)/transform/+layout.ts
@@ -1,0 +1,8 @@
+import type { LayoutLoad } from './$types'
+
+export const load: LayoutLoad = () => {
+	return {
+		menu: 'transform',
+		overrideRedirect: '/transform'
+	}
+}

--- a/src/routes/(auth)/(project)/transform/+page.svelte
+++ b/src/routes/(auth)/(project)/transform/+page.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+	import type { PageData } from './$types'
+	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import { onMount } from 'svelte'
+	import api from '$lib/api'
+
+	const { data }: { data: PageData } = $props()
+
+	const project = $derived(data.project)
+	const zones = $derived(data.zones)
+	const error = $derived(data.error)
+
+	const hasPending = $derived(zones.some((z: Api.TransformZone) => z.status === 'pending'))
+
+	// While any zone is still being applied/removed by the deployer, poll
+	// transform.list so the spinner resolves to its settled state on its own
+	// (mirrors the cache/WAF index polling pattern).
+	onMount(() => api.intervalInvalidate(async () => {
+		if (!hasPending) return
+		await api.invalidate('transform.list')
+	}, 3000))
+</script>
+
+<div class="page-head">
+	<div>
+		<h4><strong>Transform</strong></h4>
+		<p class="page-sub">
+			{zones.length} {zones.length === 1 ? 'transform zone' : 'transform zones'}
+		</p>
+	</div>
+	<div class="head-actions">
+		<GuardedButton permission="transform.set" class="button is-icon-left" href={`/transform/create?project=${project}`}>
+			<i class="fa-solid fa-plus"></i>
+			Configure transform
+		</GuardedButton>
+	</div>
+</div>
+
+<div class="panel is-level-300">
+	<p class="text-content/55 text-sm mb-4">
+		Transforms declaratively rewrite requests and responses at the proxy edge —
+		set or remove headers, rewrite the path or query, redirect, set a status, or
+		apply CORS, each scoped by an optional CEL condition. v1 runs on edge cache
+		misses; editing a response transform may need a cache purge to apply to
+		already-cached objects.
+	</p>
+	<div class="table-container">
+		<table class="table is-variant-compact">
+			<thead>
+				<tr>
+					<th>Location</th>
+					<th>Status</th>
+					<th>Description</th>
+					<th>Rules</th>
+					<th class="is-collapse is-align-right"></th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each zones as zone (zone.location)}
+					<tr>
+						<td>
+							<a href={`/transform/manage?project=${project}&location=${encodeURIComponent(zone.location)}`} class="link font-mono">{zone.location}</a>
+						</td>
+						<td>
+							{#if zone.status === 'pending'}
+								<span class="inline-flex items-center gap-2 text-content/70">
+									<i class="fa-solid fa-spinner-third fa-spin"></i>
+									{zone.action === 'delete' ? 'Removing' : 'Deploying'}
+								</span>
+							{:else if zone.status === 'error'}
+								<span class="inline-flex items-center gap-2 text-negative/80">
+									<i class="fa-solid fa-times"></i>
+									Error
+								</span>
+							{:else}
+								<span class="inline-flex items-center gap-2 text-positive/80">
+									<i class="fa-solid fa-check-circle"></i>
+									Active
+								</span>
+							{/if}
+						</td>
+						<td>
+							{#if zone.description}
+								{zone.description}
+							{:else}
+								<span class="text-content/40">—</span>
+							{/if}
+						</td>
+						<td>{zone.transforms?.length ?? 0}</td>
+						<td>
+							<div class="flex gap-1 justify-end">
+								<a class="button is-variant-secondary is-size-small"
+									href={`/transform/manage?project=${project}&location=${encodeURIComponent(zone.location)}`}>
+									Manage
+								</a>
+							</div>
+						</td>
+					</tr>
+				{/each}
+				<NoDataRow
+					span={5}
+					list={zones}
+					icon="fa-wand-magic-sparkles"
+					message="No transform zones yet"
+					hint="Configure transform to start rewriting requests and responses in a location."
+					ctaLabel="Configure transform"
+					ctaHref={`/transform/create?project=${project}`}
+					{error} />
+				<ErrorRow span={5} {error} />
+			</tbody>
+		</table>
+	</div>
+</div>
+
+<style>
+	.head-actions {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+	}
+</style>

--- a/src/routes/(auth)/(project)/transform/+page.ts
+++ b/src/routes/(auth)/(project)/transform/+page.ts
@@ -1,0 +1,14 @@
+import api from '$lib/api'
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async ({ parent, fetch }) => {
+	const { project } = await parent()
+
+	const res = await api.invoke<Api.TransformZoneList>('transform.list', { project }, fetch)
+
+	return {
+		project,
+		zones: res.result?.items ?? [],
+		error: res.error
+	}
+}

--- a/src/routes/(auth)/(project)/transform/create/+page.svelte
+++ b/src/routes/(auth)/(project)/transform/create/+page.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+	import type { PageData } from './$types'
+	import { goto } from '$app/navigation'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+
+	const { data }: { data: PageData } = $props()
+
+	const project = $derived(data.project)
+	const locations = $derived(data.locations)
+
+	const form = $state({
+		location: '',
+		description: ''
+	})
+
+	let saving = $state(false)
+
+	async function save (e: SubmitEvent) {
+		e.preventDefault()
+		if (saving) return
+
+		saving = true
+		try {
+			const resp = await api.invoke('transform.set', {
+				project,
+				location: form.location,
+				description: form.description,
+				transforms: []
+			}, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+			goto(`/transform/manage?project=${project}&location=${encodeURIComponent(form.location)}`)
+		} finally {
+			saving = false
+		}
+	}
+
+	function cancel () {
+		goto(`/transform?project=${project}`)
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/transform?project=${project}`} class="link"><h6>Transform</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<h6>Configure</h6>
+	</div>
+</div>
+
+<br>
+
+<div class="page-head">
+	<div>
+		<h4><strong>Configure transform</strong></h4>
+		<p class="page-sub">Enable request/response transforms in a location.</p>
+	</div>
+</div>
+
+<div class="panel is-level-300 grid gap-6">
+	{#if locations.length === 0}
+		<p class="text-content/60">
+			Every location already has transform configured. Manage an existing one
+			from the <a href={`/transform?project=${project}`} class="link">transform list</a>.
+		</p>
+	{:else}
+		<form class="grid gap-4 w-full" onsubmit={save}>
+			<div class="field">
+				<label for="input-location">Location</label>
+				<Select
+					id="input-location"
+					bind:value={form.location}
+					required
+					placeholder="Select Location"
+					options={locations.map((it) => ({ value: it.id, label: it.id }))} />
+			</div>
+			<div class="field">
+				<label for="input-description">Description</label>
+				<div class="input">
+					<input id="input-description" bind:value={form.description} placeholder="Optional description">
+				</div>
+			</div>
+
+			<hr>
+
+			<div class="flex gap-3">
+				<GuardedButton permission="transform.set" type="submit" loading={saving}>Save</GuardedButton>
+				<button type="button" class="button is-variant-secondary" onclick={cancel}>Cancel</button>
+			</div>
+		</form>
+	{/if}
+</div>

--- a/src/routes/(auth)/(project)/transform/create/+page.ts
+++ b/src/routes/(auth)/(project)/transform/create/+page.ts
@@ -1,0 +1,26 @@
+import api from '$lib/api'
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async ({ parent, fetch }) => {
+	const { project, locations } = await parent() as { project: string, locations: Api.Location[] }
+
+	// Only locations whose backend supports transform can host a zone; drop the
+	// rest before the fan-out (also saves a transform.get per unsupported
+	// location).
+	const supported = locations.filter((loc) => loc.features.transform)
+
+	// No "list zones" endpoint per-location — fan out transform.get to discover
+	// which locations are already configured, then offer only the unconfigured
+	// ones for create.
+	const configured = await Promise.all(
+		supported.map(async (loc) => {
+			const res = await api.invoke<Api.TransformZone>('transform.get', { project, location: loc.id }, fetch)
+			return res.ok && res.result ? loc.id : null
+		})
+	)
+	const configuredSet = configured.filter((id) => id != null)
+
+	const available = supported.filter((loc) => !configuredSet.includes(loc.id))
+
+	return { project, locations: available }
+}

--- a/src/routes/(auth)/(project)/transform/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/transform/edit/+page.svelte
@@ -1,0 +1,294 @@
+<script lang="ts">
+	import type { PageData } from './$types'
+	import { untrack } from 'svelte'
+	import { goto } from '$app/navigation'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import WafConditionBuilder from '$lib/components/WafConditionBuilder.svelte'
+	import TransformOpsEditor from '$lib/components/TransformOpsEditor.svelte'
+	import { parseExpression } from '$lib/waf/expression'
+	import {
+		newRule,
+		normalizeRules,
+		toApiRules,
+		coerceOpsToPhase,
+		validateRule,
+		phaseLabels
+	} from '$lib/transform/rules'
+
+	const { data }: { data: PageData } = $props()
+
+	const project = $derived(data.project)
+	const location = $derived(data.location)
+
+	const phaseOptions = [
+		{ value: 'request', label: 'Request — mutate the inbound request before the upstream' },
+		{ value: 'response', label: 'Response — mutate the response headers/status on the way out' }
+	]
+
+	const modeOptions = [
+		{ value: 'enforce', label: 'Enforce — apply the operations to matching requests' },
+		{ value: 'shadow', label: 'Shadow — only count matches, apply nothing' }
+	]
+
+	// The whole loaded zone's rules (ordered) are held in memory so Save can
+	// rewrite the entire zone with the edited rule in place — transform.set
+	// replaces the zone, so the rest must be echoed back untouched.
+	const rules = untrack(() => normalizeRules(data.zone?.transforms))
+	const description = untrack(() => data.zone?.description ?? '')
+	// Index of the rule being edited, or -1 when adding a brand-new one.
+	const editIndex = untrack(() => (data.ruleId ? rules.findIndex((r) => r.id === data.ruleId) : -1))
+	const isCreate = editIndex === -1
+
+	// Working-copy draft — Cancel discards it without touching the server.
+	const draft = $state(untrack(() => {
+		if (isCreate) {
+			return newRule(rules.map((r) => r.id))
+		}
+		// Deep-clone so editing the draft's ops (and their array/row fields) never
+		// aliases the seed held in `rules`.
+		const seed = rules[editIndex]
+		return { ...seed, ops: seed.ops.map((o) => structuredClone(o)) }
+	}))
+
+	let saving = $state(false)
+
+	// Filter editing mode — Visual (condition builder) or Expression (raw CEL
+	// textarea), same pattern as the WAF/cache editors. The filter is optional:
+	// empty means the rule applies to every request.
+	const canUseVisual = $derived(parseExpression(draft.filter) !== null)
+	let filterMode = $state<'visual' | 'raw'>(
+		untrack(() => (parseExpression(draft.filter) !== null ? 'visual' : 'raw'))
+	)
+
+	// If we're in Visual but the filter becomes non-representable, fall back to
+	// raw so the disabled Visual tab can't show stale rows.
+	$effect(() => {
+		if (filterMode === 'visual' && !canUseVisual) filterMode = 'raw'
+	})
+
+	let filterBuilder = $state<{ clearExpression:() => void } | undefined>()
+
+	function clearFilter () {
+		if (filterMode === 'visual' && filterBuilder) filterBuilder.clearExpression()
+		else draft.filter = ''
+	}
+
+	// When the phase changes, fold any op whose type is no longer legal in the
+	// new phase to a legal one (header ops survive; phase-specific ops collapse
+	// to set-header) — keeps the op editor consistent with the chosen phase.
+	function onPhaseChange () {
+		coerceOpsToPhase(draft.ops, draft.phase)
+	}
+
+	const validationError = $derived(validateRule(draft))
+	const canSave = $derived(validationError === null)
+
+	function backToManage () {
+		return goto(`/transform/manage?project=${project}&location=${encodeURIComponent(location)}`)
+	}
+
+	async function save (e: SubmitEvent) {
+		e.preventDefault()
+		if (saving || !canSave) return
+
+		saving = true
+		try {
+			// Rebuild the zone's rule list with the edited rule replaced by id (or
+			// appended for create), then write the whole zone.
+			let nextRules: typeof rules
+			if (isCreate) {
+				nextRules = [...rules, draft]
+			} else {
+				nextRules = rules.map((r) => (r.id === draft.id ? draft : r))
+			}
+
+			const resp = await api.invoke('transform.set', {
+				project,
+				location,
+				description,
+				transforms: toApiRules(nextRules)
+			}, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+			await backToManage()
+		} finally {
+			saving = false
+		}
+	}
+
+	function cancel () {
+		backToManage()
+	}
+
+	// Enter inside a text field must not implicitly submit the rule. Saving is
+	// deliberate, via the Save button (a <button>, where Enter still works) and
+	// the raw-CEL <textarea>.
+	function blockEnterSubmit (node: HTMLFormElement) {
+		function onKeydown (e: KeyboardEvent) {
+			if (e.key === 'Enter' && e.target instanceof HTMLInputElement) e.preventDefault()
+		}
+		node.addEventListener('keydown', onKeydown)
+		return { destroy: () => node.removeEventListener('keydown', onKeydown) }
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/transform?project=${project}`} class="link"><h6>Transform</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<a href={`/transform/manage?project=${project}&location=${encodeURIComponent(location)}`} class="link"><h6 class="font-mono">{location}</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<h6>{isCreate ? 'Add rule' : 'Edit rule'}</h6>
+	</div>
+</div>
+
+<br>
+<div class="panel is-level-300 grid gap-6">
+	<div class="grid grid-cols-1 gap-3">
+		<div class="flex items-center">
+			<h3 class="mr-6 mb-4 xl:mb-0"><strong>{isCreate ? 'Add rule' : 'Edit rule'}</strong></h3>
+		</div>
+		<p class="page-sub">Transform rule in <span class="font-mono">{location}</span></p>
+	</div>
+
+	<hr>
+
+	<form class="grid gap-6 w-full" onsubmit={save} use:blockEnterSubmit>
+		<div class="grid gap-4 sm:grid-cols-2">
+			<div class="field">
+				<label for="rule-description">Description</label>
+				<div class="input">
+					<input id="rule-description" bind:value={draft.description} placeholder="Optional description">
+				</div>
+			</div>
+			<div class="field">
+				<label for="rule-phase">Phase</label>
+				<Select id="rule-phase" bind:value={draft.phase} options={phaseOptions} onchange={onPhaseChange} />
+			</div>
+		</div>
+
+		<hr>
+
+		<div class="grid gap-4">
+			<div class="flex flex-wrap items-start justify-between gap-3">
+				<div>
+					<h6><strong>Apply to matching requests</strong></h6>
+					<p class="text-content/50 text-sm mt-1">
+						Optional — leave empty to apply this rule to every request.
+						The condition is evaluated over <code class="font-mono">request.*</code> at request time.
+					</p>
+				</div>
+				<div class="flex flex-col items-end gap-1">
+					<div class="flex items-center gap-2">
+						<div class="tabs is-variant-underline" role="tablist">
+							<button type="button" class="tab-button" class:is-active={filterMode === 'visual'}
+								role="tab" aria-selected={filterMode === 'visual'}
+								disabled={!canUseVisual}
+								title={canUseVisual ? undefined : 'This expression can’t be shown in the visual editor'}
+								onclick={() => { if (canUseVisual) filterMode = 'visual' }}>
+								<i class="fa-solid fa-sliders mr-2"></i>
+								<span>Visual</span>
+							</button>
+							<button type="button" class="tab-button" class:is-active={filterMode === 'raw'}
+								role="tab" aria-selected={filterMode === 'raw'}
+								onclick={() => (filterMode = 'raw')}>
+								<i class="fa-solid fa-code mr-2"></i>
+								<span>Expression</span>
+							</button>
+						</div>
+						<button type="button" class="button is-variant-tertiary is-size-small"
+							disabled={!draft.filter}
+							onclick={clearFilter}>
+							<i class="fa-solid fa-eraser mr-2"></i>
+							<span>Clear</span>
+						</button>
+					</div>
+					{#if !canUseVisual}
+						<p class="text-content/50 text-xs text-right max-w-xs">
+							This expression can’t be shown in the visual editor — edit it as raw CEL.
+						</p>
+					{/if}
+				</div>
+			</div>
+
+			{#if filterMode === 'visual'}
+				<WafConditionBuilder bind:this={filterBuilder} bind:expression={draft.filter} />
+			{:else}
+				<p class="text-content/60 text-sm">
+					Match on
+					<code class="font-mono">request.method</code>,
+					<code class="font-mono">.path</code>,
+					<code class="font-mono">.host</code>,
+					<code class="font-mono">.query</code>,
+					<code class="font-mono">.uri</code>,
+					<code class="font-mono">.scheme</code>,
+					<code class="font-mono">.headers[…]</code>,
+					<code class="font-mono">.country</code>,
+					<code class="font-mono">.remote_ip</code>.
+					Response rules still evaluate their condition over the request.
+				</p>
+				<div class="field">
+					<label for="rule-filter-raw">Filter (CEL)</label>
+					<div class="textarea">
+						<textarea id="rule-filter-raw" class="font-mono" rows="5" bind:value={draft.filter}
+							placeholder="e.g. request.host == &quot;acme.com&quot;"></textarea>
+					</div>
+				</div>
+			{/if}
+		</div>
+
+		<hr>
+
+		<div class="grid gap-4">
+			<div>
+				<h6><strong>Operations</strong></h6>
+				<p class="text-content/50 text-sm mt-1">
+					Operations run in order for the
+					<strong>{phaseLabels[draft.phase].toLowerCase()}</strong> phase.
+					A <strong>Redirect</strong> or <strong>CORS</strong> operation must be the
+					only operation in its rule.
+				</p>
+			</div>
+
+			<TransformOpsEditor bind:ops={draft.ops} phase={draft.phase} />
+		</div>
+
+		<hr>
+
+		<div class="grid gap-4">
+			<div>
+				<h6><strong>Mode</strong></h6>
+				<p class="text-content/50 text-sm mt-1">
+					Shadow mode counts matches without mutating traffic — stage a rule's
+					condition before enforcing it. Filters compile at the controller; a set
+					that fails to compile is rejected wholesale and the last-good set stays live.
+				</p>
+			</div>
+
+			<div class="grid gap-4 sm:grid-cols-2">
+				<div class="field">
+					<label for="rule-mode">Mode</label>
+					<Select id="rule-mode" bind:value={draft.mode} options={modeOptions} />
+				</div>
+			</div>
+		</div>
+
+		<hr>
+
+		<div class="flex items-center gap-3">
+			<GuardedButton permission="transform.set" type="submit" loading={saving} disabled={saving || !canSave}
+				title={canSave ? undefined : validationError ?? undefined}>Save</GuardedButton>
+			<button type="button" class="button is-variant-secondary" onclick={cancel}>Cancel</button>
+			{#if validationError}
+				<p class="text-content/50 text-sm">{validationError}</p>
+			{/if}
+		</div>
+	</form>
+</div>

--- a/src/routes/(auth)/(project)/transform/edit/+page.ts
+++ b/src/routes/(auth)/(project)/transform/edit/+page.ts
@@ -1,0 +1,39 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async ({ url, parent, fetch }) => {
+	const { project } = await parent()
+	const location = url.searchParams.get('location') ?? ''
+	const ruleId = url.searchParams.get('rule')
+
+	if (!location) {
+		redirect(302, `/transform?project=${project}`)
+	}
+
+	const manageUrl = `/transform/manage?project=${project}&location=${encodeURIComponent(location)}`
+
+	const res = await api.invoke<Api.TransformZone>('transform.get', { project, location }, fetch)
+	// A missing zone is the normal "transform not configured yet" state — render
+	// an empty editor (create mode). Surface anything else.
+	if (!res.ok && !res.error?.notFound) {
+		error(500, res.error?.message)
+	}
+	const zone = res.result ?? null
+
+	// Editing a specific rule requires its zone + rule to exist; otherwise send
+	// the user back to the list for this location.
+	if (ruleId) {
+		const found = zone?.transforms?.some((r) => r.id === ruleId)
+		if (!found) {
+			redirect(302, manageUrl)
+		}
+	}
+
+	return {
+		project,
+		location,
+		ruleId,
+		zone
+	}
+}

--- a/src/routes/(auth)/(project)/transform/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/transform/manage/+page.svelte
@@ -1,0 +1,320 @@
+<script lang="ts">
+	import type { PageData } from './$types'
+	import type { RuleForm } from '$lib/transform/rules'
+	import { untrack } from 'svelte'
+	import { goto } from '$app/navigation'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import DangerZone from '$lib/components/DangerZone.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import {
+		phaseLabels,
+		modeLabels,
+		describeRule,
+		normalizeRules,
+		toApiRules
+	} from '$lib/transform/rules'
+
+	const { data }: { data: PageData } = $props()
+
+	const project = $derived(data.project)
+	const location = $derived(data.location)
+
+	// The list reflects SERVER state for this location. Navigating away and back
+	// (e.g. from the edit page) reloads the loader, which re-seeds this copy.
+	let description = $state(untrack(() => data.zone?.description ?? ''))
+	let rules = $state(untrack(() => normalizeRules(data.zone?.transforms)))
+
+	let loadedLocation = untrack(() => data.location ?? '')
+
+	// Re-seed local state whenever the loader returns a different location/zone
+	// (after navigation). Track only `data` so optimistic in-place edits aren't
+	// clobbered.
+	$effect(() => {
+		const next = data
+		untrack(() => {
+			if (next.location !== loadedLocation) {
+				loadedLocation = next.location ?? ''
+				description = next.zone?.description ?? ''
+				rules = normalizeRules(next.zone?.transforms)
+			}
+		})
+	})
+
+	let savingDescription = $state(false)
+
+	async function reloadZone () {
+		const resp = await api.invoke<Api.TransformZone>('transform.get', { project, location }, fetch)
+		if (!resp.ok) {
+			if (resp.error?.notFound) {
+				// The zone disappeared underneath us — back to the index.
+				goto(`/transform?project=${project}`)
+				return
+			}
+			modal.error({ error: resp.error })
+			return
+		}
+		const zone = resp.result ?? null
+		description = zone?.description ?? ''
+		rules = normalizeRules(zone?.transforms)
+	}
+
+	// Persist the whole zone (priority follows row order). transform.set replaces
+	// the entire zone, so every rule must always travel together. On error,
+	// surface it and reload from the server so the UI matches reality.
+	async function persistZone (nextRules: RuleForm[]) {
+		const resp = await api.invoke('transform.set', {
+			project,
+			location,
+			description,
+			transforms: toApiRules(nextRules)
+		}, fetch)
+		if (!resp.ok) {
+			modal.error({ error: resp.error })
+			await reloadZone()
+			return false
+		}
+		return true
+	}
+
+	async function moveRule (i: number, dir: -1 | 1) {
+		const j = i + dir
+		if (j < 0 || j >= rules.length) return
+		const next = [...rules]
+		;[next[i], next[j]] = [next[j], next[i]]
+		rules = next
+		await persistZone(next)
+	}
+
+	function removeRule (i: number) {
+		const rule = rules[i]
+		if (!rule) return
+		modal.confirm({
+			title: `Delete rule ${rule.id}?`,
+			yes: 'Delete',
+			callback: async () => {
+				const next = rules.filter((_, k) => k !== i)
+				rules = next
+				await persistZone(next)
+			}
+		})
+	}
+
+	function editRule (rule: RuleForm) {
+		goto(`/transform/edit?project=${project}&location=${encodeURIComponent(location)}&rule=${encodeURIComponent(rule.id)}`)
+	}
+
+	function addRule () {
+		goto(`/transform/edit?project=${project}&location=${encodeURIComponent(location)}`)
+	}
+
+	async function saveDescription () {
+		if (savingDescription) return
+		savingDescription = true
+		try {
+			await persistZone(rules)
+		} finally {
+			savingDescription = false
+		}
+	}
+
+	function deleteZone () {
+		modal.confirm({
+			title: `Disable transform in ${location}? All rules will be removed.`,
+			yes: 'Disable',
+			callback: async () => {
+				const resp = await api.invoke('transform.delete', { project, location }, fetch)
+				if (!resp.ok) {
+					modal.error({ error: resp.error })
+					return
+				}
+				goto(`/transform?project=${project}`)
+			}
+		})
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/transform?project=${project}`} class="link"><h6>Transform</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<h6 class="font-mono">{location}</h6>
+	</div>
+	<div class="breadcrumb-item">
+		<h6>Manage</h6>
+	</div>
+</div>
+
+<br>
+
+<div class="page-head">
+	<div>
+		<h4><strong>Transform rules</strong></h4>
+		<p class="page-sub">
+			Rules that rewrite requests and responses in <span class="font-mono">{location}</span>
+		</p>
+	</div>
+</div>
+
+<div class="panel is-level-300 grid gap-6">
+	<div class="grid gap-4 w-full">
+		<div class="field">
+			<label for="input-location">Location</label>
+			<div class="input">
+				<input id="input-location" class="font-mono" value={location} readonly>
+			</div>
+		</div>
+
+		<div class="field">
+			<label for="input-description">Description</label>
+			<div class="input">
+				<input id="input-description" bind:value={description} placeholder="Optional description">
+			</div>
+			<div class="flex justify-self-start mt-2">
+				<GuardedButton permission="transform.set" class="button is-variant-secondary is-size-small"
+					loading={savingDescription} onclick={saveDescription}>
+					Save
+				</GuardedButton>
+			</div>
+		</div>
+
+		<br>
+		<hr>
+		<br>
+
+		<div class="flex items-center justify-between">
+			<div>
+				<h6><strong>Rules</strong></h6>
+				<p class="text-content/50 text-sm mt-1">
+					Within a phase, rules run top to bottom (lower priority first); across
+					phases there is no global order — request rules run at request time,
+					response rules at response time. Use <strong>Edit</strong> to change a
+					rule's phase, condition, and operations.
+				</p>
+			</div>
+		</div>
+
+		<div class="table-container">
+			<table class="table is-variant-compact">
+				<thead>
+					<tr>
+						<th>ID</th>
+						<th>Phase</th>
+						<th>Description</th>
+						<th>Operations</th>
+						<th>Mode</th>
+						<th class="is-collapse is-align-right">Actions</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each rules as rule, i (rule.id)}
+						<tr>
+							<td>
+								<span class="font-mono text-sm text-content/60">{rule.id}</span>
+							</td>
+							<td>
+								<span class="phase-badge" data-phase={rule.phase}>
+									{phaseLabels[rule.phase] ?? rule.phase}
+								</span>
+							</td>
+							<td>
+								{#if rule.description}
+									{rule.description}
+								{:else}
+									<span class="text-content/40">—</span>
+								{/if}
+								{#if rule.filter}
+									<div class="font-mono text-xs text-content/50 mt-1 truncate max-w-56" title={rule.filter}>
+										<i class="fa-solid fa-filter mr-1"></i>{rule.filter}
+									</div>
+								{/if}
+							</td>
+							<td>
+								<span class="text-sm text-content/70">{describeRule(rule)}</span>
+							</td>
+							<td>
+								<span class="mode-badge" data-mode={rule.mode}>
+									{modeLabels[rule.mode] ?? rule.mode}
+								</span>
+							</td>
+							<td>
+								<div class="flex gap-1 justify-end">
+									<GuardedButton permission="transform.set" class="icon-button" aria-label="Edit rule"
+										onclick={() => editRule(rule)}>
+										<i class="fa-solid fa-pencil"></i>
+									</GuardedButton>
+									<GuardedButton permission="transform.set" class="icon-button" aria-label="Move rule up"
+										disabled={i === 0} onclick={() => moveRule(i, -1)}>
+										<i class="fa-solid fa-chevron-up"></i>
+									</GuardedButton>
+									<GuardedButton permission="transform.set" class="icon-button" aria-label="Move rule down"
+										disabled={i === rules.length - 1} onclick={() => moveRule(i, 1)}>
+										<i class="fa-solid fa-chevron-down"></i>
+									</GuardedButton>
+									<GuardedButton permission="transform.set" class="icon-button" aria-label="Remove rule"
+										onclick={() => removeRule(i)}>
+										<i class="fa-solid fa-trash-alt"></i>
+									</GuardedButton>
+								</div>
+							</td>
+						</tr>
+					{/each}
+					{#if rules.length === 0}
+						<tr>
+							<td colspan="6" class="text-center text-content/50">
+								No rules yet. Add a rule to start transforming requests and responses.
+							</td>
+						</tr>
+					{/if}
+				</tbody>
+				<tfoot>
+					<tr>
+						<td colspan="6">
+							<GuardedButton permission="transform.set" class="button is-variant-secondary flex m-auto"
+								onclick={addRule}>
+								<i class="fa-solid fa-plus mr-3"></i>
+								<span>Add rule</span>
+							</GuardedButton>
+						</td>
+					</tr>
+				</tfoot>
+			</table>
+		</div>
+
+		<DangerZone description="Disable transform in this location and permanently remove all of its rules.">
+			<GuardedButton permission="transform.delete" class="button is-variant-negative" onclick={deleteZone}>Disable transform</GuardedButton>
+		</DangerZone>
+	</div>
+</div>
+
+<style>
+	.phase-badge,
+	.mode-badge {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.125rem 0.625rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		line-height: 1.5;
+		color: hsl(var(--hsl-content) / 0.75);
+		background-color: hsl(var(--hsl-content) / 0.08);
+	}
+
+	.phase-badge[data-phase='request'] {
+		color: hsl(var(--hsl-primary));
+		background-color: hsl(var(--hsl-primary) / 0.12);
+	}
+
+	.phase-badge[data-phase='response'] {
+		color: hsl(var(--hsl-accent));
+		background-color: hsl(var(--hsl-accent) / 0.12);
+	}
+
+	/* Shadow only observes — render it muted so Enforce stands out. */
+	.mode-badge[data-mode='shadow'] {
+		color: hsl(var(--hsl-content) / 0.5);
+		background-color: hsl(var(--hsl-content) / 0.05);
+	}
+</style>

--- a/src/routes/(auth)/(project)/transform/manage/+page.ts
+++ b/src/routes/(auth)/(project)/transform/manage/+page.ts
@@ -1,0 +1,27 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async ({ url, parent, fetch }) => {
+	const { project } = await parent()
+	const location = url.searchParams.get('location') ?? ''
+
+	if (!location) {
+		redirect(302, `/transform?project=${project}`)
+	}
+
+	const res = await api.invoke<Api.TransformZone>('transform.get', { project, location }, fetch)
+	// You only reach manage for a configured location — a missing zone means
+	// transform isn't configured here, so send the user back to the index.
+	if (!res.ok) {
+		if (res.error?.notFound) redirect(302, `/transform?project=${project}`)
+		error(500, res.error?.message)
+	}
+	if (!res.result) redirect(302, `/transform?project=${project}`)
+
+	return {
+		project,
+		location,
+		zone: res.result
+	}
+}

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -147,6 +147,7 @@ declare namespace Api {
             disk?: Record<string, never>
             waf?: Record<string, never>
             cache?: Record<string, never>
+            transform?: Record<string, never>
         }
         createdAt: string
     }
@@ -840,6 +841,86 @@ declare namespace Api {
     export type CacheZoneList = {
         project: string
         items: CacheZone[]
+    }
+
+    // Transform — declarative request/response transforms in the parapet proxy
+    // layer (per-(project, location) zone, whole-zone replace). snake_case wire
+    // tags on the rule/op ARE the parapet wire contract; the camelCase JSON
+    // tags below are what the api accepts/returns.
+
+    // The two physical mutation seams. Header ops are phase-polymorphic; the
+    // phase is REQUIRED on every rule (an absent phase is a hard validation
+    // error — there is no silent default).
+    export type TransformPhase = 'request' | 'response'
+
+    // Frozen op vocabulary. Legal types depend on the rule's phase:
+    //   request:  set-header, remove-header, rewrite-path, rewrite-query, redirect
+    //   response: set-header, remove-header, set-status, cors
+    export type TransformOpType =
+        | 'set-header'
+        | 'remove-header'
+        | 'rewrite-path'
+        | 'rewrite-query'
+        | 'redirect'
+        | 'set-status'
+        | 'cors'
+
+    // Flat, omitempty-driven: each op reads only its own subset of fields.
+    export type TransformOp = {
+        type: TransformOpType
+        // header ops (set-header / remove-header)
+        name?: string
+        value?: string
+        // redirect — target; '$uri' expands to the original RequestURI
+        to?: string
+        // rewrite-path — literal `path` XOR (`regex` + `replace`)
+        path?: string
+        regex?: string
+        replace?: string
+        // rewrite-query — set/overwrite `query`, delete `removeQuery`
+        query?: Record<string, string>
+        removeQuery?: string[]
+        // redirect 3xx | set-status 100..599
+        status?: number
+        // cors (dual-seam op, authored response-phase)
+        allowOrigins?: string[]
+        allowMethods?: string[]
+        allowHeaders?: string[]
+        exposeHeaders?: string[]
+        allowCredentials?: boolean
+        maxAge?: string // Go duration
+    }
+
+    export type TransformRule = {
+        id: string
+        description: string
+        // request | response — REQUIRED, the primary axis.
+        phase: TransformPhase
+        // Optional CEL over request.* (same surface as WafRule.expression);
+        // empty applies the rule to every request.
+        filter?: string
+        // Applied in array order; every op must be legal for `phase`.
+        ops: TransformOp[]
+        // '' = enforce | 'shadow' (match + count, apply nothing).
+        mode?: '' | 'shadow'
+        // ascending within a phase; ties broken by id.
+        priority: number
+    }
+
+    export type TransformZone = {
+        project: string
+        location: string
+        description: string
+        transforms: TransformRule[]
+        status: 'pending' | 'success' | 'error'
+        action: 'create' | 'delete'
+        createdAt: string
+        createdBy: string
+    }
+
+    export type TransformZoneList = {
+        project: string
+        items: TransformZone[]
     }
 
     // Scheduler — cron-driven outbound HTTP requests (project-scoped,


### PR DESCRIPTION
## Edge Transform — console UI

Management UI cloning the cache pages: list / manage / edit + a **net-new phase-gated ops editor** (set/remove-header, rewrite-path/query, redirect, set-status, cors). Reuses the CEL builder for `filter`; gates mutations with `can()`/`GuardedButton` on `transform.set`/`transform.delete`. `src/types/api.d.ts` synced to the api#119 contract (`mode` is `''|shadow`; the UI's "Enforce" choice maps to `''`).

`svelte-check` 0 errors / 0 warnings, `eslint` clean, `vite build` succeeds.

## Screenshots

### List
![list](https://raw.githubusercontent.com/deploys-app/console/screenshots/310-list.png)

### Manage
![manage](https://raw.githubusercontent.com/deploys-app/console/screenshots/310-manage.png)

### Create / Configure
![create](https://raw.githubusercontent.com/deploys-app/console/screenshots/310-create.png)

### Edit — response headers (set-header / remove-header)
![edit-headers](https://raw.githubusercontent.com/deploys-app/console/screenshots/310-edit-headers.png)

### Edit — request redirect
![edit-redirect](https://raw.githubusercontent.com/deploys-app/console/screenshots/310-edit-redirect.png)

### Edit — response CORS (shadow)
![edit-cors](https://raw.githubusercontent.com/deploys-app/console/screenshots/310-edit-cors.png)
