### PR TITLE
billing: dedicated portal + accountant-focused redesign + members UI

### DIFF
--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -1,0 +1,30 @@
+/**
+ * Billing-account role helpers.
+ *
+ * Billing is authorized by account ownership/membership, NOT project IAM, so
+ * these gates read the caller's effective `role` off the loaded account
+ * (billing.get / billing.list return it) rather than `me.permissions`.
+ */
+
+export const billingRoleLabel: Record<string, string> = {
+	owner: 'Owner',
+	admin: 'Admin',
+	accountant: 'Accountant'
+}
+
+/** Short, human description of what a role can do (shown in the members UI). */
+export const billingRoleDescription: Record<string, string> = {
+	owner: 'Full control, including deleting the account and managing members.',
+	admin: 'Co-manage: view & pay invoices, edit tax details, and manage members.',
+	accountant: 'View invoices & receipts, view usage, and pay. No account changes.'
+}
+
+/** Owner or admin: may edit tax details and manage members. */
+export function canManageBilling (role?: string): boolean {
+	return role === 'owner' || role === 'admin'
+}
+
+/** Owner only: may delete the account. */
+export function canDeleteBilling (role?: string): boolean {
+	return role === 'owner'
+}

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -183,8 +183,17 @@ const billingAccounts = [
 		taxId: '0123456789012',
 		taxName: 'Acme Co., Ltd.',
 		taxAddress: '1 Mockingbird Lane, Bangkok 10110',
-		active: true
+		active: true,
+		role: 'owner'
 	}
+]
+
+// Mutable member list so the Members page add/remove flows are exercisable in
+// mock mode (bun dev:mock + Playwright).
+const billingOwnerEmail = 'owner@example.com'
+let billingMembers = [
+	{ email: 'accountant@example.com', role: 'accountant', createdAt: '2026-06-01T09:00:00Z', createdBy: billingOwnerEmail },
+	{ email: 'cfo@example.com', role: 'admin', createdAt: '2026-05-12T10:30:00Z', createdBy: billingOwnerEmail }
 ]
 
 function deployment (project = 'acme') {
@@ -1435,6 +1444,23 @@ const handlers: Record<string, (args: any) => object> = {
 	},
 	// Multipart upload: the proxy can't JSON-parse the body in mock mode, so
 	// args is empty here — just acknowledge the upload.
+	'billing.listMembers': () => ok({ owner: billingOwnerEmail, items: billingMembers }),
+	'billing.addMember': (args) => {
+		const email = String(args?.email ?? '').toLowerCase()
+		const role = String(args?.role ?? 'accountant')
+		const existing = billingMembers.find((m) => m.email === email)
+		if (existing) {
+			existing.role = role
+		} else {
+			billingMembers = [...billingMembers, { email, role, createdAt: '2026-06-30T12:00:00Z', createdBy: billingOwnerEmail }]
+		}
+		return ok({})
+	},
+	'billing.removeMember': (args) => {
+		const email = String(args?.email ?? '').toLowerCase()
+		billingMembers = billingMembers.filter((m) => m.email !== email)
+		return ok({})
+	},
 	'billing.uploadTransferSlip': () => ok({
 		downloadUrl: 'https://dropbox.deploys.app/files/mock-slip.jpg',
 		expiresAt: '2026-06-02T00:00:00Z'

--- a/src/routes/(auth)/billing/+layout.svelte
+++ b/src/routes/(auth)/billing/+layout.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+	import { page } from '$app/stores'
+	import { billingRoleLabel, canManageBilling } from '$lib/billing'
+
+	const { children } = $props()
+
+	// The active account (when one is in context). Every account sub-page returns
+	// `billingAccount` from its loader — including its `role` — so the portal
+	// chrome reads it straight off page data instead of re-fetching.
+	const account = $derived($page.data.billingAccount as Api.BillingAccount | undefined)
+	const pathname = $derived($page.url.pathname)
+
+	type Tab = { label: string, icon: string, path: string, match: string[], show: boolean }
+
+	const tabs = $derived.by<Tab[]>(() => {
+		if (!account) return []
+		const id = account.id
+		return [
+			{ label: 'Overview', icon: 'fa-gauge-high', path: `/billing/detail?id=${id}`, match: ['/billing/detail'], show: true },
+			{ label: 'Invoices', icon: 'fa-file-invoice-dollar', path: `/billing/invoices?id=${id}`, match: ['/billing/invoices', '/billing/invoice'], show: true },
+			{ label: 'Receipts', icon: 'fa-receipt', path: `/billing/receipts?id=${id}`, match: ['/billing/receipts'], show: true },
+			{ label: 'Usage', icon: 'fa-chart-line', path: `/billing/report?id=${id}`, match: ['/billing/report'], show: true },
+			{ label: 'Members', icon: 'fa-user-group', path: `/billing/members?id=${id}`, match: ['/billing/members'], show: canManageBilling(account.role) }
+		].filter((t) => t.show)
+	})
+
+	function isActive (tab: Tab): boolean {
+		return tab.match.includes(pathname)
+	}
+</script>
+
+<div class="portal">
+	<header class="portal-head">
+		<a class="portal-brand" href="/billing">
+			<span class="portal-mark"><i class="fa-solid fa-file-invoice-dollar"></i></span>
+			<span class="portal-title">Billing</span>
+		</a>
+
+		{#if account}
+			<div class="portal-account">
+				<div class="portal-account-name" title={account.name}>{account.name}</div>
+				<span class="role-pill is-{account.role}">{billingRoleLabel[account.role] ?? account.role}</span>
+			</div>
+		{/if}
+	</header>
+
+	{#if tabs.length > 0}
+		<nav class="portal-tabs" aria-label="Billing account sections">
+			{#each tabs as tab (tab.label)}
+				<a class="portal-tab" class:is-active={isActive(tab)} href={tab.path}>
+					<i class="fa-solid {tab.icon}"></i>
+					<span>{tab.label}</span>
+				</a>
+			{/each}
+		</nav>
+	{/if}
+
+	<div class="portal-body">
+		{@render children()}
+	</div>
+</div>
+
+<style>
+	.portal {
+		display: grid;
+		gap: 0;
+	}
+
+	.portal-head {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		padding-bottom: 1rem;
+	}
+
+	.portal-brand {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.7rem;
+		color: inherit;
+		text-decoration: none;
+	}
+
+	.portal-mark {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 2.25rem;
+		height: 2.25rem;
+		border-radius: 0.65rem;
+		color: hsl(var(--hsl-primary));
+		background: hsl(var(--hsl-primary) / 0.12);
+		font-size: 1.05rem;
+	}
+
+	.portal-title {
+		font-size: 1.35rem;
+		font-weight: 700;
+		letter-spacing: -0.01em;
+	}
+
+	.portal-account {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.6rem;
+		min-width: 0;
+	}
+
+	.portal-account-name {
+		font-weight: 600;
+		max-width: 16rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.role-pill {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.15rem 0.6rem;
+		border-radius: 999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		letter-spacing: 0.02em;
+		text-transform: uppercase;
+		color: hsl(var(--hsl-content) / 0.7);
+		background: hsl(var(--hsl-content) / 0.08);
+	}
+
+	.role-pill.is-owner {
+		color: hsl(var(--hsl-primary));
+		background: hsl(var(--hsl-primary) / 0.12);
+	}
+
+	.role-pill.is-admin {
+		color: hsl(var(--hsl-info, var(--hsl-primary)));
+		background: hsl(var(--hsl-info, var(--hsl-primary)) / 0.12);
+	}
+
+	.role-pill.is-accountant {
+		color: hsl(var(--hsl-positive));
+		background: hsl(var(--hsl-positive) / 0.12);
+	}
+
+	.portal-tabs {
+		display: flex;
+		gap: 0.15rem;
+		overflow-x: auto;
+		border-bottom: 1px solid hsl(var(--hsl-line));
+		margin-bottom: 1.5rem;
+		scrollbar-width: none;
+	}
+
+	.portal-tabs::-webkit-scrollbar {
+		display: none;
+	}
+
+	.portal-tab {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.7rem 1rem;
+		color: hsl(var(--hsl-content) / 0.6);
+		text-decoration: none;
+		font-weight: 500;
+		white-space: nowrap;
+		border-bottom: 2px solid transparent;
+		margin-bottom: -1px;
+		transition: color 0.15s ease, border-color 0.15s ease;
+	}
+
+	.portal-tab i {
+		font-size: 0.9em;
+	}
+
+	.portal-tab:hover {
+		color: hsl(var(--hsl-content) / 0.9);
+	}
+
+	.portal-tab.is-active {
+		color: hsl(var(--hsl-primary));
+		border-bottom-color: hsl(var(--hsl-primary));
+	}
+</style>

--- a/src/routes/(auth)/billing/+page.svelte
+++ b/src/routes/(auth)/billing/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import { billingRoleLabel } from '$lib/billing'
 	import type { PageData } from './$types'
 
 	const { data }: { data: PageData } = $props()
@@ -9,45 +9,172 @@
 	const error = $derived(data.error)
 </script>
 
-<div class="page-head">
-	<div>
-		<h4><strong>Billing</strong></h4>
-		<p class="page-sub">{billingAccounts.length} {billingAccounts.length === 1 ? 'account' : 'accounts'}</p>
-	</div>
+<div class="head">
+	<p class="head-sub">{billingAccounts.length} {billingAccounts.length === 1 ? 'account' : 'accounts'} you can access</p>
 	<a class="button is-icon-left" href="/billing/create">
 		<i class="fa-solid fa-plus"></i>
 		Create account
 	</a>
 </div>
-<div class="panel is-level-300">
-	<div class="table-container">
-		<table class="table">
-			<thead>
-				<tr>
-					<th>Billing name</th>
-					<th>Billing ID</th>
-					<th class="is-align-center">Active</th>
-				</tr>
-			</thead>
-			<tbody>
-				{#each billingAccounts as it (it.id)}
-					<tr>
-						<td>
-							<a class="link" href="/billing/detail?id={it.id}">{it.name}</a>
-						</td>
-						<td>{it.id}</td>
-						<td class="is-align-center">
-							{#if it.active}
-								<i class="fa-solid fa-check-circle text-positive text-content/80"></i>
-							{:else}
-								<i class="fa-solid fa-times text-negative text-content/80"></i>
-							{/if}
-						</td>
-					</tr>
-				{/each}
-				<NoDataRow span={3} list={billingAccounts} {error} />
-				<ErrorRow span={3} {error} />
-			</tbody>
-		</table>
+
+{#if error}
+	<div class="panel is-level-300">
+		<table class="table"><tbody><ErrorRow span={1} {error} /></tbody></table>
 	</div>
-</div>
+{:else if billingAccounts.length === 0}
+	<div class="panel is-level-300 empty">
+		<i class="fa-solid fa-file-invoice-dollar"></i>
+		<p>You don't have access to any billing accounts yet.</p>
+		<a class="button is-variant-secondary is-icon-left" href="/billing/create">
+			<i class="fa-solid fa-plus"></i>
+			Create your first account
+		</a>
+	</div>
+{:else}
+	<div class="account-grid">
+		{#each billingAccounts as it (it.id)}
+			<a class="account-card" href="/billing/detail?id={it.id}">
+				<div class="account-card-top">
+					<span class="role-pill is-{it.role}">{billingRoleLabel[it.role] ?? it.role}</span>
+					{#if it.active}
+						<span class="dot is-positive" title="Active"><i class="fa-solid fa-circle-check"></i></span>
+					{:else}
+						<span class="dot is-negative" title="Inactive"><i class="fa-solid fa-circle-xmark"></i></span>
+					{/if}
+				</div>
+				<div class="account-name">{it.name}</div>
+				<div class="account-id">ID {it.id}</div>
+				<div class="account-go">
+					Open <i class="fa-solid fa-arrow-right"></i>
+				</div>
+			</a>
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.head {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-bottom: 1.25rem;
+	}
+
+	.head-sub {
+		color: hsl(var(--hsl-content) / 0.65);
+	}
+
+	.account-grid {
+		display: grid;
+		gap: 1rem;
+		grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+	}
+
+	.account-card {
+		display: grid;
+		gap: 0.4rem;
+		padding: 1.15rem 1.25rem;
+		border-radius: 0.75rem;
+		border: 1px solid hsl(var(--hsl-line));
+		background: hsl(var(--hsl-base-300));
+		color: inherit;
+		text-decoration: none;
+		box-shadow: var(--raised-z1);
+		transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+	}
+
+	.account-card:hover {
+		border-color: hsl(var(--hsl-primary));
+		transform: translateY(-2px);
+		box-shadow: var(--raised-z4);
+	}
+
+	.account-card-top {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 0.35rem;
+	}
+
+	.account-name {
+		font-size: 1.1rem;
+		font-weight: 600;
+		overflow-wrap: anywhere;
+	}
+
+	.account-id {
+		font-size: 0.8rem;
+		color: hsl(var(--hsl-content) / 0.55);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.account-go {
+		margin-top: 0.5rem;
+		font-size: 0.85rem;
+		font-weight: 500;
+		color: hsl(var(--hsl-primary));
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	.account-card:hover .account-go i {
+		transform: translateX(2px);
+	}
+
+	.account-go i {
+		transition: transform 0.15s ease;
+	}
+
+	.role-pill {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.15rem 0.6rem;
+		border-radius: 999px;
+		font-size: 0.72rem;
+		font-weight: 600;
+		letter-spacing: 0.02em;
+		text-transform: uppercase;
+		color: hsl(var(--hsl-content) / 0.7);
+		background: hsl(var(--hsl-content) / 0.08);
+	}
+
+	.role-pill.is-owner {
+		color: hsl(var(--hsl-primary));
+		background: hsl(var(--hsl-primary) / 0.12);
+	}
+
+	.role-pill.is-admin {
+		color: hsl(var(--hsl-info, var(--hsl-primary)));
+		background: hsl(var(--hsl-info, var(--hsl-primary)) / 0.12);
+	}
+
+	.role-pill.is-accountant {
+		color: hsl(var(--hsl-positive));
+		background: hsl(var(--hsl-positive) / 0.12);
+	}
+
+	.dot.is-positive {
+		color: hsl(var(--hsl-positive));
+	}
+
+	.dot.is-negative {
+		color: hsl(var(--hsl-content) / 0.35);
+	}
+
+	.empty {
+		display: grid;
+		justify-items: center;
+		gap: 1rem;
+		padding: 3rem 1.5rem;
+		text-align: center;
+		color: hsl(var(--hsl-content) / 0.7);
+	}
+
+	.empty i {
+		font-size: 2rem;
+		color: hsl(var(--hsl-content) / 0.3);
+	}
+</style>

--- a/src/routes/(auth)/billing/detail/+page.svelte
+++ b/src/routes/(auth)/billing/detail/+page.svelte
@@ -1,12 +1,36 @@
 <script lang="ts">
+	import dayjs from 'dayjs'
 	import { goto } from '$app/navigation'
 	import * as modal from '$lib/modal'
 	import api from '$lib/api'
+	import InvoiceStatusBadge from '$lib/components/InvoiceStatusBadge.svelte'
+	import { canManageBilling, canDeleteBilling } from '$lib/billing'
 	import type { PageData } from './$types'
 
 	const { data }: { data: PageData } = $props()
 
 	const billingAccount = $derived(data.billingAccount)
+	const invoices = $derived(data.invoices)
+
+	const canManage = $derived(canManageBilling(billingAccount.role))
+	const canDelete = $derived(canDeleteBilling(billingAccount.role))
+
+	const openInvoices = $derived(invoices.filter((it) => it.status === 'open'))
+	const currency = $derived(openInvoices[0]?.currency ?? invoices[0]?.currency ?? 'THB')
+	const amountDue = $derived(openInvoices.reduce((sum, it) => sum + it.total, 0))
+	// The most recent open invoice is the one to settle first.
+	const payTarget = $derived(openInvoices[0])
+	const latest = $derived(invoices[0])
+
+	function money (v: number, cur = currency) {
+		return `${v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${cur}`
+	}
+
+	function period (periodStart: string, periodEnd: string) {
+		const s = dayjs(periodStart)
+		const e = dayjs(periodEnd).subtract(1, 'day')
+		return s.isSame(e, 'month') ? s.format('MMM YYYY') : `${s.format('YYYY-MM-DD')} → ${e.format('YYYY-MM-DD')}`
+	}
 
 	function deleteItem () {
 		modal.confirm({
@@ -24,76 +48,111 @@
 	}
 </script>
 
-<div class="breadcrumb">
-	<div class="breadcrumb-item">
-		<a href="/billing" class="link"><h6>Billing</h6></a>
-	</div>
-	<div class="breadcrumb-item min-w-0">
-		<h6 class="min-w-0 wrap-anywhere">{billingAccount.name}</h6>
-	</div>
-</div>
-
-<br>
-
 <div class="grid gap-6">
-	<div class="panel is-level-300">
-		<div class="flex flex-wrap items-start justify-between gap-4">
-			<div class="grid gap-2 min-w-0">
-				<h3 class="min-w-0 wrap-anywhere"><strong>{billingAccount.name}</strong></h3>
-				<div class="flex flex-wrap items-center gap-2 text-sm text-content/70">
-					<span>ID</span>
-					<code class="account-id">{billingAccount.id}</code>
-				</div>
+	<!-- Amount due hero — the accountant's primary concern -->
+	<div class="panel is-level-300 hero" class:is-due={amountDue > 0}>
+		<div class="hero-main">
+			<div class="hero-label">
+				{#if amountDue > 0}
+					Amount due
+				{:else}
+					Balance
+				{/if}
 			</div>
-			{#if billingAccount.active}
-				<span class="status-badge is-positive">
-					<i class="fa-solid fa-circle-check"></i>
-					Active
-				</span>
+			<div class="hero-amount">{money(amountDue)}</div>
+			<div class="hero-sub">
+				{#if amountDue > 0}
+					{openInvoices.length} open {openInvoices.length === 1 ? 'invoice' : 'invoices'}
+				{:else}
+					<i class="fa-solid fa-circle-check text-positive"></i> You're all caught up
+				{/if}
+			</div>
+		</div>
+		<div class="hero-actions">
+			{#if payTarget}
+				<a class="button is-icon-left" href={`/billing/invoice?id=${payTarget.id}`}>
+					<i class="fa-solid fa-receipt"></i>
+					Pay now
+				</a>
+			{/if}
+			<a class="button is-variant-secondary is-icon-left" href={`/billing/invoices?id=${billingAccount.id}`}>
+				<i class="fa-solid fa-file-invoice-dollar"></i>
+				All invoices
+			</a>
+		</div>
+	</div>
+
+	<div class="grid gap-6 lg:grid-cols-2">
+		<!-- Latest invoice -->
+		<div class="panel is-level-300">
+			<div class="flex items-center justify-between mb-4">
+				<h5><strong>Latest invoice</strong></h5>
+				<a class="link text-sm" href={`/billing/invoices?id=${billingAccount.id}`}>View all</a>
+			</div>
+			{#if latest}
+				<a class="latest" href={`/billing/invoice?id=${latest.id}`}>
+					<div class="grid gap-1 min-w-0">
+						<div class="flex items-center gap-2">
+							<strong>{latest.number}</strong>
+							<InvoiceStatusBadge status={latest.status} />
+						</div>
+						<div class="text-sm text-content/65">{period(latest.periodStart, latest.periodEnd)}</div>
+					</div>
+					<div class="latest-amount">{money(latest.total, latest.currency)}</div>
+				</a>
 			{:else}
-				<span class="status-badge is-negative">
-					<i class="fa-solid fa-circle-xmark"></i>
-					Inactive
-				</span>
+				<p class="text-content/60">No invoices yet.</p>
 			{/if}
 		</div>
-	</div>
 
-	<div class="panel is-level-300">
-		<h5 class="mb-4"><strong>Quick actions</strong></h5>
-		<div class="grid gap-3 sm:grid-cols-2">
-			<a class="action-card" href={`/billing/report?id=${billingAccount.id}`}>
-				<div class="action-icon">
+		<!-- Quick links -->
+		<div class="panel is-level-300">
+			<h5 class="mb-4"><strong>Quick links</strong></h5>
+			<div class="grid gap-2">
+				<a class="quick" href={`/billing/receipts?id=${billingAccount.id}`}>
+					<i class="fa-solid fa-receipt"></i>
+					<span>Receipts</span>
+					<i class="fa-solid fa-chevron-right chevron"></i>
+				</a>
+				<a class="quick" href={`/billing/report?id=${billingAccount.id}`}>
 					<i class="fa-solid fa-chart-line"></i>
-				</div>
-				<div class="grid gap-1 min-w-0">
-					<div><strong>Usage report</strong></div>
-					<p class="text-sm text-content/70">View usage and cost charts across projects.</p>
-				</div>
-			</a>
-			<a class="action-card" href={`/billing/invoices?id=${billingAccount.id}`}>
-				<div class="action-icon">
-					<i class="fa-solid fa-file-invoice-dollar"></i>
-				</div>
-				<div class="grid gap-1 min-w-0">
-					<div><strong>Invoices</strong></div>
-					<p class="text-sm text-content/70">Browse and download past invoices.</p>
-				</div>
-			</a>
+					<span>Usage report</span>
+					<i class="fa-solid fa-chevron-right chevron"></i>
+				</a>
+				{#if canManage}
+					<a class="quick" href={`/billing/members?id=${billingAccount.id}`}>
+						<i class="fa-solid fa-user-group"></i>
+						<span>Members</span>
+						<i class="fa-solid fa-chevron-right chevron"></i>
+					</a>
+				{/if}
+			</div>
 		</div>
 	</div>
 
+	<!-- Billing information -->
 	<div class="panel is-level-300">
 		<div class="flex flex-wrap items-center justify-between gap-4 mb-4">
 			<h5><strong>Billing information</strong></h5>
-			<a class="button is-variant-secondary is-size-small" href={`/billing/create?id=${billingAccount.id}`}>
-				<i class="fa-solid fa-pen-to-square"></i>
-				Edit
-			</a>
+			<div class="flex items-center gap-3">
+				{#if billingAccount.active}
+					<span class="status-badge is-positive"><i class="fa-solid fa-circle-check"></i> Active</span>
+				{:else}
+					<span class="status-badge is-negative"><i class="fa-solid fa-circle-xmark"></i> Inactive</span>
+				{/if}
+				{#if canManage}
+					<a class="button is-variant-secondary is-size-small" href={`/billing/create?id=${billingAccount.id}`}>
+						<i class="fa-solid fa-pen-to-square"></i>
+						Edit
+					</a>
+				{/if}
+			</div>
 		</div>
 		<dl class="info-list">
 			<dt>Account name</dt>
 			<dd>{billingAccount.name}</dd>
+			<dt>Account ID</dt>
+			<dd class="tabular-nums">{billingAccount.id}</dd>
 			<dt>Entity type</dt>
 			<dd>{billingAccount.type === 'company' ? 'Company' : 'Individual'}</dd>
 			<dt>Tax ID</dt>
@@ -105,42 +164,129 @@
 		</dl>
 	</div>
 
-	<div class="panel is-level-300">
-		<h5 class="mb-4"><strong>Danger zone</strong></h5>
-		<div class="danger-zone">
-			<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-				<div class="grid gap-1 min-w-0">
-					<div><strong>Delete billing account</strong></div>
-					<p class="text-sm text-content/70">
-						Permanently removes this billing account. This action cannot be undone.
-					</p>
+	<!-- Danger zone (owner only) -->
+	{#if canDelete}
+		<div class="panel is-level-300">
+			<h5 class="mb-4"><strong>Danger zone</strong></h5>
+			<div class="danger-zone">
+				<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+					<div class="grid gap-1 min-w-0">
+						<div><strong>Delete billing account</strong></div>
+						<p class="text-sm text-content/70">
+							Permanently removes this billing account. This action cannot be undone.
+						</p>
+					</div>
+					<button class="button is-variant-negative shrink-0" type="button" onclick={deleteItem}>
+						Delete account
+					</button>
 				</div>
-				<button class="button is-variant-negative shrink-0" type="button" onclick={deleteItem}>
-					Delete account
-				</button>
 			</div>
 		</div>
-	</div>
+	{/if}
 </div>
 
 <style>
-	.account-id {
-		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-		font-size: 0.85em;
-		padding: 0.1rem 0.4rem;
-		border-radius: 0.25rem;
-		background-color: hsl(var(--hsl-base-200));
+	.hero {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1.5rem;
+	}
+
+	.hero-label {
+		font-size: 0.8rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: hsl(var(--hsl-content) / 0.55);
+	}
+
+	.hero-amount {
+		font-size: 2.25rem;
+		font-weight: 700;
+		line-height: 1.1;
+		letter-spacing: -0.02em;
+		font-variant-numeric: tabular-nums;
+		margin: 0.15rem 0 0.35rem;
+	}
+
+	.hero.is-due .hero-amount {
+		color: hsl(var(--hsl-warning, var(--hsl-primary)));
+	}
+
+	.hero-sub {
+		color: hsl(var(--hsl-content) / 0.7);
+		font-size: 0.9rem;
+	}
+
+	.hero-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+	}
+
+	.latest {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		padding: 0.9rem 1rem;
+		border-radius: 0.6rem;
+		border: 1px solid hsl(var(--hsl-line));
+		background: hsl(var(--hsl-base-200) / 0.5);
+		color: inherit;
+		text-decoration: none;
+		transition: border-color 0.15s ease;
+	}
+
+	.latest:hover {
+		border-color: hsl(var(--hsl-primary));
+	}
+
+	.latest-amount {
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+		white-space: nowrap;
+	}
+
+	.quick {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.75rem 0.9rem;
+		border-radius: 0.5rem;
+		color: inherit;
+		text-decoration: none;
+		transition: background-color 0.15s ease;
+	}
+
+	.quick:hover {
+		background: hsl(var(--hsl-content) / 0.05);
+	}
+
+	.quick > span {
+		flex: 1;
+	}
+
+	.quick > i:first-child {
+		width: 1.25rem;
+		text-align: center;
+		color: hsl(var(--hsl-primary));
+	}
+
+	.quick .chevron {
+		font-size: 0.75rem;
+		color: hsl(var(--hsl-content) / 0.4);
 	}
 
 	.status-badge {
 		display: inline-flex;
 		align-items: center;
-		gap: 0.5rem;
-		padding: 0.35rem 0.85rem;
+		gap: 0.4rem;
+		padding: 0.3rem 0.7rem;
 		border-radius: 9999px;
-		font-size: 0.875rem;
+		font-size: 0.8rem;
 		font-weight: 500;
-		flex-shrink: 0;
 	}
 
 	.status-badge.is-positive {
@@ -149,39 +295,8 @@
 	}
 
 	.status-badge.is-negative {
-		color: hsl(var(--hsl-negative));
-		background-color: hsl(var(--hsl-negative) / 0.12);
-	}
-
-	.action-card {
-		display: flex;
-		align-items: flex-start;
-		gap: 1rem;
-		padding: 1rem 1.25rem;
-		border-radius: 0.5rem;
-		border: 1px solid hsl(var(--hsl-line));
-		background-color: hsl(var(--hsl-base-200) / 0.5);
-		color: inherit;
-		text-decoration: none;
-		transition: border-color 0.15s ease, background-color 0.15s ease, transform 0.15s ease;
-	}
-
-	.action-card:hover {
-		border-color: hsl(var(--hsl-primary));
-		background-color: hsl(var(--hsl-primary) / 0.06);
-	}
-
-	.action-icon {
-		flex-shrink: 0;
-		width: 2.5rem;
-		height: 2.5rem;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		border-radius: 0.5rem;
-		font-size: 1.125rem;
-		color: hsl(var(--hsl-primary));
-		background-color: hsl(var(--hsl-primary) / 0.1);
+		color: hsl(var(--hsl-content) / 0.6);
+		background-color: hsl(var(--hsl-content) / 0.08);
 	}
 
 	.info-list {

--- a/src/routes/(auth)/billing/invoice/+page.svelte
+++ b/src/routes/(auth)/billing/invoice/+page.svelte
@@ -122,22 +122,26 @@
 	.is-align-right {
 		text-align: right;
 	}
+
+	.back-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		color: hsl(var(--hsl-content) / 0.6);
+		text-decoration: none;
+		font-size: 0.9rem;
+		transition: color 0.15s ease;
+	}
+
+	.back-link:hover {
+		color: hsl(var(--hsl-primary));
+	}
 </style>
 
-<div class="breadcrumb">
-	<div class="breadcrumb-item">
-		<a href="/billing" class="link"><h6>Billing</h6></a>
-	</div>
-	<div class="breadcrumb-item">
-		<a href={`/billing/detail?id=${billingAccount.id}`} class="link"><h6>{billingAccount.name}</h6></a>
-	</div>
-	<div class="breadcrumb-item">
-		<a href={`/billing/invoices?id=${billingAccount.id}`} class="link"><h6>Invoices</h6></a>
-	</div>
-	<div class="breadcrumb-item">
-		<h6>{invoice.number}</h6>
-	</div>
-</div>
+<a class="back-link" href={`/billing/invoices?id=${billingAccount.id}`}>
+	<i class="fa-solid fa-arrow-left"></i>
+	Back to invoices
+</a>
 
 <br>
 

--- a/src/routes/(auth)/billing/invoices/+page.svelte
+++ b/src/routes/(auth)/billing/invoices/+page.svelte
@@ -8,7 +8,6 @@
 
 	const { data }: { data: PageData } = $props()
 
-	const billingAccount = $derived(data.billingAccount)
 	const invoices = $derived(data.invoices)
 	const error = $derived(data.error)
 
@@ -26,31 +25,18 @@
 	}
 </script>
 
-<div class="breadcrumb">
-	<div class="breadcrumb-item">
-		<a href="/billing" class="link"><h6>Billing</h6></a>
-	</div>
-	<div class="breadcrumb-item">
-		<a href={`/billing/detail?id=${billingAccount.id}`} class="link"><h6>{billingAccount.name}</h6></a>
-	</div>
-	<div class="breadcrumb-item">
-		<h6>Invoices</h6>
-	</div>
-</div>
-
-<br>
-
 <div class="panel is-level-300">
-	<div class="table-container mt-4">
+	<div class="table-container">
 		<table class="table">
 			<thead>
 				<tr>
 					<th>Number</th>
-					<th>Receipt no.</th>
 					<th>Period</th>
 					<th class="is-align-right">Total</th>
 					<th>Status</th>
-					<th>Issued</th>
+					<th class="is-hide-mobile">Receipt no.</th>
+					<th class="is-hide-mobile">Issued</th>
+					<th class="is-align-right"></th>
 				</tr>
 			</thead>
 			<tbody>
@@ -59,15 +45,25 @@
 						<td>
 							<a class="link" href={`/billing/invoice?id=${it.id}`}>{it.number}</a>
 						</td>
-						<td>{it.receiptNumber || '—'}</td>
 						<td>{period(it.periodStart, it.periodEnd)}</td>
-						<td class="is-align-right">{money(it.total, it.currency)}</td>
+						<td class="is-align-right tabular-nums">{money(it.total, it.currency)}</td>
 						<td><InvoiceStatusBadge status={it.status} /></td>
-						<td>{format.datetime(it.issuedAt)}</td>
+						<td class="is-hide-mobile">{it.receiptNumber || '—'}</td>
+						<td class="is-hide-mobile">{format.datetime(it.issuedAt)}</td>
+						<td class="is-align-right">
+							{#if it.status === 'open'}
+								<a class="button is-size-small is-icon-left" href={`/billing/invoice?id=${it.id}`}>
+									<i class="fa-solid fa-receipt"></i>
+									Pay
+								</a>
+							{:else}
+								<a class="link text-sm" href={`/billing/invoice?id=${it.id}`}>View</a>
+							{/if}
+						</td>
 					</tr>
 				{/each}
-				<NoDataRow span={6} list={invoices} {error} />
-				<ErrorRow span={6} {error} />
+				<NoDataRow span={7} list={invoices} {error} />
+				<ErrorRow span={7} {error} />
 			</tbody>
 		</table>
 	</div>

--- a/src/routes/(auth)/billing/members/+page.svelte
+++ b/src/routes/(auth)/billing/members/+page.svelte
@@ -1,0 +1,279 @@
+<script lang="ts">
+	import gravatarUrl from 'gravatar-url'
+	import * as format from '$lib/format'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import { billingRoleLabel, billingRoleDescription } from '$lib/billing'
+	import type { PageData } from './$types'
+
+	const { data }: { data: PageData } = $props()
+
+	const account = $derived(data.billingAccount)
+	const owner = $derived(data.owner)
+	const members = $derived(data.members)
+	const error = $derived(data.error)
+
+	let inviteEmail = $state('')
+	let inviteRole = $state<'admin' | 'accountant'>('accountant')
+	let inviting = $state(false)
+	let busyEmail = $state<string | null>(null)
+
+	async function invite (e: Event) {
+		e.preventDefault()
+		if (inviting) return
+		const email = inviteEmail.trim()
+		if (!email) return
+		inviting = true
+		try {
+			const resp = await api.invoke('billing.addMember', { id: account.id, email, role: inviteRole }, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+			inviteEmail = ''
+			inviteRole = 'accountant'
+			api.invalidate('billing.listMembers')
+		} finally {
+			inviting = false
+		}
+	}
+
+	async function changeRole (email: string, role: string) {
+		busyEmail = email
+		try {
+			const resp = await api.invoke('billing.addMember', { id: account.id, email, role }, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+			}
+			// Re-fetch on both success and failure: the native <select> already
+			// shows the user's pick, so on a rejected change we must reload to snap
+			// it back to the member's true role.
+			api.invalidate('billing.listMembers')
+		} finally {
+			busyEmail = null
+		}
+	}
+
+	function removeMember (email: string) {
+		modal.confirm({
+			title: `Remove ${email}? They will immediately lose access to this billing account.`,
+			yes: 'Remove',
+			callback: async () => {
+				busyEmail = email
+				try {
+					const resp = await api.invoke('billing.removeMember', { id: account.id, email }, fetch)
+					if (!resp.ok) {
+						modal.error({ error: resp.error })
+						return
+					}
+					api.invalidate('billing.listMembers')
+				} finally {
+					busyEmail = null
+				}
+			}
+		})
+	}
+</script>
+
+<div class="grid gap-6">
+	<div class="panel is-level-300">
+		<div class="mb-1"><h5><strong>People with access</strong></h5></div>
+		<p class="text-sm text-content/65 mb-5">
+			Invite people to help manage this billing account. Members can view invoices and pay;
+			admins can also edit billing details and manage members.
+		</p>
+
+		<div class="member-list">
+			<!-- Owner: implicit, always present, never editable/removable here -->
+			<div class="member-row">
+				<div class="member-id">
+					<img class="avatar" src={gravatarUrl(owner, { default: 'mp' })} alt="" />
+					<div class="min-w-0">
+						<div class="member-email">{owner}</div>
+						<div class="member-meta">Account owner</div>
+					</div>
+				</div>
+				<div class="member-controls">
+					<span class="role-pill is-owner">{billingRoleLabel.owner}</span>
+				</div>
+			</div>
+
+			{#each members as m (m.email)}
+				<div class="member-row">
+					<div class="member-id">
+						<img class="avatar" src={gravatarUrl(m.email, { default: 'mp' })} alt="" />
+						<div class="min-w-0">
+							<div class="member-email">{m.email}</div>
+							<div class="member-meta">
+								Added {format.datetime(m.createdAt)}{m.createdBy ? ` · by ${m.createdBy}` : ''}
+							</div>
+						</div>
+					</div>
+					<div class="member-controls">
+						<select
+							class="select is-size-small"
+							value={m.role}
+							disabled={busyEmail === m.email}
+							onchange={(e) => changeRole(m.email, (e.currentTarget as HTMLSelectElement).value)}
+						>
+							<option value="admin">Admin</option>
+							<option value="accountant">Accountant</option>
+						</select>
+						<button
+							class="button is-variant-tertiary is-size-small icon-only"
+							title="Remove member"
+							aria-label="Remove member"
+							disabled={busyEmail === m.email}
+							onclick={() => removeMember(m.email)}
+						>
+							<i class="fa-solid fa-trash-can"></i>
+						</button>
+					</div>
+				</div>
+			{/each}
+
+			{#if error}
+				<div class="member-empty text-negative">{error.message ?? 'Could not load members.'}</div>
+			{:else if members.length === 0}
+				<div class="member-empty">No members yet — invite someone below.</div>
+			{/if}
+		</div>
+	</div>
+
+	<div class="panel is-level-300">
+		<h5 class="mb-4"><strong>Invite a member</strong></h5>
+		<form class="invite" onsubmit={invite}>
+			<div class="field grow">
+				<label class="label" for="invite-email">Email</label>
+				<input
+					id="invite-email"
+					class="input"
+					type="email"
+					placeholder="accountant@example.com"
+					bind:value={inviteEmail}
+					required
+				/>
+			</div>
+			<div class="field">
+				<label class="label" for="invite-role">Role</label>
+				<select id="invite-role" class="select" bind:value={inviteRole}>
+					<option value="accountant">Accountant</option>
+					<option value="admin">Admin</option>
+				</select>
+			</div>
+			<div class="field invite-submit">
+				<button class="button is-icon-left" type="submit" class:is-loading={inviting} disabled={inviting}>
+					<i class="fa-solid fa-user-plus"></i>
+					Invite
+				</button>
+			</div>
+		</form>
+		<p class="role-hint text-sm text-content/60">
+			<strong>{billingRoleLabel[inviteRole]}:</strong> {billingRoleDescription[inviteRole]}
+		</p>
+	</div>
+</div>
+
+<style>
+	.member-list {
+		display: grid;
+		gap: 0.25rem;
+	}
+
+	.member-row {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem 1rem;
+		padding: 0.75rem 0;
+		border-bottom: 1px solid hsl(var(--hsl-line) / 0.6);
+	}
+
+	.member-row:last-child {
+		border-bottom: 0;
+	}
+
+	.member-id {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		min-width: 0;
+	}
+
+	.avatar {
+		flex-shrink: 0;
+		width: 2.25rem;
+		height: 2.25rem;
+		border-radius: 50%;
+		background: hsl(var(--hsl-content) / 0.06);
+		object-fit: cover;
+	}
+
+	.member-email {
+		font-weight: 500;
+		overflow-wrap: anywhere;
+	}
+
+	.member-meta {
+		font-size: 0.8rem;
+		color: hsl(var(--hsl-content) / 0.55);
+	}
+
+	.member-controls {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.icon-only {
+		color: hsl(var(--hsl-content) / 0.6);
+	}
+
+	.icon-only:hover {
+		color: hsl(var(--hsl-negative));
+	}
+
+	.member-empty {
+		padding: 1rem 0;
+		color: hsl(var(--hsl-content) / 0.6);
+	}
+
+	.invite {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: flex-end;
+		gap: 1rem;
+	}
+
+	.invite .grow {
+		flex: 1;
+		min-width: 14rem;
+	}
+
+	.invite-submit {
+		justify-content: flex-end;
+	}
+
+	.role-hint {
+		margin-top: 1rem;
+	}
+
+	.role-pill {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.2rem 0.65rem;
+		border-radius: 999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		letter-spacing: 0.02em;
+		text-transform: uppercase;
+		color: hsl(var(--hsl-content) / 0.7);
+		background: hsl(var(--hsl-content) / 0.08);
+	}
+
+	.role-pill.is-owner {
+		color: hsl(var(--hsl-primary));
+		background: hsl(var(--hsl-primary) / 0.12);
+	}
+</style>

--- a/src/routes/(auth)/billing/members/+page.ts
+++ b/src/routes/(auth)/billing/members/+page.ts
@@ -1,5 +1,6 @@
 import { redirect, error } from '@sveltejs/kit'
 import api from '$lib/api'
+import { canManageBilling } from '$lib/billing'
 import type { PageLoad } from './$types'
 
 export const load: PageLoad = async ({ url, fetch }) => {
@@ -13,13 +14,18 @@ export const load: PageLoad = async ({ url, fetch }) => {
 	}
 	if (!billingAccount.result) redirect(302, '/billing')
 
-	// Load the invoices too so the overview can surface an "amount due" summary
-	// and the latest invoice — the accountant's landing view. Best-effort: a
-	// failure here must not break the account page, so fall back to an empty list.
-	const invoices = await api.invoke<Api.List<Api.InvoiceListItem>>('billing.listInvoices', { billingAccountId: id }, fetch)
+	// Managing members is owner/admin only. An accountant who deep-links here is
+	// bounced back to the account overview rather than shown a forbidden error.
+	if (!canManageBilling(billingAccount.result.role)) {
+		redirect(302, `/billing/detail?id=${id}`)
+	}
+
+	const members = await api.invoke<Api.BillingMemberList>('billing.listMembers', { id }, fetch)
 
 	return {
 		billingAccount: billingAccount.result,
-		invoices: invoices.result?.items ?? []
+		owner: members.result?.owner ?? '',
+		members: members.result?.items ?? [],
+		error: members.error
 	}
 }

--- a/src/routes/(auth)/billing/receipts/+page.svelte
+++ b/src/routes/(auth)/billing/receipts/+page.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	import dayjs from 'dayjs'
+	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import * as format from '$lib/format'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import type { PageData } from './$types'
+
+	const { data }: { data: PageData } = $props()
+
+	const error = $derived(data.error)
+	// A receipt is the proof-of-payment document, so only paid invoices have one.
+	const receipts = $derived(data.invoices.filter((it) => it.status === 'paid'))
+
+	// Track the in-flight download per invoice so each row's button spins alone.
+	let downloadingId = $state<string | null>(null)
+
+	function period (periodStart: string, periodEnd: string) {
+		const s = dayjs(periodStart)
+		const e = dayjs(periodEnd).subtract(1, 'day')
+		return s.isSame(e, 'month') ? s.format('MMM YYYY') : `${s.format('YYYY-MM-DD')} → ${e.format('YYYY-MM-DD')}`
+	}
+
+	function money (v: number, currency: string) {
+		return `${v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${currency}`
+	}
+
+	async function downloadReceipt (invoiceId: string) {
+		if (downloadingId) return
+		downloadingId = invoiceId
+		try {
+			const resp = await api.invoke<Api.InvoiceDownloadResult>('billing.downloadReceipt', { invoiceId }, fetch)
+			if (!resp.ok || !resp.result) {
+				modal.error({ error: resp.error?.message ? resp.error : 'Could not download the receipt PDF. Please try again.' })
+				return
+			}
+			window.location.href = resp.result.downloadUrl
+		} catch (err) {
+			modal.error({ error: err })
+		} finally {
+			downloadingId = null
+		}
+	}
+</script>
+
+<div class="panel is-level-300">
+	<div class="table-container">
+		<table class="table">
+			<thead>
+				<tr>
+					<th>Receipt no.</th>
+					<th>Invoice</th>
+					<th>Period</th>
+					<th class="is-align-right">Amount</th>
+					<th class="is-hide-mobile">Paid</th>
+					<th class="is-align-right"></th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each receipts as it (it.id)}
+					<tr>
+						<td class="tabular-nums">{it.receiptNumber || '—'}</td>
+						<td><a class="link" href={`/billing/invoice?id=${it.id}`}>{it.number}</a></td>
+						<td>{period(it.periodStart, it.periodEnd)}</td>
+						<td class="is-align-right tabular-nums">{money(it.total, it.currency)}</td>
+						<td class="is-hide-mobile">{format.datetime(it.paidAt) || '—'}</td>
+						<td class="is-align-right">
+							<button
+								class="button is-variant-secondary is-size-small is-icon-left"
+								class:is-loading={downloadingId === it.id}
+								disabled={downloadingId === it.id}
+								onclick={() => downloadReceipt(it.id)}
+							>
+								<i class="fa-solid fa-download"></i>
+								Receipt
+							</button>
+						</td>
+					</tr>
+				{/each}
+				<NoDataRow span={6} list={receipts} {error} />
+				<ErrorRow span={6} {error} />
+			</tbody>
+		</table>
+	</div>
+</div>
+
+{#if receipts.length === 0 && !error}
+	<p class="mt-4 text-content/60 text-sm">
+		Receipts appear here once an invoice is paid.
+	</p>
+{/if}

--- a/src/routes/(auth)/billing/receipts/+page.ts
+++ b/src/routes/(auth)/billing/receipts/+page.ts
@@ -13,13 +13,11 @@ export const load: PageLoad = async ({ url, fetch }) => {
 	}
 	if (!billingAccount.result) redirect(302, '/billing')
 
-	// Load the invoices too so the overview can surface an "amount due" summary
-	// and the latest invoice — the accountant's landing view. Best-effort: a
-	// failure here must not break the account page, so fall back to an empty list.
 	const invoices = await api.invoke<Api.List<Api.InvoiceListItem>>('billing.listInvoices', { billingAccountId: id }, fetch)
 
 	return {
 		billingAccount: billingAccount.result,
-		invoices: invoices.result?.items ?? []
+		invoices: invoices.result?.items ?? [],
+		error: invoices.error
 	}
 }

--- a/src/routes/(auth)/billing/report/+page.svelte
+++ b/src/routes/(auth)/billing/report/+page.svelte
@@ -165,19 +165,6 @@
 	})
 </script>
 
-<div class="breadcrumb">
-	<div class="breadcrumb-item">
-		<a href="/billing" class="link"><h6>Billing</h6></a>
-	</div>
-	<div class="breadcrumb-item min-w-0">
-		<a href={`/billing/detail?id=${billingAccount.id}`} class="link"><h6 class="min-w-0 wrap-anywhere">{billingAccount.name}</h6></a>
-	</div>
-	<div class="breadcrumb-item">
-		<h6>Report</h6>
-	</div>
-</div>
-
-<br>
 
 <div class="grid gap-6">
 	<div class="panel is-level-300 grid gap-5">

--- a/src/routes/(auth)/project/create/+page.ts
+++ b/src/routes/(auth)/project/create/+page.ts
@@ -1,5 +1,6 @@
 import { redirect, error } from '@sveltejs/kit'
 import api from '$lib/api'
+import { canManageBilling } from '$lib/billing'
 import type { PageLoad } from './$types'
 
 export const load: PageLoad = async ({ url, fetch }) => {
@@ -17,8 +18,11 @@ export const load: PageLoad = async ({ url, fetch }) => {
 	const billingAccounts = await api.invoke<Api.List<Api.BillingAccount>>('billing.list', {}, fetch)
 	if (!billingAccounts.ok) error(500, billingAccounts.error?.message)
 
+	// Attaching a project to a billing account is an owner/admin action, so only
+	// offer accounts the user can actually manage — an accountant sees invoices
+	// for an account but can't bill projects to it (the server refuses too).
 	return {
 		project: projectInfo?.result,
-		billingAccounts: billingAccounts.result?.items ?? []
+		billingAccounts: (billingAccounts.result?.items ?? []).filter((a) => canManageBilling(a.role))
 	}
 }

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -60,6 +60,11 @@ declare namespace Api {
 
     export type BillingAccountType = 'individual' | 'company'
 
+    // BillingRole is the caller's effective access on a billing account.
+    // 'owner' is implicit (the account's owner); 'admin' and 'accountant' are
+    // invited member roles.
+    export type BillingRole = 'owner' | 'admin' | 'accountant'
+
     export type BillingAccount = {
         id: string
         name: string
@@ -70,6 +75,24 @@ declare namespace Api {
         taxName: string
         taxAddress: string
         active: boolean
+        // role is the calling user's effective role on this account, so the UI
+        // can gate management surfaces without a second lookup.
+        role: BillingRole
+    }
+
+    // BillingMember is an invited (non-owner) user on a billing account.
+    export type BillingMember = {
+        email: string
+        role: 'admin' | 'accountant'
+        createdAt: string
+        createdBy: string
+    }
+
+    // BillingMemberList is the response of billing.listMembers: the account
+    // owner plus every invited member.
+    export type BillingMemberList = {
+        owner: string
+        items: BillingMember[]
     }
 
     export type ProjectUsage = {

--- a/tests/billing-members.spec.js
+++ b/tests/billing-members.spec.js
@@ -1,0 +1,82 @@
+import { test, expect, setMocks } from './helpers.js'
+import { sampleBillingAccount } from './fixtures/mocks.js'
+
+const ownerAccount = { ...sampleBillingAccount, role: 'owner' }
+const accountantAccount = { ...sampleBillingAccount, role: 'accountant' }
+
+const memberList = {
+	ok: true,
+	result: {
+		owner: 'owner@example.com',
+		items: [
+			{ email: 'accountant@example.com', role: 'accountant', createdAt: '2026-06-01T09:00:00Z', createdBy: 'owner@example.com' },
+			{ email: 'cfo@example.com', role: 'admin', createdAt: '2026-05-12T10:30:00Z', createdBy: 'owner@example.com' }
+		]
+	}
+}
+
+test.describe('billing members', () => {
+	test('owner sees the Members tab and the people-with-access list', async ({ page }) => {
+		await setMocks({
+			'billing.get': { ok: true, result: ownerAccount },
+			'billing.listMembers': memberList
+		})
+
+		await page.goto('/billing/members?id=ba-1')
+
+		const main = page.locator('.content-wrapper')
+		// Portal Members tab present for an owner.
+		await expect(main.getByRole('link', { name: 'Members' })).toBeVisible()
+		// Owner + both members are listed (exact match: the owner email also appears
+		// inside each member's "added by" meta line).
+		await expect(main.getByText('owner@example.com', { exact: true })).toBeVisible()
+		await expect(main.getByText('accountant@example.com', { exact: true })).toBeVisible()
+		await expect(main.getByText('cfo@example.com', { exact: true })).toBeVisible()
+		// The invite form is present.
+		await expect(main.getByRole('button', { name: 'Invite' })).toBeVisible()
+	})
+
+	test('owner can invite a member — calls billing.addMember', async ({ page }) => {
+		await setMocks({
+			'billing.get': { ok: true, result: ownerAccount },
+			'billing.listMembers': memberList,
+			'billing.addMember': { ok: true, result: {} }
+		})
+
+		await page.goto('/billing/members?id=ba-1')
+
+		const main = page.locator('.content-wrapper')
+		await main.getByLabel('Email').fill('new.accountant@example.com')
+		await main.getByRole('button', { name: 'Invite' }).click()
+
+		// On a successful add the form clears — no error modal, input reset.
+		await expect(main.getByLabel('Email')).toHaveValue('')
+		await expect(page.locator('#app-modal')).toBeHidden()
+	})
+
+	test('accountant does not see the Members tab', async ({ page }) => {
+		await setMocks({
+			'billing.get': { ok: true, result: accountantAccount }
+		})
+
+		await page.goto('/billing/detail?id=ba-1')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('link', { name: 'Overview' })).toBeVisible()
+		// Members management is owner/admin only.
+		await expect(main.getByRole('link', { name: 'Members' })).toHaveCount(0)
+		// And no Edit / Danger zone affordances.
+		await expect(main.getByRole('link', { name: 'Edit' })).toHaveCount(0)
+		await expect(main.getByText('Danger zone')).toHaveCount(0)
+	})
+
+	test('accountant deep-linking to members is redirected to the overview', async ({ page }) => {
+		await setMocks({
+			'billing.get': { ok: true, result: accountantAccount }
+		})
+
+		await page.goto('/billing/members?id=ba-1')
+
+		await expect(page).toHaveURL(/\/billing\/detail\?id=ba-1/)
+	})
+})

--- a/tests/billing.spec.js
+++ b/tests/billing.spec.js
@@ -18,7 +18,8 @@ test.describe('billing accounts', () => {
 		await page.goto('/billing')
 
 		const main = page.locator('.content-wrapper')
-		await expect(main.getByRole('heading', { name: 'Billing' })).toBeVisible()
+		// The billing portal brand + account cards (each card is a link to the account).
+		await expect(main.getByRole('link', { name: 'Billing' })).toBeVisible()
 		await expect(main.getByRole('link', { name: 'Personal' })).toBeVisible()
 		await expect(main.getByRole('link', { name: 'Company' })).toBeVisible()
 		await expect(main.getByRole('link', { name: 'Create account' })).toHaveAttribute('href', '/billing/create')
@@ -55,14 +56,15 @@ test.describe('billing accounts', () => {
 		const main = page.locator('.content-wrapper')
 		const paidRow = main.locator('table tbody tr', { hasText: 'INV-2024-001' })
 		await expect(paidRow.getByText('DPLY-RC-202605-0001')).toBeVisible()
+		// Receipt no. is the 5th column (Number, Period, Total, Status, Receipt no., Issued, action).
 		const openRow = main.locator('table tbody tr', { hasText: 'INV-2024-002' })
-		await expect(openRow.locator('td').nth(1)).toHaveText('—')
+		await expect(openRow.locator('td').nth(4)).toHaveText('—')
 	})
 
 	test('empty state when no billing accounts', async ({ page }) => {
 		await page.goto('/billing')
 		const main = page.locator('.content-wrapper')
-		await expect(main.getByText('Nothing here yet')).toBeVisible()
+		await expect(main.getByText(/don't have access to any billing accounts/)).toBeVisible()
 	})
 })
 

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -86,6 +86,12 @@ export function defaultMocks () {
 			ok: true,
 			result: { items: [] }
 		},
+		// The billing overview loads invoices for its amount-due summary; default
+		// to empty so an account page that doesn't override it renders cleanly.
+		'/billing.listInvoices': {
+			ok: true,
+			result: { items: [] }
+		},
 		'/deployment.list': {
 			ok: true,
 			result: { items: [] }
@@ -354,7 +360,8 @@ export const sampleBillingAccount = {
 	taxId: '',
 	taxName: '',
 	taxAddress: '',
-	active: true
+	active: true,
+	role: 'owner'
 }
 
 export const sampleInvoice = {


### PR DESCRIPTION
## Summary

Restructures the billing area into a focused, payment-first **portal** tailored to people who manage billing but not projects (e.g. an accountant), and adds the UI for the new **billing-account membership** feature.

**Portal shell** (new `billing/+layout.svelte`): a billing header with the account name + role pill and a tab sub-nav (Overview / Invoices / Receipts / Usage / Members) driven off the account `role` from `billing.get`. The **Members tab only shows for owner/admin**. Per-page breadcrumbs are dropped in favour of the shared chrome.

**Pages**
- **Accounts list** — role-badged account cards + empty state.
- **Overview** — an *amount-due* hero (sum of open invoices) with a prominent **Pay** CTA, latest-invoice card, quick links, and **role-gated management**: Edit billing info = owner/admin, the delete Danger zone = owner-only.
- **Invoices** — status-forward table with an inline **Pay** CTA on open invoices.
- **Receipts** (new) — paid invoices with per-row receipt download.
- **Invoice** — slim back-link instead of the 4-level breadcrumb.
- **Members** (new, owner/admin) — people-with-access list (owner + members with inline role change + remove) and an invite form (email + role). Gated on the account role, not `me.permissions` (billing isn't project IAM); an accountant deep-linking here is redirected to the overview.

Adds `Api.BillingRole` / `BillingMember` / `BillingMemberList` types + a `role` field on `BillingAccount`, a `$lib/billing` role-helper module, mock fixtures, and Playwright coverage (`billing-members.spec.js`) for the members page and role gating.

Consumes deploys-app/api#123 + deploys-app/apiserver#226. UI gating is defense-in-depth; the server enforces authz.

## Test

`bun check` + `bun lint` clean. `billing.spec.js` + `billing-members.spec.js` green (single-worker); full suite 305/310 (the 5 are the known parallel-worker dev-server contention flakes, all pass single-worker). Passed `/scrutinize`.

## Screenshots

**Overview — owner** (amount-due hero, Pay CTA, role-gated Edit + Danger zone), light & dark:

| Light | Dark |
| --- | --- |
| ![overview](https://raw.githubusercontent.com/deploys-app/console/screenshots/316-overview.png) | ![overview-dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/316-overview-dark.png) |

**Overview — accountant** (role-gated: no Members tab, no Edit, no Danger zone; can still Pay/view):

![overview-accountant](https://raw.githubusercontent.com/deploys-app/console/screenshots/316-overview-accountant.png)

**Members** (owner/admin only — people with access, inline role change + remove, invite form):

![members](https://raw.githubusercontent.com/deploys-app/console/screenshots/316-members.png)

**Accounts list** (role badges) · **Invoices** (inline Pay) · **Receipts** (new):

| Accounts | Invoices | Receipts |
| --- | --- | --- |
| ![accounts](https://raw.githubusercontent.com/deploys-app/console/screenshots/316-accounts.png) | ![invoices](https://raw.githubusercontent.com/deploys-app/console/screenshots/316-invoices.png) | ![receipts](https://raw.githubusercontent.com/deploys-app/console/screenshots/316-receipts.png) |

**Mobile** (Overview):

![mobile](https://raw.githubusercontent.com/deploys-app/console/screenshots/316-overview-mobile.png)

**Project create/edit billing picker** now only offers accounts the user can manage (owner/admin) — an accountant sees an account's invoices but can't bill a project to it, matching the server gate.
