### PR TITLE
fix: guard required ?id= param in detail/billing load functions

### DIFF
--- a/src/routes/(auth)/(project)/service-account/detail/+page.ts
+++ b/src/routes/(auth)/(project)/service-account/detail/+page.ts
@@ -5,6 +5,7 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = async ({ url, parent, fetch }) => {
 	const { project } = await parent()
 	const id = url.searchParams.get('id')
+	if (!id) redirect(302, `/service-account?project=${project}`)
 	const serviceAccount = await api.invoke<Api.ServiceAccount>('serviceAccount.get', { project, id }, fetch)
 	if (!serviceAccount.ok) {
 		if (serviceAccount.error?.message === 'api: service account not found') {

--- a/src/routes/(auth)/billing/detail/+page.ts
+++ b/src/routes/(auth)/billing/detail/+page.ts
@@ -4,6 +4,7 @@ import type { PageLoad } from './$types'
 
 export const load: PageLoad = async ({ url, fetch }) => {
 	const id = url.searchParams.get('id')
+	if (!id) redirect(302, '/billing')
 
 	const billingAccount = await api.invoke<Api.BillingAccount>('billing.get', { id }, fetch)
 	if (!billingAccount.ok) {

--- a/src/routes/(auth)/billing/invoice/+page.ts
+++ b/src/routes/(auth)/billing/invoice/+page.ts
@@ -4,6 +4,7 @@ import type { PageLoad } from './$types'
 
 export const load: PageLoad = async ({ url, fetch }) => {
 	const id = url.searchParams.get('id')
+	if (!id) redirect(302, '/billing')
 
 	const invoice = await api.invoke<Api.Invoice>('billing.getInvoice', { invoiceId: id }, fetch)
 	if (!invoice.ok) {

--- a/src/routes/(auth)/billing/invoices/+page.ts
+++ b/src/routes/(auth)/billing/invoices/+page.ts
@@ -4,6 +4,7 @@ import type { PageLoad } from './$types'
 
 export const load: PageLoad = async ({ url, fetch }) => {
 	const id = url.searchParams.get('id')
+	if (!id) redirect(302, '/billing')
 
 	const billingAccount = await api.invoke<Api.BillingAccount>('billing.get', { id }, fetch)
 	if (!billingAccount.ok) {

--- a/src/routes/(auth)/billing/report/+page.ts
+++ b/src/routes/(auth)/billing/report/+page.ts
@@ -4,6 +4,7 @@ import type { PageLoad } from './$types'
 
 export const load: PageLoad = async ({ url, fetch }) => {
 	const id = url.searchParams.get('id')
+	if (!id) redirect(302, '/billing')
 
 	const billingAccount = await api.invoke<Api.BillingAccount>('billing.get', { id }, fetch)
 	if (!billingAccount.ok) {


### PR DESCRIPTION
## What

Five `load` functions read a **required** `id` from the URL and pass it straight into `api.invoke` with no guard:

- `billing/detail`, `billing/report`, `billing/invoice`, `billing/invoices` → `billing.get` / `billing.getInvoice`
- `(project)/service-account/detail` → `serviceAccount.get`

When `?id=` is absent, `url.searchParams.get('id')` is `null`, the API receives `{ id: null }` and returns a **validation** error (not `notFound`). The pages only special-case `notFound` (`if (error?.notFound) redirect(...)`), so a missing param falls through to `error(500, ...)` — i.e. **a 500 page when you navigate without `?id=`**.

Added the same upfront guard every other detail page already uses (`role/detail`, `pull-secret/detail`, `cache/*`, …):

```ts
const id = url.searchParams.get('id')
if (!id) redirect(302, '/billing')   // service-account → `/service-account?project=${project}`
```

## Why

A missing/blank required param should redirect to the list, not 500. This also avoids a needless failing API round-trip and brings these pages in line with the established convention.

## Scope notes

- `redirect` was already imported in all 5 files; no other changes.
- **Excluded** `deployment/(detail)/errors/+page.ts`, where `?id=` is an *optional* deep-link (`?? undefined`) — correct as-is.
- No behavior change when `id` is present. Redirect targets are existing list pages that don't require `?id=`, so there's no redirect loop.

## Verification

- `bun lint` — clean.
- `bun check` — clean for the changed files. (One unrelated pre-existing error remains: `Cannot find module 'qrcode-generator'` in `PromptPayQR.svelte`, a file not touched here — the dep is declared in `package.json` and resolves on a fresh install; it was only missing from my local node_modules.)
- No user-visible UI added/changed (load-time redirect only), so no screenshots apply.