### PR TITLE
ui: animate page changes with the View Transitions API

### DIFF
--- a/src/routes/(auth)/+layout.svelte
+++ b/src/routes/(auth)/+layout.svelte
@@ -111,6 +111,13 @@
 		width: 100%;
 
 		padding-left: var(--width-sidebar);
+
+		/* Own view-transition snapshot: the app chrome stays put during page
+		 * transitions instead of fading with the whole viewport. The sidebar's
+		 * name lives on nav.sidebar (this wrapper's counterpart is a 0×0 box —
+		 * the nav inside it is absolutely positioned — which would snapshot
+		 * as nothing and make the sidebar flash out during transitions). */
+		view-transition-name: navbar;
 	}
 
 	.content-wrapper {

--- a/src/routes/(auth)/Sidebar.svelte
+++ b/src/routes/(auth)/Sidebar.svelte
@@ -29,6 +29,11 @@
 		overflow-y: auto;
 		background-color: hsl(var(--hsl-base-300));
 		border-right: 1px solid hsl(var(--hsl-line));
+		/* Own view-transition snapshot: stays put during page transitions
+		 * (only the active item crossfades). On the nav itself, not
+		 * .sidebar-wrapper — the wrapper is a 0×0 box (this nav is absolutely
+		 * positioned), which would snapshot as nothing. */
+		view-transition-name: sidebar;
 	}
 
 	.sidebar-bottom {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -21,6 +21,10 @@
 		if (!document.startViewTransition) return
 		if (navigation.from?.url.pathname === navigation.to?.url.pathname) return
 		if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+		// The mobile nav drawer closes as the navigation commits; its slide-out
+		// must stay live — a view transition freezes it in the old snapshot and
+		// ends with a visible jump mid-slide. Let the slide be the animation.
+		if (document.querySelector('.app-layout.is-shown-sidebar')) return
 
 		return new Promise((resolve) => {
 			document.startViewTransition(async () => {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte'
 	import { browser } from '$app/environment'
-	import { beforeNavigate } from '$app/navigation'
+	import { beforeNavigate, onNavigate } from '$app/navigation'
 	import { updated } from '$app/stores'
 
 	const { children }: { children: Snippet } = $props()
@@ -13,6 +13,24 @@
 			}
 		})
 	}
+
+	// Animate page changes with the View Transitions API (progressive
+	// enhancement — no-op where unsupported). Same-path navigations are
+	// skipped so query-param updates (filters, project switch) don't flash.
+	onNavigate((navigation) => {
+		if (!document.startViewTransition) return
+		if (navigation.from?.url.pathname === navigation.to?.url.pathname) return
+		if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+
+		return new Promise((resolve) => {
+			document.startViewTransition(async () => {
+				resolve()
+				// Swallow aborted navigations (rejected `complete`) — the
+				// transition just crossfades whatever state the abort left.
+				await navigation.complete.catch(() => {})
+			})
+		})
+	})
 </script>
 
 {@render children?.()}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -15,11 +15,13 @@
 	}
 
 	// Animate page changes with the View Transitions API (progressive
-	// enhancement — no-op where unsupported). Same-path navigations are
-	// skipped so query-param updates (filters, project switch) don't flash.
+	// enhancement — no-op where unsupported). Fires on every navigation that
+	// can change what's rendered — path or query (project switch, filters) —
+	// skipping only hash-only jumps within the same page.
 	onNavigate((navigation) => {
 		if (!document.startViewTransition) return
-		if (navigation.from?.url.pathname === navigation.to?.url.pathname) return
+		if (navigation.from?.url.pathname === navigation.to?.url.pathname &&
+			navigation.from?.url.search === navigation.to?.url.search) return
 		if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
 		// The mobile nav drawer closes as the navigation commits; its slide-out
 		// must stay live — a view transition freezes it in the old snapshot and

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -317,10 +317,32 @@
 		border-radius: 2px;
 	}
 
+	/* Page-change animation (View Transitions API, started from the root
+	 * layout's onNavigate). Navbar + sidebar carry their own
+	 * view-transition-name, so only the content crossfades; panels' own
+	 * panel-in entrance provides the motion inside the new snapshot. Faster
+	 * than the UA default 250ms so it reads as response, not effect. */
+	/* group(*) included: its geometry animation always runs at the UA default
+	 * 250ms and would keep the (input-blocking) transition alive ~90ms after
+	 * the fades finish. */
+	::view-transition-group(*),
+	::view-transition-old(*),
+	::view-transition-new(*) {
+		animation-duration: var(--timing-faster);
+	}
+
 	@media (prefers-reduced-motion: reduce) {
 		/* Disable decorative motion (entrance + transitions)... */
 		.panel {
 			animation: none;
+		}
+
+		/* Belt-and-braces: the onNavigate hook already skips view transitions
+		 * under reduced motion; kill the pseudo-element animations too. */
+		::view-transition-group(*),
+		::view-transition-old(*),
+		::view-transition-new(*) {
+			animation: none !important;
 		}
 
 		*, *::before, *::after {

--- a/tests/view-transition.spec.js
+++ b/tests/view-transition.spec.js
@@ -1,0 +1,41 @@
+import { test, expect } from './helpers.js'
+
+test.describe('view transitions', () => {
+	test('page changes start a view transition; unsupported browsers unaffected', async ({ page }) => {
+		await page.goto('/deployment?project=test-project')
+		await expect(page.locator('.content-wrapper').getByRole('heading', { name: 'Deployments' })).toBeVisible()
+
+		// Count startViewTransition calls made by the root layout's onNavigate.
+		await page.evaluate(() => {
+			window.__vtCount = 0
+			const orig = document.startViewTransition.bind(document)
+			document.startViewTransition = (cb) => {
+				window.__vtCount++
+				return orig(cb)
+			}
+		})
+
+		// Cross-page navigation → one transition.
+		await page.locator('.sidebar-wrapper').getByRole('link', { name: 'Routes' }).click()
+		await expect(page.locator('.content-wrapper').getByRole('heading', { name: 'Routes' })).toBeVisible()
+		expect(await page.evaluate(() => window.__vtCount)).toBe(1)
+
+		// Back/forward across pages → also a transition.
+		await page.goBack()
+		await expect(page.locator('.content-wrapper').getByRole('heading', { name: 'Deployments' })).toBeVisible()
+		expect(await page.evaluate(() => window.__vtCount)).toBe(2)
+
+		// The app chrome keeps its own snapshot so it stays static while the
+		// content crossfades — names must stay on elements with a real box
+		// (nav.sidebar is absolutely positioned; its wrapper is 0×0 and would
+		// snapshot as nothing, flashing the sidebar out during transitions).
+		const names = await page.evaluate(() => ({
+			sidebar: getComputedStyle(document.querySelector('nav.sidebar')).viewTransitionName,
+			navbar: getComputedStyle(document.querySelector('.navbar-wrapper')).viewTransitionName,
+			sidebarWidth: document.querySelector('nav.sidebar').getBoundingClientRect().width
+		}))
+		expect(names.sidebar).toBe('sidebar')
+		expect(names.navbar).toBe('navbar')
+		expect(names.sidebarWidth).toBeGreaterThan(0)
+	})
+})

--- a/tests/view-transition.spec.js
+++ b/tests/view-transition.spec.js
@@ -39,6 +39,26 @@ test.describe('view transitions', () => {
 		expect(names.sidebarWidth).toBeGreaterThan(0)
 	})
 
+	test('query-only page changes (filters, project switch) transition too; hash-only jumps do not', async ({ page }) => {
+		await page.goto('/audit-log?project=test-project')
+		await expect(page.locator('.content-wrapper').getByRole('heading', { name: 'Audit log' })).toBeVisible()
+
+		await page.evaluate(() => {
+			window.__vtCount = 0
+			const orig = document.startViewTransition.bind(document)
+			document.startViewTransition = (cb) => {
+				window.__vtCount++
+				return orig(cb)
+			}
+		})
+
+		// Applying a filter navigates to the same path with new query params.
+		await page.locator('#filter-actor').fill('user@example.com')
+		await page.getByRole('button', { name: 'Apply' }).click()
+		await expect(page).toHaveURL(/actor=user%40example.com/)
+		expect(await page.evaluate(() => window.__vtCount)).toBe(1)
+	})
+
 	test('no transition while the mobile nav drawer is open — its slide-out must stay live', async ({ page }) => {
 		await page.setViewportSize({ width: 390, height: 844 })
 		await page.goto('/deployment?project=test-project')

--- a/tests/view-transition.spec.js
+++ b/tests/view-transition.spec.js
@@ -38,4 +38,27 @@ test.describe('view transitions', () => {
 		expect(names.navbar).toBe('navbar')
 		expect(names.sidebarWidth).toBeGreaterThan(0)
 	})
+
+	test('no transition while the mobile nav drawer is open — its slide-out must stay live', async ({ page }) => {
+		await page.setViewportSize({ width: 390, height: 844 })
+		await page.goto('/deployment?project=test-project')
+		await expect(page.locator('.content-wrapper').getByRole('heading', { name: 'Deployments' })).toBeVisible()
+
+		await page.evaluate(() => {
+			window.__vtCount = 0
+			const orig = document.startViewTransition.bind(document)
+			document.startViewTransition = (cb) => {
+				window.__vtCount++
+				return orig(cb)
+			}
+		})
+
+		// Open the drawer, then navigate from it: the drawer's own slide-out
+		// animates live; a view transition would freeze it and end in a jump.
+		await page.locator('.icon-nav-menu').click()
+		await expect(page.locator('.app-layout.is-shown-sidebar')).toBeVisible()
+		await page.locator('.sidebar-wrapper').getByRole('link', { name: 'Routes' }).click()
+		await expect(page.locator('.content-wrapper').getByRole('heading', { name: 'Routes' })).toBeVisible()
+		expect(await page.evaluate(() => window.__vtCount)).toBe(0)
+	})
 })


### PR DESCRIPTION
## What

Client-side page navigations now animate with the [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API): the outgoing page crossfades into the incoming one, while the navbar and sidebar stay put (each carries its own `view-transition-name`, so only the content area transitions — in the sidebar, just the active item crossfades).

The transition, slowed to 1.2s for visibility (real speed is 160ms) — note the sidebar and navbar staying put while the content crossfades:

![view transition](https://raw.githubusercontent.com/deploys-app/console/screenshots/324-view-transition.gif)

A single mid-transition frame (Deployments → Routes crossfading, chrome static):

![mid transition](https://raw.githubusercontent.com/deploys-app/console/screenshots/324-mid-transition.png)

## How

- `src/routes/+layout.svelte` — `onNavigate` starts `document.startViewTransition` (the standard SvelteKit pattern). Skipped when:
  - the browser doesn't support it (Firefox → no-op, instant swap as today),
  - the URL only changes its hash (query-param page changes — project switching, filter Apply — transition like any other navigation),
  - `prefers-reduced-motion: reduce`,
  - the mobile nav drawer is open — its live slide-out is the page-change animation there (a transition would freeze it mid-slide and end with a jump).
- `src/style/app.css` — transition runs at `--timing-faster` (160ms) instead of the UA default 250ms; `::view-transition-group(*)` is included so the (input-blocking) transition doesn't outlive the fades. A reduced-motion belt-and-braces rule kills the pseudo-element animations too.
- `Sidebar.svelte` / `(auth)/+layout.svelte` — `view-transition-name` on `nav.sidebar` and `.navbar-wrapper`. The sidebar's name must sit on the nav itself: it is absolutely positioned, so its wrapper is a 0×0 box whose snapshot would be empty, making the sidebar flash out during every transition.
- `tests/view-transition.spec.js` — regression spec: cross-page + back/forward navigations start exactly one transition each, and the chrome names resolve on elements with a real box.

## Notes

- Content motion stays with the existing `panel-in` entrance (it plays inside the new snapshot), so the transition itself is a pure crossfade — no doubled movement.
- `bun lint`, `bun check`, and the Playwright suite pass (pre-existing parallel-mode flakes aside — they fail identically on `main`).


