### PR TITLE
billing: fix Back-to-invoices spacing above the invoice panel

### DIFF
--- a/src/routes/(auth)/billing/invoice/+page.svelte
+++ b/src/routes/(auth)/billing/invoice/+page.svelte
@@ -127,6 +127,7 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.5rem;
+		margin-bottom: 1.5rem;
 		color: hsl(var(--hsl-content) / 0.6);
 		text-decoration: none;
 		font-size: 0.9rem;
@@ -142,8 +143,6 @@
 	<i class="fa-solid fa-arrow-left"></i>
 	Back to invoices
 </a>
-
-<br>
 
 <div class="panel is-level-300 grid gap-6">
 	<div class="flex flex-wrap items-center justify-between gap-3">


### PR DESCRIPTION
## Problem

On the invoice detail page, the **"Back to invoices"** link sat almost flush against the invoice panel (~1px gap). The page used a trailing `<br>` for spacing, but a `<br>` after an `inline-flex` element adds no vertical gap before a following block element — so the intended spacing never rendered.

## Fix

Drop the `<br>` and give `.back-link` a real `margin-bottom: 1.5rem`. The link now has proper breathing room above the panel (verified: gap 1px → 24px).

Styling only. `bun check` + `bun lint` clean.

## Screenshots

| Before (~1px — flush against the panel) | After (1.5rem gap) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/320-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/320-after.png) |