### PR TITLE
billing: fix broken Invite-a-member form controls

### DIFF
--- a/src/routes/(auth)/billing/members/+page.svelte
+++ b/src/routes/(auth)/billing/members/+page.svelte
@@ -110,15 +110,16 @@
 						</div>
 					</div>
 					<div class="member-controls">
-						<select
-							class="select is-size-small"
-							value={m.role}
-							disabled={busyEmail === m.email}
-							onchange={(e) => changeRole(m.email, (e.currentTarget as HTMLSelectElement).value)}
-						>
-							<option value="admin">Admin</option>
-							<option value="accountant">Accountant</option>
-						</select>
+						<div class="select role-select">
+							<select
+								value={m.role}
+								disabled={busyEmail === m.email}
+								onchange={(e) => changeRole(m.email, (e.currentTarget as HTMLSelectElement).value)}
+							>
+								<option value="admin">Admin</option>
+								<option value="accountant">Accountant</option>
+							</select>
+						</div>
 						<button
 							class="button is-variant-tertiary is-size-small icon-only"
 							title="Remove member"
@@ -144,22 +145,25 @@
 		<h5 class="mb-4"><strong>Invite a member</strong></h5>
 		<form class="invite" onsubmit={invite}>
 			<div class="field grow">
-				<label class="label" for="invite-email">Email</label>
-				<input
-					id="invite-email"
-					class="input"
-					type="email"
-					placeholder="accountant@example.com"
-					bind:value={inviteEmail}
-					required
-				/>
+				<label for="invite-email">Email</label>
+				<div class="input">
+					<input
+						id="invite-email"
+						type="email"
+						placeholder="accountant@example.com"
+						bind:value={inviteEmail}
+						required
+					/>
+				</div>
 			</div>
-			<div class="field">
-				<label class="label" for="invite-role">Role</label>
-				<select id="invite-role" class="select" bind:value={inviteRole}>
-					<option value="accountant">Accountant</option>
-					<option value="admin">Admin</option>
-				</select>
+			<div class="field role-field">
+				<label for="invite-role">Role</label>
+				<div class="select">
+					<select id="invite-role" bind:value={inviteRole}>
+						<option value="accountant">Accountant</option>
+						<option value="admin">Admin</option>
+					</select>
+				</div>
 			</div>
 			<div class="field invite-submit">
 				<button class="button is-icon-left" type="submit" class:is-loading={inviting} disabled={inviting}>
@@ -226,6 +230,13 @@
 		gap: 0.5rem;
 	}
 
+	/* Compact, fixed-width role picker in a member row (the .select wrapper is
+	   width:100% by default, which would stretch across the row). */
+	.role-select {
+		width: 10rem;
+		min-height: 2.25rem;
+	}
+
 	.icon-only {
 		color: hsl(var(--hsl-content) / 0.6);
 	}
@@ -249,6 +260,10 @@
 	.invite .grow {
 		flex: 1;
 		min-width: 14rem;
+	}
+
+	.invite .role-field {
+		width: 11rem;
 	}
 
 	.invite-submit {


### PR DESCRIPTION
## Problem

On the billing **Members** page, the invite form's Email input and Role select — and the per-row role pickers — rendered broken: the native `<select>` chevron overlapped the text and the controls were mis-sized.

## Cause

The `.input` and `.select` design-system classes are **wrapper** classes — the padding, border reset, and native-control styling live in the `.input > input` / `.select > select` rules. The members page applied them **directly to the native `<input>`/`<select>` elements** instead of wrapping them, so those child rules never matched.

## Fix

Wrap each control in its `<div class="input">` / `<div class="select">` exactly as the rest of the console does (e.g. `billing/create`), drop the redundant `class="label"` (the `.field > label` rule already styles it), and constrain the role pickers to a fixed width (`.role-select` in the row, `.role-field` in the invite form).

No behavior change — markup/styling only. `bun check` + `bun lint` clean; `billing-members.spec.js` green.

## Screenshots

| Before (broken — chevron overlaps text) | After (fixed) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/318-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/318-after.png) |

Dark mode (after): ![after-dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/318-after-dark.png)