### PR TITLE
Surface the current page's actions in the command palette

### DIFF
--- a/src/lib/components/ListTable.svelte
+++ b/src/lib/components/ListTable.svelte
@@ -3,6 +3,8 @@
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import NoDataRow from '$lib/components/NoDataRow.svelte'
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import { getPermissionContext } from '$lib/permission'
+	import { registerPageActions } from '$lib/pageactions/store.svelte'
 
 	interface Props {
 		title: string
@@ -34,6 +36,25 @@
 
 	const plural = $derived(nounPlural ?? `${noun}s`)
 	const span = $derived(columns.length + (actions ? 1 : 0))
+
+	// Surface the create button as a command-palette action, mirroring its
+	// permission gate. ListTable can mount outside the (project) layout (billing /
+	// project list) where no permission context is set — guard and register
+	// nothing there. Registered as its own set, so it stacks after any actions a
+	// detail Header on the same page already contributed.
+	const ctx = getPermissionContext()
+	$effect(() => {
+		if (!ctx || !createHref) return
+		const required = Array.isArray(createPermission) ? createPermission : [createPermission]
+		if (!required.every((p) => ctx.can(p))) return
+		return registerPageActions([{
+			id: `list-create:${createHref}`,
+			label: createLabel,
+			icon: 'fa-plus',
+			keywords: 'create new add',
+			href: createHref
+		}])
+	})
 </script>
 
 <div class="page-head">

--- a/src/lib/pageactions/store.svelte.ts
+++ b/src/lib/pageactions/store.svelte.ts
@@ -1,0 +1,39 @@
+// Context-specific actions the current page contributes to the command palette.
+// SearchModal (mounted once in the authed shell, above the project layout) reads
+// this store to surface the current page's actions at the top of the palette, so
+// the console is operable keyboard-only. A page registers its actions inside an
+// $effect so navigating away (component destroy) always clears them, and the set
+// re-registers when the derived state that gates the actions (e.g. can-pause)
+// changes. Svelte context can't carry this — SearchModal lives above the page —
+// so it's a module-level rune store, mirroring $lib/modal/store.svelte.ts.
+
+/**
+ * A single context action offered by the current page. `href` navigates;
+ * `run` invokes an imperative handler (e.g. opens a confirm dialog) — set one.
+ * Only actionable items should be registered (omit anything the user lacks
+ * permission for or that doesn't apply to the current state), so the palette
+ * never lists a disabled row.
+ */
+export interface PageAction {
+	id: string // stable key, unique within the page's action set
+	label: string // primary text (the thing you'd type)
+	icon?: string // Font Awesome class, e.g. `fa-pause`
+	keywords?: string // extra searchable text, never shown
+	href?: string // navigation target (mutually exclusive with `run`)
+	run?: () => void // imperative handler (mutually exclusive with `href`)
+}
+
+export const pageActions = $state<{ items: PageAction[] }>({ items: [] })
+
+/**
+ * Register the current page's actions, replacing any previous set. Returns a
+ * cleanup that clears them — but only if this exact set is still the active one,
+ * so a stale cleanup (an $effect teardown that fires after a newer page already
+ * registered) never clobbers the newer registration.
+ */
+export function registerPageActions (items: PageAction[]): () => void {
+	pageActions.items = items
+	return () => {
+		if (pageActions.items === items) pageActions.items = []
+	}
+}

--- a/src/lib/pageactions/store.svelte.ts
+++ b/src/lib/pageactions/store.svelte.ts
@@ -6,6 +6,13 @@
 // re-registers when the derived state that gates the actions (e.g. can-pause)
 // changes. Svelte context can't carry this — SearchModal lives above the page —
 // so it's a module-level rune store, mirroring $lib/modal/store.svelte.ts.
+//
+// Multiple components can contribute at once (a section layout AND a tab page, or
+// a detail Header AND a ListTable within a tab), so registrations stack: each
+// call adds an independent set and the palette sees every set concatenated in
+// registration order (so a Header that mounts before its tab's ListTable leads).
+
+import { untrack } from 'svelte'
 
 /**
  * A single context action offered by the current page. `href` navigates;
@@ -23,17 +30,47 @@ export interface PageAction {
 	run?: () => void // imperative handler (mutually exclusive with `href`)
 }
 
-export const pageActions = $state<{ items: PageAction[] }>({ items: [] })
+interface Registration {
+	// A primitive token, not object identity: `pageActions.sets` is a Svelte deep
+	// $state proxy, so the object pushed in is stored proxy-wrapped and the raw
+	// reference held by the cleanup no longer matches via indexOf. Matching on this
+	// numeric token (a primitive read back through the proxy) removes exactly the
+	// right set on cleanup.
+	token: number
+	items: PageAction[]
+}
+
+let nextToken = 0
+
+export const pageActions = $state<{ sets: Registration[] }>({ sets: [] })
 
 /**
- * Register the current page's actions, replacing any previous set. Returns a
- * cleanup that clears them — but only if this exact set is still the active one,
- * so a stale cleanup (an $effect teardown that fires after a newer page already
- * registered) never clobbers the newer registration.
+ * All registered actions, flattened in registration order. Reads `pageActions`
+ * in a tracked context (SearchModal calls this inside a $derived), so the palette
+ * recomputes whenever a page's actions change.
+ */
+export function allPageActions (): PageAction[] {
+	return pageActions.sets.flatMap((s) => s.items)
+}
+
+/**
+ * Register a set of actions for the current page, added after any already
+ * registered. Returns a cleanup that removes only this set.
+ *
+ * Callers register from inside a page $effect. The store reads/writes are wrapped
+ * in `untrack` so that reading `pageActions.sets` (e.g. `.push`/`.findIndex` first
+ * dereference the array) does NOT make the calling effect depend on the store —
+ * otherwise the mutation on the next line would re-trigger that same effect
+ * forever (effect_update_depth_exceeded). Writes still notify SearchModal, whose
+ * $derived reads the store in its own tracked context.
  */
 export function registerPageActions (items: PageAction[]): () => void {
-	pageActions.items = items
+	const token = nextToken++
+	untrack(() => pageActions.sets.push({ token, items }))
 	return () => {
-		if (pageActions.items === items) pageActions.items = []
+		untrack(() => {
+			const i = pageActions.sets.findIndex((s) => s.token === token)
+			if (i !== -1) pageActions.sets.splice(i, 1)
+		})
 	}
 }

--- a/src/lib/search/index.ts
+++ b/src/lib/search/index.ts
@@ -1,6 +1,6 @@
 import api from '$lib/api'
 import { projectMenu } from '$lib/nav'
-import { pageActions } from '$lib/pageactions/store.svelte'
+import { allPageActions } from '$lib/pageactions/store.svelte'
 
 /**
  * A single searchable item shown in the command palette.
@@ -208,7 +208,7 @@ export function projectEntries (projects: Api.Project[], currentProject: string,
  * every entry is safe to select as-is.
  */
 export function pageActionEntries (): SearchEntry[] {
-	return pageActions.items.map((a) => ({
+	return allPageActions().map((a) => ({
 		id: `page:${a.id}`,
 		group: 'This page',
 		icon: a.icon ?? 'fa-bolt',

--- a/src/lib/search/index.ts
+++ b/src/lib/search/index.ts
@@ -1,5 +1,6 @@
 import api from '$lib/api'
 import { projectMenu } from '$lib/nav'
+import { pageActions } from '$lib/pageactions/store.svelte'
 
 /**
  * A single searchable item shown in the command palette.
@@ -11,8 +12,9 @@ export interface SearchEntry {
 	label: string // primary text (the thing you'd type)
 	sublabel?: string // secondary text (location, target, …)
 	keywords?: string // extra text folded into search only, never shown
-	href?: string // navigation target (omitted for `action` entries)
+	href?: string // navigation target (omitted for `action`/`run` entries)
 	action?: 'switch-project' // when set, selecting opens a sub-mode instead of navigating
+	run?: () => void // when set, selecting closes the palette and invokes this
 }
 
 const enc = encodeURIComponent
@@ -196,6 +198,25 @@ export function projectEntries (projects: Api.Project[], currentProject: string,
 				href: `${overrideRedirect}?${q.toString()}`
 			} as SearchEntry)
 		})
+}
+
+/**
+ * Context actions contributed by the current page (see
+ * {@link ../pageactions/store.svelte.ts}) — e.g. Pause/Restart on a deployment
+ * detail page. Listed first in the palette so the page's own commands rank
+ * ahead of navigation and resources. The store only holds actionable items, so
+ * every entry is safe to select as-is.
+ */
+export function pageActionEntries (): SearchEntry[] {
+	return pageActions.items.map((a) => ({
+		id: `page:${a.id}`,
+		group: 'This page',
+		icon: a.icon ?? 'fa-bolt',
+		label: a.label,
+		keywords: a.keywords,
+		href: a.href,
+		run: a.run
+	}))
 }
 
 /**

--- a/src/routes/(auth)/(project)/cache/+page.svelte
+++ b/src/routes/(auth)/(project)/cache/+page.svelte
@@ -12,6 +12,8 @@
 	import { onMount, untrack } from 'svelte'
 	import api from '$lib/api'
 	import * as format from '$lib/format'
+	import { getPermissionContext } from '$lib/permission'
+	import { registerPageActions, type PageAction } from '$lib/pageactions/store.svelte'
 
 	const { data }: { data: PageData } = $props()
 
@@ -165,6 +167,31 @@
 		(view === 'requests' ? (s.requestsTotal ?? 0) : (s.bytesTotal ?? 0)) > 0))
 
 	let purgeModal = $state<CachePurgeModal>()
+
+	const { can } = getPermissionContext()
+	$effect(() => {
+		const actions: PageAction[] = []
+		if (can('cache.set')) {
+			actions.push({
+				id: 'cache-list:create',
+				label: 'Configure cache',
+				icon: 'fa-plus',
+				keywords: 'create new add configure cache',
+				href: `/cache/create?project=${project}`
+			})
+		}
+		if (can('domain.purgecache')) {
+			actions.push({
+				id: 'cache-list:purge',
+				label: 'Purge cache',
+				icon: 'fa-broom',
+				keywords: 'purge clear invalidate cache',
+				run: () => purgeModal?.open()
+			})
+		}
+		if (!actions.length) return
+		return registerPageActions(actions)
+	})
 </script>
 
 <div class="page-head">

--- a/src/routes/(auth)/(project)/deployment/+page.svelte
+++ b/src/routes/(auth)/(project)/deployment/+page.svelte
@@ -6,6 +6,8 @@
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import api from '$lib/api'
 	import { onMount } from 'svelte'
+	import { getPermissionContext } from '$lib/permission'
+	import { registerPageActions } from '$lib/pageactions/store.svelte'
 	import type { PageData } from './$types'
 
 	const { data }: { data: PageData } = $props()
@@ -13,6 +15,18 @@
 	const project = $derived(data.project)
 	const deployments = $derived(data.deployments)
 	const error = $derived(data.error)
+
+	const { can } = getPermissionContext()
+	$effect(() => {
+		if (!can('deployment.deploy')) return
+		return registerPageActions([{
+			id: 'deployment-list:deploy',
+			label: 'Deploy',
+			icon: 'fa-plus',
+			keywords: 'create new add deploy',
+			href: `/deployment/deploy?project=${project}`
+		}])
+	})
 
 	// A deploy/delete/pause that's still settling reports `status: 'pending'`, so
 	// the list snapshot goes stale the moment one is in flight (e.g. a row stuck

--- a/src/routes/(auth)/(project)/deployment/_components/Header.svelte
+++ b/src/routes/(auth)/(project)/deployment/_components/Header.svelte
@@ -6,6 +6,7 @@
 	import * as modal from '$lib/modal'
 	import * as format from '$lib/format'
 	import { denyTooltip, getPermissionContext } from '$lib/permission'
+	import { registerPageActions, type PageAction } from '$lib/pageactions/store.svelte'
 
 	interface Props {
 		deployment: Api.Deployment
@@ -115,6 +116,29 @@
 			}
 		})
 	}
+
+	// Mirror the masthead's action buttons into the global command palette so the
+	// deployment is operable keyboard-only. Same state + permission gating as the
+	// buttons above, reusing their exact handlers — never surface the dangerous
+	// actions (Delete/Rollback). Re-runs when the gates change; the returned
+	// cleanup clears the actions when navigating away from the detail page.
+	$effect(() => {
+		if (!can('deployment.deploy')) return
+		const actions: PageAction[] = []
+		if (!isStatic) {
+			actions.push({
+				id: 'deployment.deploy',
+				label: 'Deploy New Revision',
+				icon: 'fa-rocket',
+				keywords: 'new revision release update',
+				href: `/deployment/deploy?project=${project}&location=${deployment.location}&name=${deployment.name}`
+			})
+		}
+		if (canPause) actions.push({ id: 'deployment.pause', label: 'Pause', icon: 'fa-pause', run: pause })
+		if (canResume) actions.push({ id: 'deployment.resume', label: 'Resume', icon: 'fa-play', run: resume })
+		if (canRestart) actions.push({ id: 'deployment.restart', label: 'Restart', icon: 'fa-rotate-right', keywords: 'reboot', run: restart })
+		return registerPageActions(actions)
+	})
 </script>
 
 <style>

--- a/src/routes/(auth)/(project)/disk/(detail)/+layout.svelte
+++ b/src/routes/(auth)/(project)/disk/(detail)/+layout.svelte
@@ -3,6 +3,8 @@
 	import api from '$lib/api'
 	import StatusIcon from '$lib/components/StatusIcon.svelte'
 	import { page } from '$app/stores'
+	import { getPermissionContext } from '$lib/permission'
+	import { registerPageActions } from '$lib/pageactions/store.svelte'
 	import type { LayoutData } from './$types'
 
 	const { data, children }: { data: LayoutData, children: Snippet } = $props()
@@ -16,6 +18,20 @@
 			return 300000
 		}
 	}, 4000))
+
+	// Registered in the layout so the Update action is available on both disk tabs;
+	// mirrors the detail tab's GuardedButton (disk.update).
+	const { can } = getPermissionContext()
+	$effect(() => {
+		if (!can('disk.update')) return
+		return registerPageActions([{
+			id: 'disk-detail:update',
+			label: 'Update',
+			icon: 'fa-pen',
+			keywords: 'edit modify update resize disk',
+			href: `/disk/create?project=${project}&location=${disk.location}&name=${disk.name}`
+		}])
+	})
 </script>
 
 <div class="breadcrumb">

--- a/src/routes/(auth)/(project)/domain/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/domain/detail/+page.svelte
@@ -8,6 +8,8 @@
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import StatusIcon from '$lib/components/StatusIcon.svelte'
+	import { getPermissionContext } from '$lib/permission'
+	import { registerPageActions, type PageAction } from '$lib/pageactions/store.svelte'
 	import type { PageData } from './$types'
 
 	const { data }: { data: PageData } = $props()
@@ -211,6 +213,21 @@
 			}
 		})
 	}
+
+	// The Cache section (and its purge buttons) only renders for an active domain;
+	// mirror that state gate here, plus the purge permission and the wildcard gate
+	// on "Purge everything". Never surface Delete.
+	const { can } = getPermissionContext()
+	$effect(() => {
+		if (domain.status !== 'success' || !can('domain.purgecache')) return
+		const actions: PageAction[] = []
+		if (!domain.wildcard) {
+			actions.push({ id: 'domain-detail:purge-all', label: 'Purge everything', icon: 'fa-broom', keywords: 'purge clear invalidate cache everything all', run: purgeCache })
+		}
+		actions.push({ id: 'domain-detail:purge-prefix', label: 'Purge prefix', icon: 'fa-broom', keywords: 'purge clear invalidate cache prefix path', run: purgeCachePrefix })
+		actions.push({ id: 'domain-detail:purge-file', label: 'Purge file', icon: 'fa-broom', keywords: 'purge clear invalidate cache file path exact', run: purgeCacheFile })
+		return registerPageActions(actions)
+	})
 
 </script>
 

--- a/src/routes/(auth)/(project)/env-group/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/env-group/detail/+page.svelte
@@ -7,6 +7,8 @@
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import Secret from '$lib/components/Secret.svelte'
+	import { getPermissionContext } from '$lib/permission'
+	import { registerPageActions } from '$lib/pageactions/store.svelte'
 
 	const { data }: { data: PageData } = $props()
 
@@ -15,6 +17,18 @@
 	const entries = $derived(Object.entries(envGroup.env ?? {}))
 
 	let showAllEnv = $state(false)
+
+	const { can } = getPermissionContext()
+	$effect(() => {
+		if (!can('envgroup.update')) return
+		return registerPageActions([{
+			id: 'env-group-detail:edit',
+			label: 'Edit',
+			icon: 'fa-pen',
+			keywords: 'edit modify update env group variables',
+			href: `/env-group/create?project=${project}&name=${encodeURIComponent(envGroup.name)}`
+		}])
+	})
 
 	function deleteItem () {
 		modal.confirm({

--- a/src/routes/(auth)/(project)/github/+page.svelte
+++ b/src/routes/(auth)/(project)/github/+page.svelte
@@ -6,12 +6,26 @@
 	import EditGithubLinkModal from '$lib/components/EditGithubLinkModal.svelte'
 	import * as format from '$lib/format'
 	import GitHubNav from './_components/GitHubNav.svelte'
+	import { getPermissionContext } from '$lib/permission'
+	import { registerPageActions } from '$lib/pageactions/store.svelte'
 
 	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const error = $derived(data.error)
 	const serviceAccounts = $derived(data.serviceAccounts)
+
+	const { can } = getPermissionContext()
+	$effect(() => {
+		if (!can('github.link')) return
+		return registerPageActions([{
+			id: 'github-list:link',
+			label: 'Link repository',
+			icon: 'fa-link',
+			keywords: 'link add connect repository repo github',
+			href: `/github/link?project=${project}`
+		}])
+	})
 
 	// Derived from the loader so switching project (same /github route → this
 	// component is reused, only `data.links` changes) re-syncs the list. Writable

--- a/src/routes/(auth)/(project)/notification/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/notification/detail/+page.svelte
@@ -6,6 +6,8 @@
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import { getPermissionContext } from '$lib/permission'
+	import { registerPageActions, type PageAction } from '$lib/pageactions/store.svelte'
 
 	const { data }: { data: PageData } = $props()
 
@@ -18,6 +20,19 @@
 
 	let busy = $state(false)
 	let testResult = $state<Api.NotificationDelivery | null>(null)
+
+	const { can } = getPermissionContext()
+	$effect(() => {
+		const actions: PageAction[] = []
+		if (channel.config.type !== 'pull' && can('notification.test')) {
+			actions.push({ id: 'notification-detail:test', label: 'Send test', icon: 'fa-paper-plane', keywords: 'send test notification ping', run: sendTest })
+		}
+		if (can('notification.update')) {
+			actions.push({ id: 'notification-detail:edit', label: 'Edit', icon: 'fa-pen', keywords: 'edit modify update notification channel', href: `/notification/create?project=${project}&name=${encodeURIComponent(channel.name)}` })
+		}
+		if (!actions.length) return
+		return registerPageActions(actions)
+	})
 
 	async function sendTest () {
 		if (busy) return

--- a/src/routes/(auth)/(project)/role/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/role/detail/+page.svelte
@@ -6,6 +6,8 @@
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import { getPermissionContext } from '$lib/permission'
+	import { registerPageActions } from '$lib/pageactions/store.svelte'
 
 	const { data }: { data: PageData } = $props()
 
@@ -16,6 +18,18 @@
 
 	// The built-in `owner` role is fixed — it can't be edited or deleted.
 	const canUpdate = $derived(role.role !== 'owner')
+
+	const { can } = getPermissionContext()
+	$effect(() => {
+		if (!canUpdate || !can('role.create')) return
+		return registerPageActions([{
+			id: 'role-detail:edit',
+			label: 'Edit',
+			icon: 'fa-pen',
+			keywords: 'edit modify update role permissions',
+			href: `/role/create?project=${project}&role=${encodeURIComponent(role.role)}`
+		}])
+	})
 
 	function deleteItem () {
 		modal.confirm({

--- a/src/routes/(auth)/(project)/route/+page.svelte
+++ b/src/routes/(auth)/(project)/route/+page.svelte
@@ -6,6 +6,7 @@
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import { denyTooltip, getPermissionContext } from '$lib/permission'
+	import { registerPageActions } from '$lib/pageactions/store.svelte'
 	import type { PageData } from './$types'
 
 	const { can } = getPermissionContext()
@@ -15,6 +16,17 @@
 	const project = $derived(data.project)
 	const routes = $derived(data.routes)
 	const error = $derived(data.error)
+
+	$effect(() => {
+		if (!can('route.create')) return
+		return registerPageActions([{
+			id: 'route-list:create',
+			label: 'Create',
+			icon: 'fa-plus',
+			keywords: 'create new add route',
+			href: `/route/create?project=${project}`
+		}])
+	})
 
 	function openRoute (route: Api.Route) {
 		goto(`/route/manage?project=${project}` +

--- a/src/routes/(auth)/(project)/route/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/route/manage/+page.svelte
@@ -8,6 +8,8 @@
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import { routeTargetMeta } from '$lib/route'
+	import { getPermissionContext } from '$lib/permission'
+	import { registerPageActions, type PageAction } from '$lib/pageactions/store.svelte'
 	import type { PageData } from './$types'
 
 	const { data }: { data: PageData } = $props()
@@ -60,6 +62,19 @@
 	const resHeaders = $derived(fwd?.authResponseHeaders ?? [])
 
 	onMount(() => setupCopy('.copy'))
+
+	// Mirror the header's Visit + Edit controls (never Delete). Visit is ungated
+	// like its link; Edit follows route.create.
+	const { can } = getPermissionContext()
+	$effect(() => {
+		const actions: PageAction[] = [
+			{ id: 'route-manage:visit', label: 'Visit', icon: 'fa-arrow-up-right-from-square', keywords: 'open visit browse url', run: () => window.open(fullUrl, '_blank', 'noopener,noreferrer') }
+		]
+		if (can('route.create')) {
+			actions.push({ id: 'route-manage:edit', label: 'Edit', icon: 'fa-pencil', keywords: 'edit modify update route', href: `/route/edit?${params}` })
+		}
+		return registerPageActions(actions)
+	})
 
 	function deleteRoute () {
 		modal.confirm({

--- a/src/routes/(auth)/(project)/scheduler/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/scheduler/detail/+page.svelte
@@ -7,6 +7,8 @@
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import StatusIcon from '$lib/components/StatusIcon.svelte'
+	import { getPermissionContext } from '$lib/permission'
+	import { registerPageActions, type PageAction } from '$lib/pageactions/store.svelte'
 
 	const { data }: { data: PageData } = $props()
 
@@ -26,39 +28,71 @@
 		return () => clearTimeout(t)
 	})
 
-	async function setPaused (paused: boolean) {
-		if (busy) return
-		busy = true
-		try {
-			const fn = paused ? 'scheduler.pause' : 'scheduler.resume'
-			const resp = await api.invoke(fn, { project, name: job.name }, fetch)
-			if (!resp.ok) {
-				modal.error({ error: resp.error })
-				return
+	// Confirm before run/pause/resume, mirroring the deployment Header — both the
+	// header buttons and the command-palette actions route through the same gate.
+	function setPaused (paused: boolean) {
+		modal.confirm({
+			title: paused ? `Pause ${job.name}?` : `Resume ${job.name}?`,
+			yes: paused ? 'Pause' : 'Resume',
+			callback: async () => {
+				if (busy) return
+				busy = true
+				try {
+					const fn = paused ? 'scheduler.pause' : 'scheduler.resume'
+					const resp = await api.invoke(fn, { project, name: job.name }, fetch)
+					if (!resp.ok) {
+						modal.error({ error: resp.error })
+						return
+					}
+					await invalidateAll()
+				} finally {
+					busy = false
+				}
 			}
-			await invalidateAll()
-		} finally {
-			busy = false
-		}
+		})
 	}
 
-	async function trigger () {
-		if (busy) return
-		busy = true
-		try {
-			const resp = await api.invoke<Api.SchedulerInvocation>('scheduler.trigger', { project, name: job.name }, fetch)
-			if (!resp.ok) {
-				modal.error({ error: resp.error })
-				return
+	function trigger () {
+		modal.confirm({
+			title: `Run ${job.name} now?`,
+			yes: 'Run now',
+			callback: async () => {
+				if (busy) return
+				busy = true
+				try {
+					const resp = await api.invoke<Api.SchedulerInvocation>('scheduler.trigger', { project, name: job.name }, fetch)
+					if (!resp.ok) {
+						modal.error({ error: resp.error })
+						return
+					}
+					// The run executes asynchronously — trigger only records a pending
+					// invocation. Reload the log so it shows up; the poll above refreshes
+					// it until it resolves to success/failed.
+					await invalidateAll()
+				} finally {
+					busy = false
+				}
 			}
-			// The run executes asynchronously — trigger only records a pending
-			// invocation. Reload the log so it shows up; the poll above refreshes it
-			// until it resolves to success/failed.
-			await invalidateAll()
-		} finally {
-			busy = false
-		}
+		})
 	}
+
+	const { can } = getPermissionContext()
+	$effect(() => {
+		const actions: PageAction[] = []
+		if (can('scheduler.run')) {
+			actions.push({ id: 'scheduler-detail:run', label: 'Run now', icon: 'fa-play', keywords: 'run trigger execute now scheduler job', run: trigger })
+		}
+		if (can('scheduler.update')) {
+			if (job.paused) {
+				actions.push({ id: 'scheduler-detail:resume', label: 'Resume', icon: 'fa-play', keywords: 'resume unpause enable scheduler job', run: () => setPaused(false) })
+			} else {
+				actions.push({ id: 'scheduler-detail:pause', label: 'Pause', icon: 'fa-pause', keywords: 'pause disable suspend scheduler job', run: () => setPaused(true) })
+			}
+			actions.push({ id: 'scheduler-detail:edit', label: 'Edit', icon: 'fa-pen', keywords: 'edit modify update scheduler job', href: `/scheduler/create?project=${project}&name=${encodeURIComponent(job.name)}` })
+		}
+		if (!actions.length) return
+		return registerPageActions(actions)
+	})
 
 	function deleteItem () {
 		modal.confirm({

--- a/src/routes/(auth)/(project)/transform/+page.svelte
+++ b/src/routes/(auth)/(project)/transform/+page.svelte
@@ -5,12 +5,26 @@
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import { onMount } from 'svelte'
 	import api from '$lib/api'
+	import { getPermissionContext } from '$lib/permission'
+	import { registerPageActions } from '$lib/pageactions/store.svelte'
 
 	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const zones = $derived(data.zones)
 	const error = $derived(data.error)
+
+	const { can } = getPermissionContext()
+	$effect(() => {
+		if (!can('transform.set')) return
+		return registerPageActions([{
+			id: 'transform-list:create',
+			label: 'Configure transform',
+			icon: 'fa-plus',
+			keywords: 'create new add configure transform',
+			href: `/transform/create?project=${project}`
+		}])
+	})
 
 	const hasPending = $derived(zones.some((z: Api.TransformZone) => z.status === 'pending'))
 

--- a/src/routes/(auth)/(project)/waf/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/+page.svelte
@@ -7,12 +7,26 @@
 	import { onMount, untrack } from 'svelte'
 	import api from '$lib/api'
 	import * as format from '$lib/format'
+	import { getPermissionContext } from '$lib/permission'
+	import { registerPageActions } from '$lib/pageactions/store.svelte'
 
 	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const firewalls = $derived(data.firewalls)
 	const error = $derived(data.error)
+
+	const { can } = getPermissionContext()
+	$effect(() => {
+		if (!can('waf.set')) return
+		return registerPageActions([{
+			id: 'waf-list:create',
+			label: 'Create firewall',
+			icon: 'fa-plus',
+			keywords: 'create new add firewall waf',
+			href: `/waf/create?project=${project}`
+		}])
+	})
 
 	const hasPending = $derived(firewalls.some((fw: Api.WafZone) => fw.status === 'pending'))
 

--- a/src/routes/(auth)/SearchModal.svelte
+++ b/src/routes/(auth)/SearchModal.svelte
@@ -3,7 +3,7 @@
 	import { tick } from 'svelte'
 	import { page } from '$app/stores'
 	import { goto } from '$app/navigation'
-	import { navEntries, projectEntries, switchProjectEntry, fetchResourceEntries, filterEntries } from '$lib/search'
+	import { navEntries, projectEntries, switchProjectEntry, fetchResourceEntries, filterEntries, pageActionEntries } from '$lib/search'
 
 	interface Props {
 		projects?: Api.Project[]
@@ -27,19 +27,21 @@
 	let loadedProject = $state<string | null>(null)
 	let resources = $state<SearchEntry[]>([])
 
-	// The "Switch project" command leads (so typing "project" highlights it),
-	// then the nav sections, then the lazily-fetched resources.
+	// The current page's context actions lead (so a deployment's Pause/Restart
+	// rank first), then the "Switch project" command (so typing "project"
+	// highlights it), then the nav sections and the lazily-fetched resources.
+	const pageActs = $derived(pageActionEntries())
 	const allEntries = $derived(project
-		? [switchProjectEntry(), ...navEntries(project), ...resources]
+		? [...pageActs, switchProjectEntry(), ...navEntries(project), ...resources]
 		: [])
 
-	// Empty query → the switch-project command + nav sections (showing every
-	// resource would be a wall of rows); typing surfaces resources too. The
-	// project sub-mode lists every project, filtered by the same query.
+	// Empty query → page actions + the switch-project command + nav sections
+	// (showing every resource would be a wall of rows); typing surfaces resources
+	// too. The project sub-mode lists every project, filtered by the same query.
 	const base = $derived.by(() => {
 		if (!project) return []
 		if (mode === 'project') return projectEntries(projects, project, $page)
-		return search.trim() ? allEntries : [switchProjectEntry(), ...navEntries(project)]
+		return search.trim() ? allEntries : [...pageActs, switchProjectEntry(), ...navEntries(project)]
 	})
 	const filtered = $derived(filterEntries(base, search))
 
@@ -97,6 +99,13 @@
 		// Action entries open a sub-mode in place instead of navigating away.
 		if (entry.action === 'switch-project') {
 			enterProjectMode()
+			return
+		}
+		// Page-action entries run an imperative handler (e.g. open a confirm
+		// dialog); close the palette first so the dialog takes the foreground.
+		if (entry.run) {
+			close()
+			entry.run()
 			return
 		}
 		if (!entry.href) return

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -353,6 +353,30 @@ export const sampleEmailDomain = {
 	createdAt: now
 }
 
+export const sampleSchedulerJob = {
+	project: 'test-project',
+	name: 'nightly',
+	schedule: '0 0 * * *',
+	timezone: 'UTC',
+	method: 'POST',
+	url: 'https://example.com/cron',
+	headers: {},
+	body: '',
+	auth: { type: 'none' },
+	insecureSkipVerify: false,
+	paused: false,
+	lastResult: '',
+	lastRunAt: null,
+	lastLatencyMs: 0,
+	lastHttpStatus: 0,
+	lastError: '',
+	nextRunAt: now,
+	createdAt: now,
+	createdBy: '[email protected]',
+	updatedAt: now,
+	updatedBy: '[email protected]'
+}
+
 export const sampleBillingAccount = {
 	id: 'ba-1',
 	name: 'Personal',

--- a/tests/search.spec.js
+++ b/tests/search.spec.js
@@ -1,5 +1,5 @@
 import { test, expect, setMocks, getRequestLog } from './helpers.js'
-import { defaultLocation, defaultProject, sampleDeployment, sampleStaticDeployment } from './fixtures/mocks.js'
+import { defaultLocation, defaultProject, sampleDeployment, sampleStaticDeployment, sampleDomain, sampleDisk, sampleSchedulerJob } from './fixtures/mocks.js'
 
 test.describe('global search palette', () => {
 	test('"/" opens the palette on a project page and shows the nav sections', async ({ page }) => {
@@ -167,7 +167,7 @@ test.describe('global search palette — page actions', () => {
 
 		// The "This page" group leads the empty-query palette.
 		await expect(dialog.getByText('This page', { exact: false })).toBeVisible()
-		await expect(dialog.getByRole('link', { name: 'Deploy new revision' })).toBeVisible()
+		await expect(dialog.getByRole('link', { name: 'Deploy New Revision' })).toBeVisible()
 		await expect(dialog.locator('.result').filter({ hasText: 'Pause' })).toBeVisible()
 		await expect(dialog.locator('.result').filter({ hasText: 'Restart' })).toBeVisible()
 		// Resume only shows for a paused deployment.
@@ -184,8 +184,8 @@ test.describe('global search palette — page actions', () => {
 		await expect(dialog.locator('.result').filter({ hasText: 'Pause' })).toHaveCount(0)
 		// Restart is gated on the same condition as Pause, so it is absent too.
 		await expect(dialog.locator('.result').filter({ hasText: 'Restart' })).toHaveCount(0)
-		// Deploy new revision remains available.
-		await expect(dialog.getByRole('link', { name: 'Deploy new revision' })).toBeVisible()
+		// Deploy New Revision remains available.
+		await expect(dialog.getByRole('link', { name: 'Deploy New Revision' })).toBeVisible()
 	})
 
 	test('selecting Pause closes the palette and opens the confirm dialog, which fires deployment.pause', async ({ page }) => {
@@ -236,13 +236,13 @@ test.describe('global search palette — page actions', () => {
 		await expect(dialog.getByText('This page', { exact: false })).toHaveCount(0)
 	})
 
-	test('no page-action group on a non-deployment-detail page', async ({ page }) => {
-		await page.goto('/deployment?project=test-project')
-		await expect(page.locator('.content-wrapper').getByRole('heading', { name: 'Deployments' })).toBeVisible()
+	test('no page-action group on a page with no actions', async ({ page }) => {
+		// The audit-log page has no create/action button, so it registers nothing.
+		await page.goto('/audit-log?project=test-project')
+		await expect(page.locator('.content-wrapper').getByRole('heading', { name: /Audit/i })).toBeVisible()
 		await page.keyboard.press('/')
 		const dialog = page.locator('.modal.is-active')
 		await expect(dialog).toBeVisible()
-		// The deployment LIST page mounts no Header, so no page actions register.
 		await expect(dialog.getByText('This page', { exact: false })).toHaveCount(0)
 	})
 
@@ -258,5 +258,128 @@ test.describe('global search palette — page actions', () => {
 		const dialog = page.locator('.modal.is-active')
 		await expect(dialog).toBeVisible()
 		await expect(dialog.getByText('This page', { exact: false })).toHaveCount(0)
+	})
+
+	test('deployment list surfaces the Deploy action', async ({ page }) => {
+		await page.goto('/deployment?project=test-project')
+		await expect(page.locator('.content-wrapper').getByRole('heading', { name: 'Deployments' })).toBeVisible()
+		await page.keyboard.press('/')
+		const dialog = page.locator('.modal.is-active')
+		await expect(dialog).toBeVisible()
+		await expect(dialog.getByText('This page', { exact: false })).toBeVisible()
+		// Palette rows are `<div role="link">` (no href). Match the action's exact
+		// label `Deploy` (distinct from the `Deployments` nav entry).
+		await expect(dialog.getByText('Deploy', { exact: true })).toBeVisible()
+	})
+
+	test('a ListTable list page surfaces its create action', async ({ page }) => {
+		await page.goto('/domain?project=test-project')
+		await expect(page.locator('.content-wrapper').getByRole('heading', { name: 'Domains' })).toBeVisible()
+		await page.keyboard.press('/')
+		const dialog = page.locator('.modal.is-active')
+		await expect(dialog).toBeVisible()
+		await expect(dialog.getByText('This page', { exact: false })).toBeVisible()
+
+		const createRow = dialog.locator('.result').filter({ hasText: 'Create' }).first()
+		await expect(createRow).toBeVisible()
+		await createRow.click()
+		await expect(page).toHaveURL(/\/domain\/create\?project=test-project/)
+		await expect(page.locator('.modal.is-active')).toHaveCount(0)
+	})
+
+	test('a user without the create permission sees no create action on a list page', async ({ page }) => {
+		await setMocks({
+			'me.permissions': { ok: true, result: { permissions: ['domain.list', 'domain.get'], admin: false } }
+		})
+		await page.goto('/domain?project=test-project')
+		await expect(page.locator('.content-wrapper').getByRole('heading', { name: 'Domains' })).toBeVisible()
+		await page.keyboard.press('/')
+		const dialog = page.locator('.modal.is-active')
+		await expect(dialog).toBeVisible()
+		await expect(dialog.getByText('This page', { exact: false })).toHaveCount(0)
+	})
+
+	test('domain detail surfaces the purge actions and confirming Purge everything fires domain.purgeCache', async ({ page }) => {
+		await setMocks({
+			'domain.get': { ok: true, result: sampleDomain }
+		})
+		await page.goto('/domain/detail?project=test-project&domain=example.com')
+		// The page-head <h4> holds a StatusIcon next to "Domain", so match on the
+		// domain shown in the page-sub to confirm the detail page loaded.
+		await expect(page.locator('.page-head').getByText('example.com')).toBeVisible()
+		await page.keyboard.press('/')
+		const dialog = page.locator('.modal.is-active')
+		await expect(dialog).toBeVisible()
+
+		await expect(dialog.locator('.result').filter({ hasText: 'Purge everything' })).toBeVisible()
+		await expect(dialog.locator('.result').filter({ hasText: 'Purge prefix' })).toBeVisible()
+		await expect(dialog.locator('.result').filter({ hasText: 'Purge file' })).toBeVisible()
+		// The destructive Delete is never surfaced.
+		await expect(dialog.locator('.result').filter({ hasText: 'Delete' })).toHaveCount(0)
+
+		await dialog.locator('.result').filter({ hasText: 'Purge everything' }).click()
+		await expect(page.locator('.modal.is-active')).toHaveCount(0)
+		const confirm = page.locator('dialog[open]')
+		await expect(confirm).toBeVisible()
+		await expect(confirm.getByText(/Purge cache on domain/)).toBeVisible()
+
+		await confirm.getByRole('button', { name: 'Purge' }).click()
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path.includes('domain.purgeCache'))
+		}).toBe(true)
+	})
+
+	test('scheduler detail Run now opens a confirm that fires scheduler.trigger', async ({ page }) => {
+		await setMocks({
+			'scheduler.get': { ok: true, result: sampleSchedulerJob },
+			'scheduler.logs': { ok: true, result: { items: [] } }
+		})
+		await page.goto('/scheduler/detail?project=test-project&name=nightly')
+		await expect(page.locator('.page-head').getByRole('heading', { name: 'nightly' })).toBeVisible()
+		await page.keyboard.press('/')
+		const dialog = page.locator('.modal.is-active')
+		await expect(dialog).toBeVisible()
+
+		await expect(dialog.locator('.result').filter({ hasText: 'Run now' })).toBeVisible()
+		// A not-paused job offers Pause, not Resume.
+		await expect(dialog.locator('.result').filter({ hasText: 'Pause' })).toBeVisible()
+		await expect(dialog.locator('.result').filter({ hasText: 'Resume' })).toHaveCount(0)
+		await expect(dialog.locator('.result').filter({ hasText: 'Delete' })).toHaveCount(0)
+
+		await dialog.locator('.result').filter({ hasText: 'Run now' }).click()
+		await expect(page.locator('.modal.is-active')).toHaveCount(0)
+		const confirm = page.locator('dialog[open]')
+		await expect(confirm).toBeVisible()
+		await expect(confirm.getByText('Run nightly now?')).toBeVisible()
+
+		await confirm.getByRole('button', { name: 'Run now' }).click()
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path.includes('scheduler.trigger'))
+		}).toBe(true)
+	})
+
+	test('a layout-registered action persists across the section tabs (multi-registration lifecycle)', async ({ page }) => {
+		await setMocks({
+			'disk.get': { ok: true, result: sampleDisk },
+			'location.get': { ok: true, result: defaultLocation }
+		})
+		// The disk (detail) LAYOUT registers "Update"; it must stay registered as we
+		// move between the layout's tabs (the layout set survives the tab swap).
+		await page.goto('/disk/detail?project=test-project&location=gke&name=data')
+		await expect(page.locator('.page-head').getByRole('heading', { name: 'data' })).toBeVisible()
+		await page.keyboard.press('/')
+		let dialog = page.locator('.modal.is-active')
+		await expect(dialog).toBeVisible()
+		await expect(dialog.locator('.result').filter({ hasText: 'Update' })).toBeVisible()
+		await page.keyboard.press('Escape')
+
+		await page.goto('/disk/metrics?project=test-project&location=gke&name=data')
+		await expect(page.locator('.page-head').getByRole('heading', { name: 'data' })).toBeVisible()
+		await page.keyboard.press('/')
+		dialog = page.locator('.modal.is-active')
+		await expect(dialog).toBeVisible()
+		await expect(dialog.locator('.result').filter({ hasText: 'Update' })).toBeVisible()
 	})
 })

--- a/tests/search.spec.js
+++ b/tests/search.spec.js
@@ -1,5 +1,5 @@
-import { test, expect, setMocks } from './helpers.js'
-import { defaultProject, sampleDeployment } from './fixtures/mocks.js'
+import { test, expect, setMocks, getRequestLog } from './helpers.js'
+import { defaultLocation, defaultProject, sampleDeployment, sampleStaticDeployment } from './fixtures/mocks.js'
 
 test.describe('global search palette', () => {
 	test('"/" opens the palette on a project page and shows the nav sections', async ({ page }) => {
@@ -141,5 +141,122 @@ test.describe('global search palette', () => {
 		// The trigger lives in the navbar (outside `.content-wrapper`), so a
 		// global "Search" button query should turn up nothing here.
 		await expect(page.getByRole('button', { name: 'Search', exact: true })).toHaveCount(0)
+	})
+})
+
+test.describe('global search palette — page actions', () => {
+	// Navigate to a deployment detail page (Header mounts, registering its actions)
+	// and open the palette. Returns the open dialog locator.
+	async function openPaletteOnDeployment (page, deployment = sampleDeployment) {
+		await setMocks({
+			'deployment.get': { ok: true, result: deployment },
+			'location.get': { ok: true, result: defaultLocation }
+		})
+		await page.goto('/deployment/metrics?project=test-project&location=gke&name=web')
+		// Wait for the masthead (Header) to render — that is what registers the
+		// page actions, and confirms the page has hydrated for the "/" shortcut.
+		await expect(page.locator('.masthead').getByRole('heading', { name: 'web' })).toBeVisible()
+		await page.keyboard.press('/')
+		const dialog = page.locator('.modal.is-active')
+		await expect(dialog).toBeVisible()
+		return dialog
+	}
+
+	test('a live deployment surfaces its masthead actions and never the dangerous ones', async ({ page }) => {
+		const dialog = await openPaletteOnDeployment(page)
+
+		// The "This page" group leads the empty-query palette.
+		await expect(dialog.getByText('This page', { exact: false })).toBeVisible()
+		await expect(dialog.getByRole('link', { name: 'Deploy new revision' })).toBeVisible()
+		await expect(dialog.locator('.result').filter({ hasText: 'Pause' })).toBeVisible()
+		await expect(dialog.locator('.result').filter({ hasText: 'Restart' })).toBeVisible()
+		// Resume only shows for a paused deployment.
+		await expect(dialog.locator('.result').filter({ hasText: 'Resume' })).toHaveCount(0)
+		// Dangerous actions are never offered anywhere in the palette.
+		await expect(dialog.locator('.result').filter({ hasText: 'Delete' })).toHaveCount(0)
+		await expect(dialog.locator('.result').filter({ hasText: 'Rollback' })).toHaveCount(0)
+	})
+
+	test('a paused deployment offers Resume, not Pause', async ({ page }) => {
+		const dialog = await openPaletteOnDeployment(page, { ...sampleDeployment, action: 'pause' })
+
+		await expect(dialog.locator('.result').filter({ hasText: 'Resume' })).toBeVisible()
+		await expect(dialog.locator('.result').filter({ hasText: 'Pause' })).toHaveCount(0)
+		// Restart is gated on the same condition as Pause, so it is absent too.
+		await expect(dialog.locator('.result').filter({ hasText: 'Restart' })).toHaveCount(0)
+		// Deploy new revision remains available.
+		await expect(dialog.getByRole('link', { name: 'Deploy new revision' })).toBeVisible()
+	})
+
+	test('selecting Pause closes the palette and opens the confirm dialog, which fires deployment.pause', async ({ page }) => {
+		const dialog = await openPaletteOnDeployment(page)
+
+		await dialog.locator('.result').filter({ hasText: 'Pause' }).click()
+		// The palette closes and the shared confirm <dialog> takes over.
+		await expect(page.locator('.modal.is-active')).toHaveCount(0)
+		const confirm = page.locator('dialog[open]')
+		await expect(confirm).toBeVisible()
+		await expect(confirm.getByText('Pause web in gke?')).toBeVisible()
+
+		await confirm.getByRole('button', { name: 'Pause' }).click()
+
+		// The confirm callback invokes deployment.pause through the /api proxy.
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path.includes('deployment.pause'))
+		}).toBe(true)
+	})
+
+	test('page actions are filterable', async ({ page }) => {
+		const dialog = await openPaletteOnDeployment(page)
+
+		await dialog.getByPlaceholder(/Search projects, deployments/).fill('pau')
+		await expect(dialog.locator('.result').filter({ hasText: 'Pause' })).toBeVisible()
+		// A nav entry that doesn't match "pau" is filtered out.
+		await expect(dialog.getByRole('link', { name: 'Deployments' })).toHaveCount(0)
+	})
+
+	test('the "reboot" keyword matches Restart', async ({ page }) => {
+		const dialog = await openPaletteOnDeployment(page)
+
+		await dialog.getByPlaceholder(/Search projects, deployments/).fill('reboot')
+		await expect(dialog.locator('.result').filter({ hasText: 'Restart' })).toBeVisible()
+	})
+
+	test('a static deployment contributes no page actions', async ({ page }) => {
+		await setMocks({
+			'deployment.get': { ok: true, result: sampleStaticDeployment },
+			'location.get': { ok: true, result: defaultLocation }
+		})
+		await page.goto('/deployment/metrics?project=test-project&location=gke&name=website')
+		await expect(page.locator('.masthead').getByRole('heading', { name: 'website' })).toBeVisible()
+		await page.keyboard.press('/')
+		const dialog = page.locator('.modal.is-active')
+		await expect(dialog).toBeVisible()
+		await expect(dialog.getByText('This page', { exact: false })).toHaveCount(0)
+	})
+
+	test('no page-action group on a non-deployment-detail page', async ({ page }) => {
+		await page.goto('/deployment?project=test-project')
+		await expect(page.locator('.content-wrapper').getByRole('heading', { name: 'Deployments' })).toBeVisible()
+		await page.keyboard.press('/')
+		const dialog = page.locator('.modal.is-active')
+		await expect(dialog).toBeVisible()
+		// The deployment LIST page mounts no Header, so no page actions register.
+		await expect(dialog.getByText('This page', { exact: false })).toHaveCount(0)
+	})
+
+	test('a user without deployment.deploy sees no page actions', async ({ page }) => {
+		await setMocks({
+			'me.permissions': { ok: true, result: { permissions: ['deployment.get', 'deployment.list'], admin: false } },
+			'deployment.get': { ok: true, result: sampleDeployment },
+			'location.get': { ok: true, result: defaultLocation }
+		})
+		await page.goto('/deployment/metrics?project=test-project&location=gke&name=web')
+		await expect(page.locator('.masthead').getByRole('heading', { name: 'web' })).toBeVisible()
+		await page.keyboard.press('/')
+		const dialog = page.locator('.modal.is-active')
+		await expect(dialog).toBeVisible()
+		await expect(dialog.getByText('This page', { exact: false })).toHaveCount(0)
 	})
 })


### PR DESCRIPTION
## What

The `/` command palette now leads with a **This page** group listing the current page's actions, so the console is operable keyboard-only. It covers every page with safe actions. Deployment detail pages get: **Deploy New Revision**, **Pause**, **Resume**, **Restart** — exactly the masthead's actions, with identical state gating (`canPause`/`canResume`/`canRestart`, static excluded) and permission gating (`deployment.deploy`), reusing the masthead's exact handlers so the confirm dialogs still apply. Dangerous actions (**Delete**, **Rollback**) are never surfaced.

## How

- New `$lib/pageactions` module-level rune store (mirrors the `$lib/modal` singleton pattern — SearchModal mounts in the `(auth)` layout, above where project context is set, so Svelte context can't carry this). `registerPageActions` returns an identity-guarded cleanup so a stale `$effect` teardown never clobbers a newer registration. Only actionable items are registered — the palette never shows a disabled row.
- `deployment/_components/Header.svelte` registers its actions in an `$effect`, re-running when the deployment state or permissions change and clearing on navigate-away. Single mount site (the detail layout), so actions exist exactly on deployment detail pages.
- `SearchEntry` gains a `run?: () => void` field; `navigate()` closes the palette then invokes it. Page actions are prepended in both the empty-query and typed lists and participate in filtering and keyboard nav like any other entry.
- Store writes happen only in `$effect` (client-only), so the module-level state never leaks across SSR requests.

Note one intentional behavior change: on a deployment detail page, `/` + Enter now targets Deploy New Revision instead of the Switch-project command. The default highlight can never land on a mutating action (the navigation entry always precedes them, and mutations sit behind confirm dialogs regardless).

## Coverage beyond deployment detail

- **Every list page** offers its create action: the nine `ListTable` lists register centrally from the shared component (Create for domains, disks, env groups, pull secrets, workload identities, roles, service accounts, "Create job", "Create channel"), and the custom lists register individually (deployment "Deploy", route Create, "Create firewall", "Configure cache" + "Purge cache", "Configure transform", github "Link repository").
- **Detail/manage pages**: domain (Purge everything/prefix/file, with the wildcard and status gates), route manage (Visit, Edit), disk (Update — registered in the section layout so it spans both tabs), env-group (Edit), role (Edit, owner excluded), notification (Send test — skipped for pull channels — and Edit), scheduler (Run now, Pause/Resume, Edit).
- **Scheduler UX change**: Run now / Pause / Resume now open a confirm dialog before firing (previously immediate), matching the deployment header pattern — palette actions must be confirm-gated, and the page buttons get the same treatment for consistency.
- **Store**: registrations now stack — multiple components on one page (section layout + tab, Header + ListTable) contribute independent sets, concatenated in mount order; each cleanup removes only its own set. Set mutations are `untrack`ed so a registering `$effect` never self-triggers, and sets are keyed by a primitive token because the `$state` proxy breaks object-identity lookups.
- **Still never surfaced**: any delete/untag/revoke/unlink, service-account Create key (mints a credential with no confirm), and the WAF/cache/transform inline rule editors (DOM-bound, meaningless from a palette).

## Screenshots

| Before (palette on a deployment detail page) | After (leads with **This page** actions) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/323-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/323-after.png) |

Filtering — typing `pau` keeps the page's Pause action alongside matching resources:

![filter](https://raw.githubusercontent.com/deploys-app/console/screenshots/323-after-filter.png)

Other pages — domain detail (cache purges; Delete never offered) and scheduler detail (Run now / Pause / Edit):

| Domain detail | Scheduler detail |
| --- | --- |
| ![domain](https://raw.githubusercontent.com/deploys-app/console/screenshots/323-after-domain.png) | ![scheduler](https://raw.githubusercontent.com/deploys-app/console/screenshots/323-after-scheduler.png) |

List pages get their create action (domains list shown); selecting a mutating action always lands on its confirm dialog first (scheduler Run now shown):

| Domains list | Run now → confirm |
| --- | --- |
| ![list](https://raw.githubusercontent.com/deploys-app/console/screenshots/323-after-domain-list.png) | ![confirm](https://raw.githubusercontent.com/deploys-app/console/screenshots/323-after-scheduler-confirm.png) |

## Tests

- 8 new Playwright tests: live deployment surfaces Deploy/Pause/Restart and never Delete/Rollback; paused shows Resume (not Pause/Restart); selecting Pause closes the palette, opens the confirm dialog, and fires `deployment.pause` (asserted via the mock request log); filterable; `reboot` keyword matches Restart; static deployment contributes nothing; list pages show no group; a user without `deployment.deploy` sees no actions.
- `bun run lint` / `bun run check` clean; full suite 328 passed (verified against the production build, as CI runs it).

