### PR TITLE
waf: copy a zone's rules and rate limits to another location

### DIFF
--- a/src/lib/components/WafCopyModal.svelte
+++ b/src/lib/components/WafCopyModal.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+	import Select from '$lib/components/Select.svelte'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+
+	/**
+	 * Copy a WAF zone's rules + rate limits into another WAF-capable location
+	 * that has no zone yet, using only waf.list / waf.set. Rule and limit ids are
+	 * server-managed and resolve against the TARGET zone, so the copy sends them
+	 * blank ("") and the server mints fresh ids — which also means the copy
+	 * starts with fresh metric series.
+	 *
+	 * The modal is self-contained: open(source) fetches a fresh waf.list so
+	 * eligibility (empty targets) never trusts possibly-stale page data, and
+	 * confirm re-fetches it to shrink the open→confirm race in which someone
+	 * else creates a zone on the target (waf.set is a whole-zone upsert, so
+	 * losing that race would silently replace their zone).
+	 */
+
+	interface Props {
+		project: string
+		locations: Api.Location[]
+	}
+
+	const { project, locations }: Props = $props()
+
+	// Invalidates the async continuation of a superseded or dismissed open():
+	// a late waf.list response must not overwrite state opened for another
+	// source, nor pop errors after the user closed the modal.
+	let openGen = 0
+
+	let isActive = $state(false)
+	let loading = $state(false)
+	let submitting = $state(false)
+	let source = $state('')
+	let zones = $state<Api.WafZone[]>([])
+	let target = $state('')
+	let description = $state('')
+
+	const sourceZone = $derived(zones.find((z) => z.location === source))
+
+	// Eligible targets = WAF-capable ∧ no zone ∧ not the source. `locations`
+	// carries the layout's session-cached feature flags; `zones` is the fresh
+	// list fetched at open/confirm, so a pending zone (deploying or deleting)
+	// counts as occupied.
+	const eligible = $derived(locations.filter((loc) =>
+		loc.features.waf &&
+		loc.id !== source &&
+		!zones.some((z) => z.location === loc.id)))
+
+	export async function open (sourceLocation: string): Promise<void> {
+		const gen = ++openGen
+		isActive = true
+		loading = true
+		submitting = false
+		source = sourceLocation
+		target = ''
+		description = ''
+		zones = []
+
+		const resp = await api.invoke<Api.WafZoneList>('waf.list', { project }, fetch)
+		if (gen !== openGen) return
+		loading = false
+		if (!resp.ok) {
+			isActive = false
+			modal.error({ error: resp.error })
+			return
+		}
+		zones = resp.result?.items ?? []
+
+		const src = zones.find((z) => z.location === sourceLocation)
+		if (!src) {
+			// Deleted underneath us — surface it and refresh the stale page list.
+			isActive = false
+			modal.error({ error: `The firewall in ${sourceLocation} no longer exists.` })
+			await api.invalidate('waf.list')
+			return
+		}
+		description = src.description
+	}
+
+	function close () {
+		if (submitting) return
+		openGen++
+		isActive = false
+	}
+
+	async function copy () {
+		if (!target || submitting) return
+
+		submitting = true
+		try {
+			// Confirm-time re-check: the modal can sit open indefinitely, and
+			// waf.set has no compare-and-set — re-list so a zone created on the
+			// target in the meantime is never silently replaced.
+			const listResp = await api.invoke<Api.WafZoneList>('waf.list', { project }, fetch)
+			if (!listResp.ok) {
+				modal.error({ error: listResp.error })
+				return
+			}
+			zones = listResp.result?.items ?? []
+
+			const src = zones.find((z) => z.location === source)
+			if (!src) {
+				isActive = false
+				modal.error({ error: `The firewall in ${source} no longer exists.` })
+				await api.invalidate('waf.list')
+				return
+			}
+			if (zones.some((z) => z.location === target)) {
+				const taken = target
+				target = ''
+				modal.error({ error: `A firewall was just created in ${taken}.` })
+				return
+			}
+
+			const resp = await api.invoke('waf.set', {
+				project,
+				location: target,
+				description,
+				rules: (src.rules ?? []).map((r) => ({ ...r, id: '' })),
+				limits: (src.limits ?? []).map((l) => ({ ...l, id: '' }))
+			}, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+
+			isActive = false
+			await api.invalidate('waf.list')
+			modal.success({ content: `Firewall copied to ${target}. It is now deploying.` })
+		} finally {
+			submitting = false
+		}
+	}
+</script>
+
+<div class="modal" onclick={close} class:is-active={isActive} aria-hidden={!isActive}>
+	<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+	<div class="modal-panel" onclick={(e) => e.stopPropagation()}>
+		<div class="modal-close" onclick={close} onkeypress={close} tabindex="0" role="button">✕</div>
+		<h4><strong>Copy firewall</strong></h4>
+
+		{#if loading}
+			<p class="mt-4">Loading…</p>
+		{:else if sourceZone}
+			{#if eligible.length === 0}
+				<p class="mt-4">
+					Every WAF-capable location already has a firewall. Disable an
+					existing firewall first to copy over it.
+				</p>
+				<div class="actions mt-6">
+					<button class="button is-variant-tertiary" onclick={close}>Close</button>
+				</div>
+			{:else}
+				<p class="mt-4">
+					Copies
+					<strong>{sourceZone.rules?.length ?? 0} {(sourceZone.rules?.length ?? 0) === 1 ? 'rule' : 'rules'}</strong>
+					and
+					<strong>{sourceZone.limits?.length ?? 0} {(sourceZone.limits?.length ?? 0) === 1 ? 'rate limit' : 'rate limits'}</strong>
+					from <span class="font-mono">{source}</span>.
+				</p>
+				<p class="hint mt-2">
+					The copy starts with fresh metric series — match history stays with
+					the source zone.
+				</p>
+
+				<div class="field mt-4">
+					<label for="copy-target-location">Target location</label>
+					<Select
+						id="copy-target-location"
+						bind:value={target}
+						required
+						placeholder="Select Location"
+						options={eligible.map((loc) => ({ value: loc.id, label: loc.id }))} />
+				</div>
+
+				<div class="field mt-4">
+					<label for="copy-description">Description</label>
+					<div class="input">
+						<input id="copy-description" bind:value={description} placeholder="Optional description">
+					</div>
+				</div>
+
+				<div class="actions mt-6">
+					<button class="button is-variant-tertiary" onclick={close} disabled={submitting}>Cancel</button>
+					<button class="button" class:is-loading={submitting}
+						onclick={copy} disabled={!target || submitting}>
+						Copy firewall
+					</button>
+				</div>
+			{/if}
+		{/if}
+	</div>
+</div>
+
+<style>
+	.modal-panel {
+		width: 100%;
+		max-width: 32rem;
+	}
+
+	.hint {
+		font-size: 0.8125rem;
+		color: hsl(var(--hsl-content) / 0.55);
+	}
+
+	.actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 1rem;
+	}
+</style>

--- a/src/routes/(auth)/(project)/waf/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/+page.svelte
@@ -4,6 +4,7 @@
 	import ErrorRow from '$lib/components/ErrorRow.svelte'
 	import Sparkline from '$lib/components/Sparkline.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import WafCopyModal from '$lib/components/WafCopyModal.svelte'
 	import { onMount, untrack } from 'svelte'
 	import api from '$lib/api'
 	import * as format from '$lib/format'
@@ -15,6 +16,8 @@
 	const project = $derived(data.project)
 	const firewalls = $derived(data.firewalls)
 	const error = $derived(data.error)
+
+	let copyModal = $state<WafCopyModal>()
 
 	const { can } = getPermissionContext()
 	$effect(() => {
@@ -177,6 +180,11 @@
 						</td>
 						<td>
 							<div class="flex gap-1 justify-end">
+								<GuardedButton permission={['waf.set', 'waf.list']} class="button is-variant-secondary is-size-small"
+									aria-label={`Copy firewall in ${fw.location}`}
+									onclick={() => copyModal?.open(fw.location)}>
+									Copy
+								</GuardedButton>
 								<a class="button is-variant-secondary is-size-small"
 									href={`/waf/manage?project=${project}&location=${encodeURIComponent(fw.location)}`}>
 									Manage
@@ -199,6 +207,8 @@
 		</table>
 	</div>
 </div>
+
+<WafCopyModal bind:this={copyModal} {project} locations={data.locations} />
 
 <style>
 	/* Hold a fixed box across the loading / loaded / empty states: min-height

--- a/src/routes/(auth)/(project)/waf/create/+page.ts
+++ b/src/routes/(auth)/(project)/waf/create/+page.ts
@@ -4,21 +4,30 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = async ({ parent, fetch }) => {
 	const { project, locations } = await parent() as { project: string, locations: Api.Location[] }
 
-	// Only locations whose backend supports the WAF can host a firewall; drop the
-	// rest before the fan-out (also saves a waf.get per unsupported location).
+	// Only locations whose backend supports the WAF can host a firewall.
 	const supported = locations.filter((loc) => loc.features.waf)
 
-	// No "list zones" endpoint — fan out waf.get to discover which locations are
-	// already configured, then offer only the unconfigured ones for create.
-	const configured = await Promise.all(
-		supported.map(async (loc) => {
-			const res = await api.invoke<Api.WafZone>('waf.get', { project, location: loc.id }, fetch)
-			return res.ok && res.result ? loc.id : null
-		})
-	)
-	const configuredSet = configured.filter((id) => id != null)
+	// One waf.list discovers every configured location; offer only the
+	// unconfigured ones for create. waf.list is its own IAM check, separate
+	// from waf.get — a role holding waf.get without waf.list falls back to the
+	// per-location waf.get fan-out so its page stays accurately filtered. With
+	// neither grant, a non-ok get counts as unconfigured and every location is
+	// offered rather than erroring the page — the server still enforces
+	// waf.set on submit.
+	const res = await api.invoke<Api.WafZoneList>('waf.list', { project }, fetch)
+	let configured: string[]
+	if (res.ok) {
+		configured = (res.result?.items ?? []).map((z) => z.location)
+	} else {
+		configured = (await Promise.all(
+			supported.map(async (loc) => {
+				const r = await api.invoke<Api.WafZone>('waf.get', { project, location: loc.id }, fetch)
+				return r.ok && r.result ? loc.id : null
+			})
+		)).filter((id) => id != null)
+	}
 
-	const available = supported.filter((loc) => !configuredSet.includes(loc.id))
+	const available = supported.filter((loc) => !configured.includes(loc.id))
 
 	return { project, locations: available }
 }

--- a/src/routes/(auth)/(project)/waf/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/manage/+page.svelte
@@ -7,6 +7,7 @@
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import WafTestPanel from '$lib/components/WafTestPanel.svelte'
+	import WafCopyModal from '$lib/components/WafCopyModal.svelte'
 	import type { RuleForm } from '$lib/waf/rules'
 	import { actionLabels, normalizeRules, toApiRules } from '$lib/waf/rules'
 	import type { LimitForm } from '$lib/waf/limits'
@@ -16,6 +17,8 @@
 
 	const project = $derived(data.project)
 	const location = $derived(data.location)
+
+	let copyModal = $state<WafCopyModal>()
 
 	// The list reflects SERVER state for this location. Navigating away and back
 	// (e.g. from the edit page) reloads the loader, which re-seeds this copy.
@@ -183,11 +186,18 @@
 			Rules that filter incoming traffic in <span class="font-mono">{location}</span>
 		</p>
 	</div>
-	<a class="button is-variant-secondary is-icon-left"
-		href={`/waf/metrics?project=${project}&location=${encodeURIComponent(location)}`}>
-		<i class="fa-solid fa-chart-simple"></i>
-		View metrics
-	</a>
+	<div class="flex gap-3">
+		<GuardedButton permission={['waf.set', 'waf.list']} class="button is-variant-secondary is-icon-left"
+			onclick={() => copyModal?.open(location)}>
+			<i class="fa-solid fa-copy"></i>
+			Copy to location
+		</GuardedButton>
+		<a class="button is-variant-secondary is-icon-left"
+			href={`/waf/metrics?project=${project}&location=${encodeURIComponent(location)}`}>
+			<i class="fa-solid fa-chart-simple"></i>
+			View metrics
+		</a>
+	</div>
 </div>
 
 <div class="panel is-level-300 grid gap-6">
@@ -394,6 +404,8 @@
 		</DangerZone>
 	</div>
 </div>
+
+<WafCopyModal bind:this={copyModal} {project} locations={data.locations} />
 
 <style>
 	.action-badge {

--- a/tests/waf.spec.js
+++ b/tests/waf.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, setMocks, getRequestLog } from './helpers.js'
+import { test, expect, setMocks, getRequestLog, pickSelect } from './helpers.js'
 import { defaultLocation } from './fixtures/mocks.js'
 
 // A WAF-capable location (the default fixture location has no `waf` feature).
@@ -11,6 +11,7 @@ function wafZone (overrides = {}) {
 		location: 'gke',
 		description: '',
 		rules: [],
+		limits: [],
 		status: 'success',
 		action: 'create',
 		createdAt: '2024-01-01T00:00:00Z',
@@ -78,8 +79,9 @@ test.describe('firewall list', () => {
 test.describe('firewall create', () => {
 	test('offers only unconfigured WAF locations and saves an empty zone', async ({ page }) => {
 		await setMocks({
-			'location.list': { ok: true, result: { items: [wafLocation] } }
-			// waf.get is unmocked → 404 (notFound) → the location is unconfigured/available.
+			'location.list': { ok: true, result: { items: [wafLocation] } },
+			// No zones anywhere → every supported location is available.
+			'waf.list': { ok: true, result: { project: 'test-project', items: [] } }
 		})
 
 		await page.goto('/waf/create?project=test-project')
@@ -108,11 +110,198 @@ test.describe('firewall create', () => {
 		await setMocks({
 			'location.list': { ok: true, result: { items: [wafLocation] } },
 			// The only supported location already has a zone → nothing to create.
+			'waf.list': { ok: true, result: { project: 'test-project', items: [wafZone({ location: 'gke' })] } }
+		})
+
+		await page.goto('/waf/create?project=test-project')
+		await expect(page.getByText('Every location already has a firewall configured')).toBeVisible()
+	})
+
+	test('falls back to the waf.get fan-out when waf.list is forbidden', async ({ page }) => {
+		await setMocks({
+			'location.list': { ok: true, result: { items: [wafLocation] } },
+			// A role with waf.get but not waf.list still gets an accurately
+			// filtered page: the loader falls back to per-location waf.get.
+			'waf.list': { ok: false, error: { message: 'iam: forbidden' } },
 			'waf.get': { ok: true, result: wafZone({ location: 'gke' }) }
 		})
 
 		await page.goto('/waf/create?project=test-project')
 		await expect(page.getByText('Every location already has a firewall configured')).toBeVisible()
+
+		const log = await getRequestLog()
+		expect(log.some((r) => r.path === '/waf.get')).toBe(true)
+	})
+})
+
+test.describe('firewall copy', () => {
+	const gkeWaf = { ...defaultLocation, id: 'gke', features: { waf: true } }
+	const sgpWaf = { ...defaultLocation, id: 'sgp', features: { waf: true } }
+	const osaka = { ...defaultLocation, id: 'osaka', features: {} } // no waf
+
+	/** The source zone used across the copy tests: one rule + one rate limit. */
+	function sourceZone () {
+		return wafZone({
+			location: 'gke',
+			description: 'prod edge',
+			rules: [wafRule({ id: 'rule-aaaaaa' })],
+			limits: [{
+				id: 'lim-bbbbbb',
+				description: '',
+				key: ['ip'],
+				rate: 100,
+				window: '1m',
+				algorithm: 'sliding',
+				mode: 'enforce'
+			}]
+		})
+	}
+
+	test('copies a zone to an empty waf location with fresh ids', async ({ page }) => {
+		await setMocks({
+			'location.list': { ok: true, result: { items: [gkeWaf, sgpWaf, osaka] } },
+			'waf.list': { ok: true, result: { project: 'test-project', items: [sourceZone()] } },
+			'waf.metrics': { ok: true, result: { series: [], total: 0 } },
+			'waf.set': { ok: true, result: {} }
+		})
+
+		await page.goto('/waf?project=test-project')
+		await page.getByRole('button', { name: 'Copy firewall in gke' }).click()
+
+		const panel = page.locator('.modal.is-active .modal-panel')
+		await expect(panel.getByText('1 rule', { exact: true })).toBeVisible()
+		await expect(panel.getByText('1 rate limit', { exact: true })).toBeVisible()
+
+		// Only sgp is eligible: gke is the source, osaka lacks the waf feature.
+		await panel.locator('#copy-target-location').click()
+		await expect(page.getByRole('option', { name: 'sgp', exact: true })).toBeVisible()
+		await expect(page.getByRole('option', { name: 'gke', exact: true })).toHaveCount(0)
+		await expect(page.getByRole('option', { name: 'osaka', exact: true })).toHaveCount(0)
+		await page.getByRole('option', { name: 'sgp', exact: true }).click()
+
+		// The description is prefilled from the source zone.
+		await expect(panel.locator('#copy-description')).toHaveValue('prod edge')
+
+		await panel.getByRole('button', { name: 'Copy firewall', exact: true }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/waf.set')
+		}).toBe(true)
+
+		const setReq = (await getRequestLog()).find((r) => r.path === '/waf.set')
+		const body = JSON.parse(setReq?.body ?? '{}')
+		expect(body.location).toBe('sgp')
+		expect(body.description).toBe('prod edge')
+		expect(body.rules[0].id).toBe('')
+		expect(body.rules[0].expression).toBe('request.path == "/admin"')
+		expect(body.limits[0].id).toBe('')
+		expect(body.limits[0].rate).toBe(100)
+	})
+
+	test('reports when no empty waf location exists', async ({ page }) => {
+		await setMocks({
+			'location.list': { ok: true, result: { items: [gkeWaf, sgpWaf] } },
+			'waf.list': {
+				ok: true,
+				result: {
+					project: 'test-project',
+					items: [sourceZone(), wafZone({ location: 'sgp' })]
+				}
+			},
+			'waf.metrics': { ok: true, result: { series: [], total: 0 } }
+		})
+
+		await page.goto('/waf?project=test-project')
+		await page.getByRole('button', { name: 'Copy firewall in gke' }).click()
+
+		const panel = page.locator('.modal.is-active .modal-panel')
+		await expect(panel.getByText('Every WAF-capable location already has a firewall')).toBeVisible()
+		await expect(panel.getByRole('button', { name: 'Copy firewall', exact: true })).toHaveCount(0)
+	})
+
+	test('copy is available from the manage page', async ({ page }) => {
+		await setMocks({
+			'waf.get': { ok: true, result: sourceZone() },
+			'location.list': { ok: true, result: { items: [gkeWaf, sgpWaf] } },
+			'waf.list': { ok: true, result: { project: 'test-project', items: [sourceZone()] } },
+			'waf.set': { ok: true, result: {} }
+		})
+
+		await page.goto('/waf/manage?project=test-project&location=gke')
+		await page.getByRole('button', { name: 'Copy to location' }).click()
+
+		await pickSelect(page, 'copy-target-location', 'sgp')
+		await page.getByRole('button', { name: 'Copy firewall', exact: true }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/waf.set')
+		}).toBe(true)
+
+		const setReq = (await getRequestLog()).find((r) => r.path === '/waf.set')
+		expect(JSON.parse(setReq?.body ?? '{}').location).toBe('sgp')
+	})
+
+	test('copy is gated on waf.set', async ({ page }) => {
+		await setMocks({
+			'location.list': { ok: true, result: { items: [gkeWaf, sgpWaf, osaka] } },
+			'waf.list': { ok: true, result: { project: 'test-project', items: [sourceZone()] } },
+			'waf.metrics': { ok: true, result: { series: [], total: 0 } },
+			'me.permissions': { ok: true, result: { permissions: ['waf.list', 'waf.get'], admin: false } }
+		})
+
+		await page.goto('/waf?project=test-project')
+
+		const copyButton = page.getByRole('button', { name: 'Copy firewall in gke' })
+		await expect(copyButton).toBeDisabled()
+		// The wrapping span carries the deny tooltip naming the missing grant.
+		await expect(page.locator('span.inline-flex', { has: copyButton }))
+			.toHaveAttribute('title', "You don't have permission to do this (requires waf.set).")
+
+		// A click never opens the modal.
+		await copyButton.click({ force: true })
+		await expect(page.locator('.modal.is-active')).toHaveCount(0)
+
+		// Both permissions are required: waf.set alone (no waf.list) is denied too.
+		await setMocks({
+			'me.permissions': { ok: true, result: { permissions: ['waf.get', 'waf.set'], admin: false } }
+		})
+		await page.goto('/waf?project=test-project')
+		await expect(page.getByRole('button', { name: 'Copy firewall in gke' })).toBeDisabled()
+	})
+
+	test('aborts when the target gains a zone before confirm', async ({ page }) => {
+		await setMocks({
+			'location.list': { ok: true, result: { items: [gkeWaf, sgpWaf, osaka] } },
+			'waf.list': { ok: true, result: { project: 'test-project', items: [sourceZone()] } },
+			'waf.metrics': { ok: true, result: { series: [], total: 0 } },
+			'waf.set': { ok: true, result: {} }
+		})
+
+		await page.goto('/waf?project=test-project')
+		await page.getByRole('button', { name: 'Copy firewall in gke' }).click()
+
+		const panel = page.locator('.modal.is-active .modal-panel')
+		await pickSelect(page, 'copy-target-location', 'sgp')
+
+		// Someone creates a zone on sgp while the modal sits open.
+		await setMocks({
+			'waf.list': {
+				ok: true,
+				result: {
+					project: 'test-project',
+					items: [sourceZone(), wafZone({ location: 'sgp' })]
+				}
+			}
+		})
+
+		await panel.getByRole('button', { name: 'Copy firewall', exact: true }).click()
+
+		// The confirm-time re-check catches the occupied target: no waf.set fires.
+		await expect(page.getByText('A firewall was just created in sgp.')).toBeVisible()
+		const log = await getRequestLog()
+		expect(log.some((r) => r.path === '/waf.set')).toBe(false)
 	})
 })
 


### PR DESCRIPTION
## What

Adds a **Copy firewall** action that clones a WAF zone's rules and rate limits into another WAF-capable location, per `PLAN-waf-copy-zone.md` (console-only — no api/apiserver/deployer change; uses the existing `waf.list` / `waf.set` RPCs).

## Changes

- **`WafCopyModal.svelte`** (new) — self-contained modal: `open(source)` fetches a fresh `waf.list` for eligibility (WAF-capable ∧ no zone ∧ not the source; a `pending` zone counts as occupied), prefills the description, and `confirm` **re-fetches `waf.list`** before `waf.set` so a zone created on the target while the modal sat open is never silently replaced (whole-zone upsert). Rule/limit ids are sent blank (`""`) so the server mints fresh ids — the modal notes the copy starts with fresh metric series. A per-open generation token discards late `waf.list` responses from a superseded or dismissed `open()`.
- **`waf/+page.svelte`** — per-row **Copy** button; **`waf/manage/+page.svelte`** — **Copy to location** button in the page head. Both are `GuardedButton`s on `['waf.set', 'waf.list']` (both grants required; the open fetch is its own IAM check).
- **`waf/create/+page.ts`** — unified onto one `waf.list` instead of the per-location `waf.get` fan-out (the "No 'list zones' endpoint" comment predated `waf.list`). A forbidden `waf.list` falls back to the `waf.get` fan-out so a `waf.get`-only role keeps an accurately filtered page; with neither grant the page degrades to all-offered exactly as before (server still enforces `waf.set`).
- **`tests/waf.spec.js`** — new `firewall copy` block: copy flow with id stripping, no-eligible-target state, manage-page entry point, permission gating (both grants), confirm-time occupied-target abort; plus the create-loader `waf.get` fallback.

Non-goals (v1, per the plan): no overwrite of an existing target zone (use Disable firewall first), no cross-project copy, no partial copy, no CLI/MCP verb.

## Tests

`bun lint` 0 errors, `bun check` 0 errors, `bun run test` — **337 passed**.

## Screenshots

List page — per-row Copy action:

![list](https://raw.githubusercontent.com/deploys-app/console/screenshots/327-list.png)

Copy modal — ready state (target picked, description prefilled) vs no eligible target:

| ready | no targets |
| --- | --- |
| ![ready](https://raw.githubusercontent.com/deploys-app/console/screenshots/327-modal-ready.png) | ![no targets](https://raw.githubusercontent.com/deploys-app/console/screenshots/327-modal-no-targets.png) |

Denied state — role without `waf.set`: the Copy button renders disabled (its tooltip reads "You don't have permission to do this (requires waf.set)." — native `title` tooltips don't capture in screenshots):

![denied](https://raw.githubusercontent.com/deploys-app/console/screenshots/327-denied.png)

Manage page — Copy to location entry point:

![manage](https://raw.githubusercontent.com/deploys-app/console/screenshots/327-manage.png)

## Rollout

Console-only: ship on merge. No migration, no deploy-order constraint, no feature flag. Possible follow-up (pre-existing house pattern, shared with `RegistryGcModal`): `api.invoke` propagates network-level fetch rejections, so an open-fetch that rejects (vs resolving non-ok) leaves the modal on Loading… until dismissed.
