### PR TITLE
test: gate Playwright navigations on client hydration to fix parallel flake

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,10 +1,22 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte'
+	import { onMount } from 'svelte'
 	import { browser } from '$app/environment'
 	import { beforeNavigate, onNavigate } from '$app/navigation'
 	import { updated } from '$app/stores'
 
 	const { children }: { children: Snippet } = $props()
+
+	// Mark the document once the client has hydrated and every component's event
+	// handlers are wired (onMount flushes after the whole tree mounts). This is a
+	// hydration signal for e2e tests: a one-shot input (a "/" keypress, a dropdown
+	// click) dispatched before hydration lands on nothing and is lost, which under
+	// dev-server on-demand-compile load (parallel workers) produced flaky "modal
+	// never opened" failures. Tests wait for this attribute after navigating so
+	// they never race hydration. Harmless in production.
+	onMount(() => {
+		document.documentElement.dataset.hydrated = ''
+	})
 
 	if (browser) {
 		beforeNavigate(({ willUnload, to }) => {

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -125,6 +125,27 @@ export async function setMockKeyCookie (context, key) {
  * the `mock_key` cookie, and reset that bucket — so each test starts from a
  * clean, isolated copy of the default mocks even under parallel workers.
  */
+/**
+ * Wrap `page.goto` so it resolves only after the SvelteKit client has hydrated
+ * (the root layout sets `<html data-hydrated>` in `onMount`). Web-first
+ * assertions auto-wait for elements, but one-shot inputs — `keyboard.press('/')`
+ * to open the palette, a click that opens a custom Select — are dispatched once
+ * and lost if they land before hydration wires the handlers. Under the Vite dev
+ * server's on-demand compilation with many parallel workers, hydration lags well
+ * behind the SSR paint the tests gate on, so those inputs raced and the run
+ * flaked (a different modal-driven test each time). Gating every navigation on
+ * hydration removes the race for all specs at once, with no per-test changes.
+ */
+function withHydrationGate (page) {
+	const origGoto = page.goto.bind(page)
+	page.goto = async (url, opts) => {
+		const res = await origGoto(url, opts)
+		await page.locator('html[data-hydrated]').waitFor({ state: 'attached', timeout: 20_000 })
+		return res
+	}
+	return page
+}
+
 export const test = base.extend({
 	context: async ({ context }, use) => {
 		currentKey = randomUUID()
@@ -132,6 +153,9 @@ export const test = base.extend({
 		await signIn(context)
 		await resetMocks()
 		await use(context)
+	},
+	page: async ({ page }, use) => {
+		await use(withHydrationGate(page))
 	}
 })
 
@@ -141,6 +165,9 @@ export const unauthedTest = base.extend({
 		await setMockKeyCookie(context, currentKey)
 		await resetMocks()
 		await use(context)
+	},
+	page: async ({ page }, use) => {
+		await use(withHydrationGate(page))
 	}
 })
 


### PR DESCRIPTION
## Problem

Full-suite runs (`bun run test`, fullyParallel at `workers: '50%'`) failed with 3–6 flaky failures, a **different set of modal-driven specs each run** (billing pay modal, route/cache delete confirms, search palette, disk create error modal, …). Each failing spec passed in isolation.

## Root cause

A hydration race in the test environment — not a product bug.

The failing specs all do `page.goto(...)` → assert on a server-rendered heading → dispatch a **one-shot** interaction (`keyboard.press('/')`, a click that opens a custom `Select`, a Save click). The heading is visible from SSR **before** the client hydrates, but the handlers (`svelte:window onkeydown` in the auth layout, component `onclick`s) are only wired once hydration mounts the tree. Under the Vite dev server's on-demand compilation with ~10 parallel workers, hydration lags well behind the SSR paint, so the input lands on nothing and is silently lost — Playwright auto-waits for element actionability, not for a JS handler to be attached. The subsequent `expect(...).toBeVisible()` then times out because the modal/dropdown/request never happened. Which worker loses the race depends on compile timing → a rotating failure set.

Ruled out by experiment: the View Transitions crossfade (#324) — disabling it entirely still flaked; the failing specs also navigate via full-load `page.goto`, which never fires `onNavigate`. The codebase already documents this race locally (`clickWhenReady` in `deployment-routes.spec.js`, 'page must have hydrated before we press /' comments); the flaking specs just lacked such a gate.

## Fix

One central, deterministic gate instead of patching ~200 `goto` sites:

- **`src/routes/+layout.svelte`** — root layout stamps `<html data-hydrated>` in `onMount`, which flushes only after the whole component tree has mounted and every handler is wired. Inert in production (a bare data attribute; nothing references it outside the tests).
- **`tests/helpers.js`** — the shared `test` / `unauthedTest` fixtures wrap `page.goto` to wait for `html[data-hydrated]` after each navigation, so no spec can dispatch a one-shot input pre-hydration.

## Validation

- 4 consecutive full-suite runs at full parallelism: **331/331 passing** each time (previously every run failed).
- Suite time drops **~1.3 m → ~41 s** — the flaky specs were burning near-miss timeout waits even when they passed.
- `bun lint` and `bun check` clean.

No UI change (test infra + an invisible attribute), so no screenshots.