### PR TITLE
billing: withholding tax (3%) option in the Pay modal

### DIFF
--- a/src/lib/components/PayInvoiceModal.svelte
+++ b/src/lib/components/PayInvoiceModal.svelte
@@ -12,19 +12,60 @@
 
 	const { onuploaded }: Props = $props()
 
+	// Thai service withholding-tax rate (mirrors api.WithholdingTaxRate). Only a
+	// company buyer may withhold; it is deducted off the pre-VAT subtotal.
+	const WHT_RATE = 0.03
+
 	let invoice = $state<Api.Invoice | null>(null)
 	let isActive = $state(false)
 	let uploading = $state(false)
 	let error = $state('')
 	let selectedFile = $state<File | null>(null)
 	let elFile = $state<HTMLInputElement | null>(null)
+	let withholdTax = $state(false)
+	let certFile = $state<File | null>(null)
+	let elCert = $state<HTMLInputElement | null>(null)
+
+	// Only a company (juristic) buyer may withhold tax. The amount is 3% of the
+	// pre-VAT subtotal, rounded to satang like the server; the net is what to
+	// transfer. Withholding off -> net == total.
+	const isCompany = $derived(invoice?.taxEntityType === 'company')
+	const whtAmount = $derived(
+		withholdTax && invoice ? Math.round(invoice.subtotal * WHT_RATE * 100) / 100 : 0
+	)
+	const netAmount = $derived(invoice ? Math.round((invoice.total - whtAmount) * 100) / 100 : 0)
 
 	export function open (inv: Api.Invoice): void {
 		invoice = inv
 		selectedFile = null
+		withholdTax = false
+		certFile = null
 		error = ''
 		if (elFile) elFile.value = ''
+		if (elCert) elCert.value = ''
 		isActive = true
+	}
+
+	function onToggleWithhold (e: Event) {
+		withholdTax = (e.currentTarget as HTMLInputElement).checked
+		// Clearing the election drops any attached certificate too.
+		if (!withholdTax) {
+			certFile = null
+			if (elCert) elCert.value = ''
+		}
+	}
+
+	function onCertChange (e: Event) {
+		const input = e.currentTarget as HTMLInputElement
+		const f = input.files?.[0] ?? null
+		error = ''
+		if (f && f.size > MAX_SIZE) {
+			error = 'Certificate is too large (max 10 MB).'
+			certFile = null
+			input.value = ''
+			return
+		}
+		certFile = f
 	}
 
 	function close () {
@@ -62,6 +103,8 @@
 			const fd = new FormData()
 			fd.append('id', invoice.id)
 			fd.append('slip', selectedFile)
+			if (isCompany) fd.append('withholdingTax', String(withholdTax))
+			if (withholdTax && certFile) fd.append('whtCert', certFile)
 			const resp = await fetch('/api/billing.uploadTransferSlip', {
 				method: 'POST',
 				body: fd
@@ -104,7 +147,14 @@
 				<div class="pay-to-title">Transfer to</div>
 				<div class="pay-grid">
 					<div class="pay-key">Amount due</div>
-					<div class="font-semibold tabular-nums">{money(invoice.total, invoice.currency)}</div>
+					<div>
+						<div class="font-semibold tabular-nums">{money(netAmount, invoice.currency)}</div>
+						{#if withholdTax}
+							<div class="wht-note tabular-nums">
+								{money(invoice.total, invoice.currency)} less {WHT_RATE * 100}% withholding {money(whtAmount, invoice.currency)}
+							</div>
+						{/if}
+					</div>
 					<div class="pay-key">Bank</div>
 					<div>{invoice.payment.bank}</div>
 					<div class="pay-key">Account name</div>
@@ -119,9 +169,50 @@
 				     so no wrapper/spacing is rendered for non-THB invoices. -->
 				<PromptPayQR
 					promptPay={invoice.payment.promptPay}
-					amount={invoice.total}
+					amount={netAmount}
 					currency={invoice.currency}
 				/>
+			</div>
+		{/if}
+
+		{#if isCompany}
+			<div class="wht mt-4">
+				<label class="checkbox">
+					<input type="checkbox" checked={withholdTax} onchange={onToggleWithhold}>
+					<span>Withhold 3% tax (หัก ณ ที่จ่าย)</span>
+				</label>
+				<p class="mt-1 text-content/60 text-sm">
+					For a company withholding tax on this payment: transfer the net amount above and,
+					if you have it, attach the withholding tax certificate (50 ทวิ). The invoice is still
+					settled in full.
+				</p>
+
+				{#if withholdTax}
+					<input
+						bind:this={elCert}
+						class="hidden-input"
+						type="file"
+						accept="image/*,application/pdf"
+						onchange={onCertChange}
+					>
+					<button
+						type="button"
+						class="button is-variant-secondary is-icon-left is-size-small mt-3"
+						onclick={() => elCert?.click()}
+					>
+						<i class="fa-solid fa-paperclip"></i>
+						Attach WHT certificate (optional)
+					</button>
+					{#if certFile}
+						<div class="selected-file mt-2">
+							<i class="fa-solid fa-file-lines file-icon"></i>
+							<div class="file-meta">
+								<div class="file-name">{certFile.name}</div>
+								<div class="file-size">{fileSize(certFile.size)}</div>
+							</div>
+						</div>
+					{/if}
+				{/if}
 			</div>
 		{/if}
 
@@ -206,6 +297,12 @@
 
 	.pay-grid .pay-key {
 		color: hsl(var(--hsl-content) / 0.65);
+	}
+
+	.wht-note {
+		margin-top: 0.15rem;
+		font-size: var(--fs-1);
+		color: hsl(var(--hsl-content) / 0.6);
 	}
 
 	.selected-file {

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -1422,7 +1422,18 @@ const handlers: Record<string, (args: any) => object> = {
 	'billing.listInvoices': () => list(invoices.map(invoiceListItem)),
 	'billing.getInvoice': (args) => {
 		const inv = invoices.find((i) => i.id === args?.invoiceId) ?? invoices[0]
-		return ok({ ...inv, receiptNumber: receiptNumberFor(inv), taxEntityType: 'company', payment: mockPayment })
+		// Demo a 3% withholding-tax deduction on a paid (company) invoice so the
+		// receipt/totals show the offline-dev case; unpaid invoices carry none.
+		const withholdingTaxAmount = inv.status === 'paid' ? Math.round(inv.subtotal * 0.03 * 100) / 100 : 0
+		const withholdingTaxRate = withholdingTaxAmount > 0 ? 0.03 : 0
+		return ok({
+			...inv,
+			receiptNumber: receiptNumberFor(inv),
+			taxEntityType: 'company',
+			withholdingTaxRate,
+			withholdingTaxAmount,
+			payment: mockPayment
+		})
 	},
 	'billing.downloadInvoice': (args) => {
 		const inv = invoices.find((i) => i.id === args?.invoiceId) ?? invoices[0]

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -1476,6 +1476,10 @@ const handlers: Record<string, (args: any) => object> = {
 		downloadUrl: 'https://dropbox.deploys.app/files/mock-slip.jpg',
 		expiresAt: '2026-06-02T00:00:00Z'
 	}),
+	'billing.uploadWHTCertificate': () => ok({
+		downloadUrl: 'https://dropbox.deploys.app/files/mock-whtcert.pdf',
+		expiresAt: '2027-05-31T00:00:00Z'
+	}),
 
 	'auditLog.list': (args) => {
 		let arr = auditLogItems

--- a/src/routes/(auth)/billing/invoice/+page.svelte
+++ b/src/routes/(auth)/billing/invoice/+page.svelte
@@ -79,6 +79,7 @@
 	}
 
 	const taxRatePct = $derived(`${(invoice.taxRate * 100).toLocaleString(undefined, { maximumFractionDigits: 2 })}%`)
+	const whtRatePct = $derived(`${(invoice.withholdingTaxRate * 100).toLocaleString(undefined, { maximumFractionDigits: 2 })}%`)
 </script>
 
 <style>
@@ -256,6 +257,10 @@
 			<div class="value">{money(invoice.taxAmount)}</div>
 			<div class="grand label">Total</div>
 			<div class="grand value">{money(invoice.total)}</div>
+			{#if invoice.withholdingTaxAmount > 0}
+				<div class="label">Withholding tax ({whtRatePct})</div>
+				<div class="value">−{money(invoice.withholdingTaxAmount)}</div>
+			{/if}
 		</div>
 	</div>
 

--- a/src/routes/(auth)/billing/invoice/+page.svelte
+++ b/src/routes/(auth)/billing/invoice/+page.svelte
@@ -65,6 +65,45 @@
 		}
 	}
 
+	// Attach a withholding-tax certificate after the fact (company invoices). Shown
+	// while the invoice is still open (may withhold) or once it was paid with
+	// withholding — for customers who send the 50 ทวิ certificate later.
+	const MAX_CERT_SIZE = 10 * 1024 * 1024
+	let attachingCert = $state(false)
+	let elCert = $state<HTMLInputElement | null>(null)
+	const canAttachCert = $derived(
+		invoice.taxEntityType === 'company' &&
+		(invoice.status === 'open' || invoice.withholdingTaxAmount > 0)
+	)
+
+	async function onCertChange (e: Event) {
+		const input = e.currentTarget as HTMLInputElement
+		const file = input.files?.[0] ?? null
+		input.value = ''
+		if (!file) return
+		if (file.size > MAX_CERT_SIZE) {
+			await modal.error({ error: 'Certificate is too large (max 10 MB).' })
+			return
+		}
+		attachingCert = true
+		try {
+			const fd = new FormData()
+			fd.append('id', invoice.id)
+			fd.append('whtCert', file)
+			const resp = await fetch('/api/billing.uploadWHTCertificate', { method: 'POST', body: fd })
+			const res = await resp.json().catch(() => null)
+			if (!resp.ok || !res?.ok) {
+				await modal.error({ error: res?.error?.message ? res.error : `Upload failed (${resp.status}).` })
+				return
+			}
+			await modal.success({ content: 'Withholding tax certificate attached.' })
+		} catch (err) {
+			await modal.error({ error: err })
+		} finally {
+			attachingCert = false
+		}
+	}
+
 	const periodLabel = $derived.by(() => {
 		const s = dayjs(invoice.periodStart)
 		const e = dayjs(invoice.periodEnd).subtract(1, 'day')
@@ -171,6 +210,24 @@
 				>
 					<i class="fa-solid fa-file-invoice"></i>
 					Download receipt
+				</button>
+			{/if}
+			{#if canAttachCert}
+				<input
+					bind:this={elCert}
+					class="hidden"
+					type="file"
+					accept="image/*,application/pdf"
+					onchange={onCertChange}
+				>
+				<button
+					class="button is-variant-secondary is-icon-left"
+					class:is-loading={attachingCert}
+					disabled={attachingCert}
+					onclick={() => elCert?.click()}
+				>
+					<i class="fa-solid fa-file-contract"></i>
+					Attach WHT certificate
 				</button>
 			{/if}
 			{#if invoice.status === 'open'}

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -709,6 +709,11 @@ declare namespace Api {
         // taxEntityType is the buyer's entity type snapshotted at issue time.
         // 'company' prints the Head Office line on the bill-to block.
         taxEntityType: BillingAccountType
+        // withholdingTaxRate / withholdingTaxAmount record a 3% withholding tax a
+        // company buyer deducted at payment (ภาษีหัก ณ ที่จ่าย); 0 for a normal or
+        // unpaid invoice. Settled in full when paidAmount + withholdingTaxAmount ≥ total.
+        withholdingTaxRate: number
+        withholdingTaxAmount: number
         issuedAt: string
         paidAt: string
         voidedAt: string

--- a/tests/billing.spec.js
+++ b/tests/billing.spec.js
@@ -200,6 +200,28 @@ test.describe('invoice detail', () => {
 		await expect(modal.getByText('Withhold 3% tax')).toHaveCount(0)
 	})
 
+	test('shows the Attach WHT certificate button on a company invoice paid with withholding', async ({ page }) => {
+		await setMocks({
+			'billing.getInvoice': {
+				ok: true,
+				result: { ...sampleInvoice, status: 'paid', paidAt: '2026-05-03T00:00:00Z', withholdingTaxRate: 0.03, withholdingTaxAmount: 0.3 }
+			},
+			'billing.get': { ok: true, result: sampleBillingAccount }
+		})
+		await page.goto('/billing/invoice?id=inv-1')
+		// Company + paid-with-WHT → the customer can still attach the 50 ทวิ certificate later.
+		await expect(page.getByRole('button', { name: /Attach WHT certificate/ })).toBeVisible()
+	})
+
+	test('hides the Attach WHT certificate button for an individual invoice', async ({ page }) => {
+		await setMocks({
+			'billing.getInvoice': { ok: true, result: { ...sampleInvoice, taxEntityType: 'individual' } },
+			'billing.get': { ok: true, result: sampleBillingAccount }
+		})
+		await page.goto('/billing/invoice?id=inv-1')
+		await expect(page.getByRole('button', { name: /Attach WHT certificate/ })).toHaveCount(0)
+	})
+
 	test('shows a PromptPay QR in the pay modal for a THB invoice', async ({ page }) => {
 		await setMocks({
 			// PromptPay settles in THB, so the QR only renders for THB invoices.
@@ -240,7 +262,8 @@ test.describe('invoice detail', () => {
 
 		// A long, unbreakable (no-spaces) name is the worst case: without min-width:0
 		// on the selected-file row it pushes the whole modal wider than its panel.
-		await page.locator('input[type=file]').setInputFiles({
+		// Scope to the modal's slip input (the invoice page also has a cert input).
+		await page.locator('.modal.is-active input[type=file]').setInputFiles({
 			name: 'transfer-slip-payment-confirmation-screenshot-from-mobile-banking-app-INV-2026-0009-original-highres.pdf',
 			mimeType: 'application/pdf',
 			buffer: Buffer.from('%PDF-1.4 mock slip')

--- a/tests/billing.spec.js
+++ b/tests/billing.spec.js
@@ -166,6 +166,40 @@ test.describe('invoice detail', () => {
 		await expect(modal.getByText('0812345678')).toBeVisible()
 	})
 
+	test('pay modal offers a 3% withholding-tax option for a company invoice', async ({ page }) => {
+		await setMocks({
+			'billing.getInvoice': { ok: true, result: sampleInvoice }, // company, open, total 10.70
+			'billing.get': { ok: true, result: sampleBillingAccount }
+		})
+
+		await page.goto('/billing/invoice?id=inv-1')
+		await page.getByRole('button', { name: 'Pay' }).click()
+
+		const modal = page.locator('.modal.is-active .modal-panel')
+		// Amount due starts at the full total.
+		await expect(modal.getByText('10.70 USD')).toBeVisible()
+
+		// Electing 3% withholding drops the net to transfer (10.70 − 0.30 = 10.40),
+		// shows the breakdown, and reveals the certificate attach button.
+		await modal.getByText('Withhold 3% tax').click()
+		await expect(modal.getByText('10.40 USD')).toBeVisible()
+		await expect(modal.getByText('less 3% withholding')).toBeVisible()
+		await expect(modal.getByRole('button', { name: /Attach WHT certificate/ })).toBeVisible()
+	})
+
+	test('pay modal hides withholding tax for an individual invoice', async ({ page }) => {
+		await setMocks({
+			'billing.getInvoice': { ok: true, result: { ...sampleInvoice, taxEntityType: 'individual' } },
+			'billing.get': { ok: true, result: sampleBillingAccount }
+		})
+
+		await page.goto('/billing/invoice?id=inv-1')
+		await page.getByRole('button', { name: 'Pay' }).click()
+
+		const modal = page.locator('.modal.is-active .modal-panel')
+		await expect(modal.getByText('Withhold 3% tax')).toHaveCount(0)
+	})
+
 	test('shows a PromptPay QR in the pay modal for a THB invoice', async ({ page }) => {
 		await setMocks({
 			// PromptPay settles in THB, so the QR only renders for THB invoices.

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -381,6 +381,8 @@ export const sampleInvoice = {
 	taxName: 'Acme Co',
 	taxAddress: '',
 	taxEntityType: 'company',
+	withholdingTaxRate: 0,
+	withholdingTaxAmount: 0,
 	issuedAt: now,
 	paidAt: '0001-01-01T00:00:00Z',
 	voidedAt: '0001-01-01T00:00:00Z',


### PR DESCRIPTION
## What

Lets a **company (juristic) buyer** elect to withhold **3% tax** (ภาษีหัก ณ ที่จ่าย) when paying an invoice, and attach the withholding-tax certificate (50 ทวิ) either with the slip or **later**. Server: deploys-app/apiserver#227; contract: deploys-app/api#124.

## Changes

- **`PayInvoiceModal.svelte`** — company invoice only: a `Withhold 3% tax` checkbox. Ticking it recomputes **Amount due** to the net (`Total − round(subtotal × 3%)`) with a breakdown line, updates the **PromptPay QR** to the net, and reveals an optional **WHT certificate** upload. The election + cert ride on the existing multipart slip upload (`withholdingTax` + `whtCert`).
- **`billing/invoice/+page.svelte`** — a paid invoice's totals show a `Withholding tax (3%) −฿…` line; and a new **Attach WHT certificate** button (company invoice that is `open` or was paid with withholding) uploads the cert on its own via `billing.uploadWHTCertificate` — for customers who send the 50 ทวิ later.
- **`types/api.d.ts`** — `Api.Invoice` gains `withholdingTaxRate` / `withholdingTaxAmount`.
- **mock + Playwright** — mock demos a 3% deduction on paid invoices + a `uploadWHTCertificate` handler; specs cover the company (checkbox → net + cert button) / individual (hidden) cases and the attach-cert button gating.

## Verification

`bun check` (0 errors), `bun lint` (clean), `bun run test tests/billing.spec.js` — **22 passed** (incl. WHT modal, attach-cert gating, and slip-truncate rescoped for the second file input).

## Screenshots

Pay modal — withholding **off** vs **on** (net + breakdown + QR + certificate upload):

| off | on |
| --- | --- |
| ![off](https://raw.githubusercontent.com/deploys-app/console/screenshots/321-pay-modal-off.png) | ![on](https://raw.githubusercontent.com/deploys-app/console/screenshots/321-pay-modal-on.png) |

Paid invoice — WHT totals line + **Attach WHT certificate** button:

![paid](https://raw.githubusercontent.com/deploys-app/console/screenshots/321-invoice-paid.png)

![attach](https://raw.githubusercontent.com/deploys-app/console/screenshots/321-invoice-attach.png)