### PR TITLE
ui: normalize the select dropdown arrow across browsers

### DIFF
--- a/src/style/app.css
+++ b/src/style/app.css
@@ -734,6 +734,38 @@
 		font-size: 0.875rem;
 	}
 
+	/* Native <select> arrows render inconsistently across browsers/OSes (Safari
+	 * in particular crams its own control chrome against the right edge). Drop
+	 * the native arrow and draw one custom chevron with a controlled margin, so
+	 * every .select-wrapped picker looks identical everywhere. Extra right
+	 * padding reserves room so long option text never runs under the chevron. */
+	.select {
+		position: relative;
+	}
+
+	.select > select {
+		appearance: none;
+		-webkit-appearance: none;
+		padding-right: 2rem;
+	}
+
+	.select::after {
+		content: '';
+		position: absolute;
+		top: 50%;
+		right: 0.85rem;
+		width: 0.45rem;
+		height: 0.45rem;
+		border-right: 1.5px solid hsl(var(--hsl-content) / 0.55);
+		border-bottom: 1.5px solid hsl(var(--hsl-content) / 0.55);
+		transform: translateY(-65%) rotate(45deg);
+		pointer-events: none;
+	}
+
+	.select:has(> select[disabled])::after {
+		opacity: 0.4;
+	}
+
 	.textarea > textarea {
 		resize: vertical;
 	}


### PR DESCRIPTION
## Problem

After #318 fixed the Members invite form to use the proper `.select` wrapper, the **dropdown arrow margin still looked broken** in real browsers. Root cause: the `.select` wrapper kept the **native `<select>` arrow**, which renders inconsistently across browsers/OSes — Safari/WebKit draws its own control chrome crammed against the right edge, so the arrow margin looked off (Chromium happened to look fine, which is why headless review missed it).

## Fix

Normalize the arrow at the design-system level: `appearance: none` on `.select > select` + one custom chevron drawn via `.select::after` with a controlled right margin, and extra right padding so long option text never runs under it. Every `.select`-wrapped picker (billing create, members, …) now looks identical in every browser.

Scope is limited to native selects wrapped in `.select`. The custom `Select.svelte` combobox (`.select-box` / `.select-chevron`) and any `.input`-wrapped selects are untouched.

`bun check` + `bun lint` clean; `billing-members.spec.js` green.

## Screenshots

**WebKit (Safari engine)** — the native arrow (before) vs the normalized chevron (after):

| Before (native — crammed double-arrow) | After (custom chevron, controlled margin) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/319-before-webkit.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/319-after-webkit.png) |

Full members page (after): ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/319-after.png)

Dark: ![after-dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/319-after-dark.png)