### PR TITLE
feat: add in-console Usage Policy summary

### DIFF
--- a/src/routes/(auth)/Sidebar.svelte
+++ b/src/routes/(auth)/Sidebar.svelte
@@ -143,6 +143,16 @@
 		color: hsl(var(--hsl-content));
 		background-color: hsl(var(--hsl-content) / 0.06);
 	}
+
+	.sidebar-legal > a {
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-content) / 0.5);
+		transition: color var(--timing-faster) ease;
+	}
+
+	.sidebar-legal > a:hover {
+		color: hsl(var(--hsl-content));
+	}
 </style>
 
 <nav class="sidebar pt-4 absolute z-[1]">
@@ -210,7 +220,10 @@
 		<div class="px-3 mb-3">
 			<hr>
 		</div>
-		<div class="flex justify-between items-center flex-col">
+		<div class="flex justify-between items-center flex-col gap-2">
+			<div class="sidebar-legal flex justify-center items-center w-full px-4">
+				<a href="/usage-policy">Usage policy</a>
+			</div>
 			<div class="social flex justify-end items-center gap-2 w-full px-4">
 				<a href="https://docs.deploys.app" target="_blank" rel="external" class="flex justify-center items-center rounded w-8 h-8" aria-label="Read the docs">
 					<i class="fa-solid fa-book-open"></i>

--- a/src/routes/(auth)/usage-policy/+page.svelte
+++ b/src/routes/(auth)/usage-policy/+page.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	const fullPolicyUrl = 'https://www.deploys.app/usage-policy/'
+
+	const points: { title: string, body: string }[] = [
+		{
+			title: 'Build and run your own things',
+			body: 'Use any feature for any lawful purpose. The line we draw is intent and harm: workloads built to attack, defraud, deceive, or freeload off others are not allowed.'
+		},
+		{
+			title: 'No platform abuse aimed at others',
+			body: 'No crypto mining, DoS/DDoS, unauthorized scanning, malware/ransomware/botnet C2, phishing and fraud, spam, telephony/VoIP fraud, stalkerware, or abusive proxies/relays. Public Tor exit nodes aren’t allowed (IP reputation); a private VPN or good-faith Tor bridge for your own apps is fine.'
+		},
+		{
+			title: 'No illegal content — CSAM is zero-tolerance',
+			body: 'Detected CSAM means immediate termination and reporting to the authorities, no notice required. Also off-limits: piracy/counterfeiting, illegal marketplaces, unlawful hate/extremist content, and content unlawful under Thai law (Computer Crime Act, court/regulator orders).'
+		},
+		{
+			title: 'Security research is welcome under our safe harbour',
+			body: 'Test only your own resources or with written authorization, don’t touch other tenants’ data, don’t disrupt the service, and report privately to contact@moonrhythm.io.'
+		},
+		{
+			title: 'Feature rules',
+			body: 'The registry is for images you actually run (not warez/malware distribution); custom domains/CDN only for domains you control and not for laundering or hotlinking; disks and static storage aren’t bulk file lockers; invite-only email is consent-only with no open relays; keep API keys and tokens secret and within rate quotas.'
+		},
+		{
+			title: 'Fair use & billing integrity',
+			body: 'Measured against your documented quotas, rate limits, and fair-use thresholds — don’t exhaust shared capacity, shard around limits, abuse free trials, or commit billing/chargeback fraud. We won’t reclaim your domains, images, or disks while your account is in good standing and paid.'
+		},
+		{
+			title: 'You’re responsible for your apps and end users',
+			body: 'Your code, your patching, your content, and your users’ conduct. Keep your own backups; the platform isn’t a guaranteed backup service.'
+		},
+		{
+			title: 'Data protection',
+			body: 'For your end users’ data you are the controller and we are your processor (we’re the controller only for your own account data). Meet your own PDPA/GDPR duties, including breach notice to the PDPC. Our infrastructure runs outside Thailand — account for that transfer. Request a DPA at contact@moonrhythm.io.'
+		},
+		{
+			title: 'Enforcement scales with severity',
+			body: 'Severe or active abuse is actioned immediately without notice; contestable issues generally get notice and a chance to fix. Evading enforcement (new accounts to dodge a suspension) is itself a violation.'
+		}
+	]
+</script>
+
+<div class="page-head">
+	<div>
+		<h4><strong>Usage Policy</strong></h4>
+		<p class="page-sub">The short version — what you can and can’t run on Deploys.app.</p>
+	</div>
+	<a class="button is-icon-right" href={fullPolicyUrl} target="_blank" rel="noopener">
+		Read the full policy
+		<i class="fa-solid fa-arrow-up-right-from-square"></i>
+	</a>
+</div>
+
+<div class="grid gap-4 max-w-3xl">
+	<div class="panel is-level-200">
+		<ul class="grid gap-5">
+			{#each points as p (p.title)}
+				<li class="grid grid-cols-[auto_1fr] gap-3 items-start">
+					<i class="fa-solid fa-circle-check text-primary mt-[0.2rem]" aria-hidden="true"></i>
+					<div>
+						<strong class="text-content">{p.title}</strong>
+						<p class="text-content/70 mt-1 leading-relaxed">{p.body}</p>
+					</div>
+				</li>
+			{/each}
+		</ul>
+	</div>
+
+	<div class="panel is-level-200 text-content/70 text-sm leading-relaxed">
+		<p>
+			This is a summary. The full <a class="link" href={fullPolicyUrl} target="_blank" rel="noopener">Usage Policy</a>
+			is the authoritative document — it supplements, and does not replace, our Privacy Policy and Terms of Service.
+		</p>
+		<p class="mt-2">
+			See something abusive on the platform, or want to report a vulnerability? Email
+			<a class="link" href="mailto:contact@moonrhythm.io">contact@moonrhythm.io</a>.
+		</p>
+	</div>
+</div>


### PR DESCRIPTION
## What

Surfaces the new **Usage Policy** inside the console as a concise, plain-language summary that links out to the authoritative full policy on the website.

- New route `/usage-policy` (under `(auth)`, no project required) — a `page-head` + summary `panel` of 9 bullet points with a prominent **Read the full policy** link to `https://www.deploys.app/usage-policy/`.
- New subtle **Usage policy** link in the sidebar bottom (above the docs/GitHub/Discord/email row), reachable from anywhere.

## Why

The full Usage Policy (Acceptable Use Policy) lives on the marketing site (deploys-app/website#23). Logged-in users shouldn't have to leave the console to learn the ground rules, so this gives them the short version in-context with a one-click path to the full text. The summary is the same short version reviewed alongside the website page.

## Notes

- Pure static content — no API calls, so no mock fixture needed.
- Uses existing design-system primitives only (`page-head`, `panel is-level-200`, `button`, `link`, design tokens) — no new components.
- `bun lint` ✅ and `bun check` ✅ (0 errors, 0 warnings).

## Screenshots

| Light | Dark |
| --- | --- |
| ![light](https://raw.githubusercontent.com/deploys-app/console/screenshots/313-light.png) | ![dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/313-dark.png) |

_(sidebar "Usage policy" link is visible bottom-left in both)_
