### PR TITLE
dashboard: show cache egress as its own billing row

### DIFF
--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -1381,6 +1381,7 @@ const handlers: Record<string, (args: any) => object> = {
 		cpu: 1.5,
 		memory: 805306368,
 		egress: 1073741824,
+		cacheEgress: 3221225472,
 		registryEgress: 268435456,
 		dropboxEgress: 134217728,
 		disk: 10737418240,

--- a/src/routes/(auth)/(project)/+page.svelte
+++ b/src/routes/(auth)/(project)/+page.svelte
@@ -134,6 +134,12 @@
 					...formatStorage(usage.egress, '')
 				},
 				{
+					key: 'cacheEgress',
+					icon: 'fa-bolt',
+					label: 'Cache Egress',
+					...formatStorage(usage.cacheEgress, '')
+				},
+				{
 					key: 'registryEgress',
 					icon: 'fa-box-archive',
 					label: 'Registry Egress',

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -100,6 +100,7 @@ declare namespace Api {
         cpu: number
         memory: number
         egress: number
+        cacheEgress: number
         registryEgress: number
         dropboxEgress: number
         disk: number


### PR DESCRIPTION
## What

The dashboard billing card's Network group now shows **Egress** and **Cache Egress** as separate rows instead of one summed Egress line.

Backed by apiserver returning `cacheEgress` separately from `project.usage` (deploys-app/apiserver#234; api field added in deploys-app/api#127, merged): `egress` is now origin + waf egress only, and `cacheEgress` carries the edge-cache HIT bytes — the same split `project.usageMetrics` already uses for the charts.

Changes:
- `+page.svelte`: new Cache Egress row (icon `fa-bolt`, matching the Cache section) after Egress in the Network group
- `src/types/api.d.ts`: `Api.ProjectUsage.cacheEgress`
- `src/lib/server/mock.ts`: mock fixture gets `cacheEgress` (3 GiB), consistent with the existing `project.metrics` cache series

## Deploy order

Deploy after (or with) apiserver#234 — against an old server the new row reads `?` (field absent). No migration, no permission change.

## Tests

`bun lint` / `bun check` green. Playwright: 330 passed; `search.spec.js:363` (palette multi-registration lifecycle) fails identically on clean `main` — pre-existing, unrelated.

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/console/screenshots/325-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/console/screenshots/325-after.png) |
