### PR TITLE
fix(a11y): role/bind remove control — accessible name + correct key activation

### DIFF
--- a/src/routes/(auth)/(project)/role/bind/+page.svelte
+++ b/src/routes/(auth)/(project)/role/bind/+page.svelte
@@ -144,8 +144,9 @@
 					<tr>
 						<td>{it}</td>
 						<td>
-							<div class="icon-button" role="button" tabindex="0"
-								onclick={() => removeRole(it)} onkeypress={() => removeRole(it)}>
+							<div class="icon-button" role="button" tabindex="0" aria-label={`Remove ${it}`}
+								onclick={() => removeRole(it)}
+								onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); removeRole(it) } }}>
 								<i class="fa-solid fa-trash-alt"></i>
 							</div>
 						</td>


### PR DESCRIPTION
## What

The per-row **remove role** control on `role/bind` is a `<div role="button">` with a bare trash icon:

```svelte
<div class="icon-button" role="button" tabindex="0"
  onclick={() => removeRole(it)} onkeypress={() => removeRole(it)}>
  <i class="fa-solid fa-trash-alt"></i>
</div>
```

Two accessibility problems:

1. **No accessible name** — screen readers announce just "button" (the icon is decorative).
2. **`onkeypress` fires on *any* key** — the handler ignores the event, so once the control is keyboard-focused, pressing almost any key (`keypress` fires for Enter, Space, and every character key) **deletes the role binding**. `onkeypress` is also deprecated.

Fix:

```svelte
<div class="icon-button" role="button" tabindex="0" aria-label={`Remove ${it}`}
  onclick={() => removeRole(it)}
  onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); removeRole(it) } }}>
```

- `aria-label` gives the control a real name (`Remove <role>`).
- `onkeydown` activates only on **Enter/Space** (standard WCAG button keys), with `preventDefault` so Space doesn't scroll the page.

Mouse click is unchanged.

## Scope

Kept it a `div role="button"` (a valid, compliant pattern) rather than swapping to `<button>`, so there's **no visual change** — hence no screenshots (nothing user-visible changed; only the accessible name and which keys activate it).

## Verification

- `bun lint` — clean.
- `bun check` — **0 a11y warnings** on this file. (One pre-existing unrelated error remains: `Cannot find module 'qrcode-generator'` in `PromptPayQR.svelte`, untouched — declared in `package.json`, only missing from my local node_modules.)