### PR TITLE
billing: remove Head Office helper hint under Entity type

### DIFF
--- a/src/routes/(auth)/billing/create/+page.svelte
+++ b/src/routes/(auth)/billing/create/+page.svelte
@@ -94,7 +94,6 @@
 					<option value="company">Company</option>
 				</select>
 			</div>
-			<p class="text-sm text-content/60 mt-1">A company has “Head Office (สำนักงานใหญ่)” printed on its tax invoices and receipts.</p>
 		</div>
 
 		<div class="field">


### PR DESCRIPTION
## What

Removes the helper line under **Entity type** on the billing account create form:

> A company has "Head Office (สำนักงานใหญ่)" printed on its tax invoices and receipts.

## Why

Requested cleanup — the hint is dropped so the Entity type select flows directly into the Tax ID field.

## Scope

- One line removed from `src/routes/(auth)/billing/create/+page.svelte` (the `<p class="text-sm …">` helper). Presentational only — no bindings, logic, or types touched.
- `bun lint` and `bun check` both green.
- No tests reference this text; the Playwright tests that mention "Head Office (สำนักงานใหญ่)" assert on the separate invoice-display page (`/billing/invoice`), which is unchanged.

## Screenshots

Billing create form — before (with hint) vs after (removed):

| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/317-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/317-after.png) |
| --- | --- |