### PR TITLE
waf: test panel — dry-run a sample request against the zone (waf.test)

### DIFF
--- a/src/lib/components/WafTestPanel.svelte
+++ b/src/lib/components/WafTestPanel.svelte
@@ -1,0 +1,362 @@
+<script lang="ts">
+	/**
+	 * Collapsible waf.test dry-run panel. Two modes, one result shape:
+	 * `expression` (rule/filter editors — tests one CEL expression) or
+	 * `rules`+`limits` (manage page — tests a whole zone draft). Nothing is
+	 * stored server-side; the RPC only needs the read-only waf.get permission.
+	 */
+	import api from '$lib/api'
+	import CountrySelect from '$lib/components/CountrySelect.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import Select from '$lib/components/Select.svelte'
+	import { actionLabels } from '$lib/waf/rules'
+	import type { KvRow } from '$lib/waf/test'
+	import {
+		limitNote,
+		methodOptions,
+		outcomeText,
+		rememberSample,
+		schemeOptions,
+		seedSample,
+		toWafTestRequest
+	} from '$lib/waf/test'
+
+	interface Props {
+		project: string
+		location: string
+		/** expression mode — dry-run one CEL expression (rule/filter editors) */
+		expression?: string
+		/** draft mode — dry-run a whole zone draft (manage page) */
+		rules?: Api.WafRule[]
+		limits?: Api.WafLimit[]
+	}
+
+	const { project, location, expression, rules, limits }: Props = $props()
+
+	const expressionMode = $derived(expression !== undefined)
+	// Nothing to test: an empty expression, or a zone with no rules and no
+	// limits — both are rejected by waf.test's validation (the mode would be
+	// ambiguous), so the panel disables itself instead of sending an
+	// always-invalid request.
+	const testable = $derived(expressionMode
+		? !!expression?.trim()
+		: (rules?.length ?? 0) + (limits?.length ?? 0) > 0)
+
+	let open = $state(false)
+	const sample = $state(seedSample())
+	let running = $state(false)
+	let result = $state<Api.WafTestResult | null>(null)
+	let runErrors = $state<string[]>([])
+
+	// A result (or error) describes the exact draft it ran against — remember
+	// that draft's fingerprint and only show it while it still matches, so a
+	// stale verdict can't mislead after the draft changes underneath.
+	const draftKey = $derived(JSON.stringify(expressionMode ? expression : [rules, limits]))
+	let ranKey = $state('')
+
+	function addRow (rows: KvRow[]) {
+		rows.push({ k: '', v: '' })
+	}
+
+	function removeRow (rows: KvRow[], i: number) {
+		rows.splice(i, 1)
+	}
+
+	async function run () {
+		if (running || !testable) return
+		running = true
+		runErrors = []
+		try {
+			rememberSample(sample)
+			const payload = {
+				project,
+				location,
+				...(expressionMode
+					? { expression }
+					: { rules: rules ?? [], limits: limits ?? [] }),
+				request: toWafTestRequest(sample)
+			}
+			const resp = await api.invoke<Api.WafTestResult>('waf.test', payload, fetch)
+			ranKey = draftKey
+			if (!resp.ok) {
+				result = null
+				// A validate error carries per-item messages (which sample field
+				// or draft item was rejected) — show those, not the generic
+				// envelope message.
+				runErrors = resp.error?.validate?.length
+					? resp.error.validate
+					: [resp.error?.message ?? 'test failed']
+				return
+			}
+			result = resp.result ?? null
+		} finally {
+			running = false
+		}
+	}
+</script>
+
+{#snippet kvEditor(title: string, rows: KvRow[], addLabel: string)}
+	<div class="grid gap-2 content-start">
+		<span class="label">{title}</span>
+		{#each rows as row, i (i)}
+			<div class="flex items-center gap-2">
+				<div class="input flex-1">
+					<input class="font-mono" bind:value={row.k} placeholder="name" aria-label={`${title} name`}>
+				</div>
+				<span class="text-content/40">:</span>
+				<div class="input flex-1">
+					<input class="font-mono" bind:value={row.v} placeholder="value" aria-label={`${title} value`}>
+				</div>
+				<button type="button" class="icon-button" aria-label={`Remove ${title.toLowerCase()} row`}
+					onclick={() => removeRow(rows, i)}>
+					<i class="fa-solid fa-trash-alt"></i>
+				</button>
+			</div>
+		{/each}
+		<div>
+			<button type="button" class="button is-variant-secondary is-size-small" onclick={() => addRow(rows)}>
+				<i class="fa-solid fa-plus mr-2"></i>
+				<span>{addLabel}</span>
+			</button>
+		</div>
+	</div>
+{/snippet}
+
+<div class="panel is-level-400 grid gap-4">
+	<button type="button" class="test-toggle" aria-expanded={open} onclick={() => (open = !open)}>
+		<div class="text-left">
+			<h6><strong>Test</strong></h6>
+			<p class="text-content/50 text-sm mt-1">
+				{#if expressionMode}
+					Dry-run this expression against a sample request — nothing is stored.
+				{:else}
+					Dry-run the zone against a sample request — nothing is stored.
+				{/if}
+			</p>
+		</div>
+		<i class="fa-solid fa-chevron-down transition-transform" class:rotate-180={open}></i>
+	</button>
+
+	{#if open}
+		{#if !testable}
+			<p class="text-content/50 text-sm">
+				{#if expressionMode}
+					Nothing to test yet — add a condition first.
+				{:else}
+					No rules or limits to test.
+				{/if}
+			</p>
+		{:else}
+			<div class="grid gap-4">
+				<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+					<div class="field">
+						<label for="waf-test-method">Method</label>
+						<Select id="waf-test-method" bind:value={sample.method} options={methodOptions} />
+					</div>
+					<div class="field">
+						<label for="waf-test-path">Path</label>
+						<div class="input">
+							<input id="waf-test-path" class="font-mono" bind:value={sample.path} placeholder="/">
+						</div>
+					</div>
+					<div class="field">
+						<label for="waf-test-host">Host</label>
+						<div class="input">
+							<input id="waf-test-host" class="font-mono" bind:value={sample.host} placeholder="app.example.com">
+						</div>
+					</div>
+					<div class="field">
+						<label for="waf-test-query">Query string</label>
+						<div class="input">
+							<input id="waf-test-query" class="font-mono" bind:value={sample.query} placeholder="key=value">
+						</div>
+					</div>
+					<div class="field">
+						<label for="waf-test-scheme">Scheme</label>
+						<Select id="waf-test-scheme" bind:value={sample.scheme} options={schemeOptions} />
+					</div>
+					<div class="field">
+						<label for="waf-test-ip">Client IP</label>
+						<div class="input">
+							<input id="waf-test-ip" class="font-mono" bind:value={sample.ip} placeholder="203.0.113.7">
+						</div>
+					</div>
+					<div class="field">
+						<label for="waf-test-country">Country</label>
+						<CountrySelect id="waf-test-country" bind:value={sample.country} />
+					</div>
+					<div class="field">
+						<label for="waf-test-asn">ASN</label>
+						<div class="input">
+							<input id="waf-test-asn" type="number" min="0" bind:value={sample.asn} placeholder="13335">
+						</div>
+					</div>
+				</div>
+
+				<p class="text-content/50 text-xs">
+					Country and ASN are simulation inputs — production resolves them via GeoIP at the edge.
+				</p>
+
+				<div class="grid gap-4 lg:grid-cols-2">
+					{@render kvEditor('Headers', sample.headers, 'Add header')}
+					{@render kvEditor('Cookies', sample.cookies, 'Add cookie')}
+				</div>
+
+				<div>
+					<GuardedButton permission="waf.get" class="button is-icon-left" loading={running} onclick={run}>
+						<i class="fa-solid fa-flask"></i>
+						Run test
+					</GuardedButton>
+				</div>
+
+				{#if runErrors.length > 0 && ranKey === draftKey}
+					<div class="grid gap-1">
+						{#each runErrors as e, i (i)}
+							<p class="text-negative text-sm">{e}</p>
+						{/each}
+					</div>
+				{/if}
+
+				{#if result && ranKey === draftKey}
+					<div class="outcome-banner" data-outcome={result.outcome}>
+						<strong>{outcomeText(result)}</strong>
+					</div>
+
+					{#if !result.valid}
+						<p class="text-negative text-sm">
+							Some expressions failed to compile — this draft would be rejected on save.
+						</p>
+					{/if}
+
+					{#if result.rules.length > 0}
+						<div class="grid gap-2">
+							<span class="label">Rules (evaluation order)</span>
+							{#each result.rules as rule, i (i)}
+								<div class="result-row">
+									<span class="font-mono text-sm">{rule.id}</span>
+									<span class="action-badge" data-action={rule.action}>
+										{actionLabels[rule.action] ?? rule.action}
+									</span>
+									{#if rule.error}
+										<span class="state-badge" data-state="error">Error</span>
+									{:else if rule.matched}
+										<span class="state-badge" data-state="matched">Matched</span>
+									{:else}
+										<span class="state-badge">Not matched</span>
+									{/if}
+									{#if !rule.evaluated}
+										<span class="state-badge">Not evaluated</span>
+									{/if}
+									{#if rule.terminal}
+										<span class="state-badge" data-state="terminal">Decided the outcome</span>
+									{/if}
+									{#if rule.error}
+										<p class="basis-full text-negative text-xs font-mono">{rule.error}</p>
+									{/if}
+								</div>
+							{/each}
+						</div>
+					{/if}
+
+					{#if result.limits.length > 0}
+						<div class="grid gap-2">
+							<span class="label">Rate limits</span>
+							{#each result.limits as limit, i (i)}
+								<div class="result-row">
+									<span class="font-mono text-sm">{limit.id}</span>
+									{#if limit.mode === 'shadow'}
+										<span class="state-badge">Shadow</span>
+									{/if}
+									{#if limit.error}
+										<span class="state-badge" data-state="error">Error</span>
+										<p class="basis-full text-negative text-xs font-mono">{limit.error}</p>
+									{:else}
+										<span class="text-content/60 text-sm">{limitNote(limit, result)}</span>
+									{/if}
+								</div>
+							{/each}
+						</div>
+					{/if}
+				{/if}
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.test-toggle {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		width: 100%;
+		cursor: pointer;
+	}
+
+	.outcome-banner {
+		padding: 0.75rem 1rem;
+		border-radius: var(--radius-md);
+		border: 1px solid hsl(var(--hsl-line));
+		background-color: hsl(var(--hsl-content) / 0.04);
+	}
+
+	.outcome-banner[data-outcome='allow'] {
+		border-color: hsl(var(--hsl-positive) / 0.4);
+		background-color: hsl(var(--hsl-positive) / 0.08);
+		color: hsl(var(--hsl-positive));
+	}
+
+	.outcome-banner[data-outcome='block'] {
+		border-color: hsl(var(--hsl-negative) / 0.4);
+		background-color: hsl(var(--hsl-negative) / 0.08);
+		color: hsl(var(--hsl-negative));
+	}
+
+	.result-row {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.5rem 0.75rem;
+		border-radius: var(--radius-md);
+		border: 1px solid hsl(var(--hsl-line));
+	}
+
+	.action-badge,
+	.state-badge {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.125rem 0.625rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		line-height: 1.5;
+		color: hsl(var(--hsl-content) / 0.55);
+		background-color: hsl(var(--hsl-content) / 0.06);
+	}
+
+	.action-badge[data-action='block'] {
+		color: hsl(var(--hsl-negative));
+		background-color: hsl(var(--hsl-negative) / 0.12);
+	}
+
+	.action-badge[data-action='allow'] {
+		color: hsl(var(--hsl-positive));
+		background-color: hsl(var(--hsl-positive) / 0.12);
+	}
+
+	.state-badge[data-state='matched'] {
+		color: hsl(var(--hsl-positive));
+		background-color: hsl(var(--hsl-positive) / 0.12);
+	}
+
+	.state-badge[data-state='error'] {
+		color: hsl(var(--hsl-negative));
+		background-color: hsl(var(--hsl-negative) / 0.12);
+	}
+
+	.state-badge[data-state='terminal'] {
+		color: hsl(var(--hsl-content) / 0.85);
+		background-color: hsl(var(--hsl-content) / 0.12);
+	}
+</style>

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -3,6 +3,8 @@
 // src/routes/api/registry/[fn]/+server.js) so the console can run fully
 // offline without the real api.deploys.app backend or an OAuth token.
 
+import { type ExpressionSpec, parseExpression, parseList } from '$lib/waf/expression'
+
 const CREATED_AT = '2026-05-01T08:00:00Z'
 const LOCATION_ID = 'gke.cluster-rcf2'
 const DOMAIN_SUFFIX = 'rcf2.deploys.app'
@@ -455,11 +457,15 @@ const wafZone = {
 	project: 'acme',
 	location: LOCATION_ID,
 	description: 'Block admin paths and noisy bots',
+	// Seed expressions stay in the visual builder's emitted grammar
+	// (double-quoted literals, engine field names) so parseExpression can
+	// round-trip them and the waf.test mock evaluator can actually evaluate
+	// them — a dry run against the seed zone shows real matches offline.
 	rules: [
 		{
 			id: 'block-admin',
 			description: 'Block external access to /admin',
-			expression: "request.path.startsWith('/admin')",
+			expression: 'request.path.startsWith("/admin")',
 			action: 'block',
 			status: 403,
 			message: 'Forbidden',
@@ -468,14 +474,14 @@ const wafZone = {
 		{
 			id: 'log-bots',
 			description: 'Log suspected bot traffic',
-			expression: "request.headers['user-agent'].contains('bot')",
+			expression: 'containsAny(request.headers["user-agent"], ["bot"])',
 			action: 'log',
 			priority: 20
 		},
 		{
 			id: 'allow-office',
 			description: 'Always allow the office egress IP',
-			expression: "request.ip == '203.0.113.7'",
+			expression: 'request.remote_ip == "203.0.113.7"',
 			action: 'allow',
 			priority: 30
 		}
@@ -620,6 +626,121 @@ function wafConfiguredZone (location: string, advance = false) {
 		createdAt: CREATED_AT,
 		createdBy: USER_EMAIL
 	}
+}
+
+// ---- waf.test dry run -------------------------------------------------------
+// Offline approximation of the server's CEL evaluation, so the test panel
+// feels live under `bun dev:mock` (Playwright specs don't use it — they set
+// static per-test mocks). Expressions the visual builder can represent
+// (parseExpression) are evaluated against the sample request. The RESULT
+// SHAPE follows the waf.test contract exactly — outcome/winningRuleId/status/
+// message, per-rule matched/evaluated/terminal, per-limit filterMatched/
+// counted, valid. Known divergences from the real engine, by design: raw CEL
+// the builder can't represent silently reports "not matched" (never an
+// error), matches_regex uses JS RegExp not RE2, and eval errors don't exist
+// here — never treat a mock verdict as engine truth.
+
+interface WafTestSample {
+	method?: string
+	path?: string
+	query?: string
+	host?: string
+	scheme?: string
+	headers?: Record<string, string>
+	cookies?: Record<string, string>
+	ip?: string
+	country?: string
+	asn?: number
+}
+
+function wafSampleField (spec: ExpressionSpec, req: WafTestSample): string | number {
+	const headers = Object.fromEntries(
+		Object.entries(req.headers ?? {}).map(([k, v]) => [k.toLowerCase(), v])
+	)
+	const path = req.path || '/'
+	switch (spec.field) {
+	case 'method': return (req.method || 'GET').toUpperCase()
+	case 'path': return path
+	case 'host': return req.host ?? ''
+	case 'query': return req.query ?? ''
+	case 'uri': return req.query ? `${path}?${req.query}` : path
+	case 'scheme': return req.scheme || 'https'
+	case 'user_agent': return headers['user-agent'] ?? ''
+	case 'referer': return headers.referer ?? ''
+	case 'remote_ip': return req.ip ?? ''
+	case 'country': return req.country ?? ''
+	case 'asn': return req.asn ?? 0
+	case 'content_length': return 0 // the synthetic request has no body
+	case 'header': return headers[(spec.name ?? '').toLowerCase()] ?? ''
+	case 'arg': {
+		// first value wins, like the engine's request.args map
+		const v = new URLSearchParams(req.query ?? '').get(spec.name ?? '')
+		return v ?? ''
+	}
+	case 'cookie': return (req.cookies ?? {})[spec.name ?? ''] ?? ''
+	default: return ''
+	}
+}
+
+/** Naive IPv4-only CIDR membership — enough for dry-running dev fixtures. */
+function wafIpInCidr (ip: string, cidr: string): boolean {
+	const [net, bitsRaw] = cidr.split('/')
+	const bits = bitsRaw === undefined ? 32 : Number(bitsRaw)
+	const toInt = (v: string): number | null => {
+		const parts = v.split('.').map(Number)
+		if (parts.length !== 4 || parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) return null
+		return ((parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) >>> 0
+	}
+	const a = toInt(ip)
+	const b = toInt(net)
+	if (a === null || b === null || !Number.isInteger(bits) || bits < 0 || bits > 32) return false
+	if (bits === 0) return true
+	const mask = (~0 << (32 - bits)) >>> 0
+	return ((a & mask) >>> 0) === ((b & mask) >>> 0)
+}
+
+function wafEvalCondition (spec: ExpressionSpec, req: WafTestSample): boolean {
+	const val = wafSampleField(spec, req)
+	const s = String(val)
+	const list = parseList(spec.values ?? '')
+	switch (spec.operator) {
+	case 'equals':
+		if (spec.tls !== undefined) return spec.tls ? s === 'https' : s === 'http'
+		return s === (spec.value ?? '')
+	case 'not_equals': return s !== (spec.value ?? '')
+	case 'in_list': return list.includes(s)
+	case 'not_in_list': return !list.includes(s)
+	case 'contains_any': return list.some((v) => s.includes(v))
+	case 'starts_with': return s.startsWith(spec.value ?? '')
+	case 'not_starts_with': return !s.startsWith(spec.value ?? '')
+	case 'ends_with': return s.endsWith(spec.value ?? '')
+	case 'not_ends_with': return !s.endsWith(spec.value ?? '')
+	case 'matches_regex':
+		try { return new RegExp(spec.value ?? '').test(s) } catch { return false }
+	case 'ip_equals': return s === (spec.value ?? '')
+	case 'in_cidr': return wafIpInCidr(s, spec.value ?? '')
+	case 'num_eq': return Number(val) === Number(spec.value)
+	case 'num_ne': return Number(val) !== Number(spec.value)
+	case 'num_lt': return Number(val) < Number(spec.value)
+	case 'num_gt': return Number(val) > Number(spec.value)
+	case 'num_le': return Number(val) <= Number(spec.value)
+	case 'num_ge': return Number(val) >= Number(spec.value)
+	default: return false
+	}
+}
+
+/**
+ * Evaluate a CEL expression against the sample. Returns null when the
+ * expression isn't representable by the visual-builder grammar — the mock's
+ * stand-in for "can't evaluate" (treated as no match, never as an error).
+ * An EMPTY expression matches everything (only limit filters may be empty).
+ */
+function wafEvalExpression (expr: string, req: WafTestSample): boolean | null {
+	const group = parseExpression(expr)
+	if (!group) return null
+	if (group.conditions.length === 0) return true
+	const results = group.conditions.map((c) => wafEvalCondition(c, req))
+	return group.combinator === 'or' ? results.some(Boolean) : results.every(Boolean)
 }
 
 const cacheZone = {
@@ -2024,6 +2145,87 @@ const handlers: Record<string, (args: any) => object> = {
 	'waf.delete': (args) => {
 		if (args?.location) wafConfigured.delete(args.location)
 		return ok({})
+	},
+	// Dry run per the waf.test contract: expression mode compiles one synthetic
+	// log rule {id: 'expression'}; draft mode walks the given rules in priority
+	// order (stable) — first matched allow/block terminates, log continues,
+	// rules past the terminal report matched but not evaluated. Limits echo
+	// mode and report filterMatched + counted (a blocked request is never
+	// counted — the WAF runs before the rate limiter). Nothing is stored.
+	'waf.test': (args) => {
+		const req: WafTestSample = args?.request ?? {}
+		const expressionMode = !!args?.expression
+		type InRule = { id?: string, expression?: string, action?: string, priority?: number, status?: number, message?: string }
+		type InLimit = { id?: string, mode?: string, filter?: string }
+		const inputRules: InRule[] = expressionMode
+			? [{ id: 'expression', expression: args.expression, action: 'log', priority: 0 }]
+			: (args?.rules ?? [])
+		const inputLimits: InLimit[] = expressionMode ? [] : (args?.limits ?? [])
+
+		// Evaluation order: stable sort by priority asc, ids defaulting to
+		// '#<index>' (never resolved or generated).
+		const ordered = inputRules
+			.map((r, i) => ({ ...r, id: r.id || `#${i}` }))
+			.map((r, i) => ({ r, i }))
+			.sort((a, b) => ((a.r.priority ?? 0) - (b.r.priority ?? 0)) || (a.i - b.i))
+			.map(({ r }) => r)
+
+		const ruleResults = ordered.map((r) => {
+			// The mock can't compile CEL; the only compile error it can honestly
+			// simulate is an empty expression. (An empty expression must NOT fall
+			// through to wafEvalExpression — empty only means match-everything for
+			// limit filters, never for rules.)
+			const error = (r.expression ?? '').trim() ? '' : 'compile error: empty expression'
+			return {
+				id: r.id,
+				action: r.action ?? 'log',
+				priority: r.priority ?? 0,
+				matched: !error && wafEvalExpression(r.expression ?? '', req) === true,
+				evaluated: true,
+				terminal: false,
+				error
+			}
+		})
+
+		let outcome = 'pass'
+		let winningRuleId = ''
+		let status = 0
+		let message = ''
+		for (const [i, rr] of ruleResults.entries()) {
+			if (rr.error || !rr.matched) continue
+			if (rr.action !== 'allow' && rr.action !== 'block') continue
+			rr.terminal = true
+			outcome = rr.action
+			winningRuleId = rr.id
+			if (rr.action === 'block') {
+				status = ordered[i].status || 403
+				message = ordered[i].message || 'Forbidden'
+			}
+			for (let j = i + 1; j < ruleResults.length; j++) ruleResults[j].evaluated = false
+			break
+		}
+
+		const limitResults = inputLimits.map((l, i) => {
+			const filter = (l.filter ?? '').trim()
+			const filterMatched = !filter || wafEvalExpression(filter, req) === true
+			return {
+				id: l.id || `#${i}`,
+				mode: l.mode === 'shadow' ? 'shadow' : 'enforce',
+				filterMatched,
+				counted: filterMatched && outcome !== 'block',
+				error: ''
+			}
+		})
+
+		return ok({
+			outcome,
+			winningRuleId,
+			status,
+			message,
+			rules: ruleResults,
+			limits: limitResults,
+			valid: ruleResults.every((r) => !r.error)
+		})
 	},
 
 	// The seed location starts configured and live; every other location is

--- a/src/lib/waf/test.ts
+++ b/src/lib/waf/test.ts
@@ -1,0 +1,125 @@
+// Shared helpers for the firewall test panel (waf.test dry runs): the sample
+// request form model, its mapping to the RPC payload, and result phrasing.
+
+export interface KvRow {
+	k: string
+	v: string
+}
+
+export interface SampleForm {
+	method: string
+	path: string
+	host: string
+	query: string
+	scheme: string
+	ip: string
+	country: string
+	asn: string
+	headers: KvRow[]
+	cookies: KvRow[]
+}
+
+export const methodOptions = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']
+	.map((m) => ({ value: m, label: m }))
+
+export const schemeOptions = [
+	{ value: 'https', label: 'https' },
+	{ value: 'http', label: 'http' }
+]
+
+export function defaultSample (): SampleForm {
+	return {
+		method: 'GET',
+		path: '/',
+		host: '',
+		query: '',
+		scheme: 'https',
+		ip: '',
+		country: '',
+		asn: '',
+		headers: [],
+		cookies: []
+	}
+}
+
+// Last-used sample, kept in module state so re-opening a panel (or moving
+// between the rule/limit editors) reuses the previous sample within one SPA
+// session. Deliberately not persisted.
+let lastSample: SampleForm | null = null
+
+export function seedSample (): SampleForm {
+	return lastSample ? clone(lastSample) : defaultSample()
+}
+
+export function rememberSample (form: SampleForm): void {
+	lastSample = clone(form)
+}
+
+// JSON round-trip (not structuredClone) so $state proxies clone cleanly.
+function clone (form: SampleForm): SampleForm {
+	return JSON.parse(JSON.stringify(form)) as SampleForm
+}
+
+/**
+ * Map key/value rows to the wire map: trimmed names, empty names dropped,
+ * later duplicates win. Header names are lowercased (the engine's request map
+ * is lowercase-keyed); cookie names keep their spelling (cookies match
+ * case-sensitively).
+ */
+function rowsToMap (rows: KvRow[], lowercaseNames = false): Record<string, string> {
+	const out: Record<string, string> = {}
+	for (const { k, v } of rows) {
+		let name = k.trim()
+		if (lowercaseNames) name = name.toLowerCase()
+		if (!name) continue
+		out[name] = v
+	}
+	return out
+}
+
+/**
+ * Map the form model to the waf.test sample request. Path falls back to '/'
+ * and is anchored so the server-side "must start with /" validation can't
+ * trip on casual input.
+ */
+export function toWafTestRequest (form: SampleForm): Api.WafTestRequest {
+	const path = form.path.trim() || '/'
+	return {
+		method: form.method,
+		path: path.startsWith('/') ? path : `/${path}`,
+		query: form.query.trim().replace(/^\?/, ''),
+		host: form.host.trim(),
+		scheme: form.scheme,
+		headers: rowsToMap(form.headers, true),
+		cookies: rowsToMap(form.cookies),
+		ip: form.ip.trim(),
+		country: form.country,
+		asn: Number(form.asn) || 0
+	}
+}
+
+/**
+ * One-line banner phrasing for the dry-run outcome.
+ */
+export function outcomeText (r: Api.WafTestResult): string {
+	switch (r.outcome) {
+	case 'block':
+		return `Blocked by rule ${r.winningRuleId} — ${r.status} ${r.message}`
+	case 'allow':
+		return `Allowed by rule ${r.winningRuleId}`
+	default:
+		return 'Passed — no rule terminated this request'
+	}
+}
+
+/**
+ * Per-limit phrasing keyed off `counted`: whether the request would actually
+ * be counted against the limit (a rule-blocked request never reaches the rate
+ * limiter). Errors are rendered separately by the panel.
+ */
+export function limitNote (l: Api.WafTestLimitResult, r: Api.WafTestResult): string {
+	if (l.error) return ''
+	if (l.counted) return 'Counts toward this limit.'
+	if (l.filterMatched) return `Matches the filter — not counted (request blocked by rule ${r.winningRuleId}).`
+	return 'Filter does not match this request.'
+}

--- a/src/routes/(auth)/(project)/waf/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/edit/+page.svelte
@@ -7,6 +7,7 @@
 	import Select from '$lib/components/Select.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import WafConditionBuilder from '$lib/components/WafConditionBuilder.svelte'
+	import WafTestPanel from '$lib/components/WafTestPanel.svelte'
 	import { parseExpression } from '$lib/waf/expression'
 	import {
 		DEFAULT_STATUS,
@@ -289,4 +290,9 @@
 			{/if}
 		</div>
 	</form>
+
+	<hr>
+
+	<!-- Test the draft's expression BEFORE saving — the headline UX win. -->
+	<WafTestPanel {project} {location} expression={draft.expression} />
 </div>

--- a/src/routes/(auth)/(project)/waf/limit/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/limit/+page.svelte
@@ -7,6 +7,7 @@
 	import Select from '$lib/components/Select.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import WafConditionBuilder from '$lib/components/WafConditionBuilder.svelte'
+	import WafTestPanel from '$lib/components/WafTestPanel.svelte'
 	import { parseExpression } from '$lib/waf/expression'
 	import { normalizeRules, toApiRules } from '$lib/waf/rules'
 	import type { KeyRow } from '$lib/waf/limits'
@@ -411,6 +412,13 @@
 			{/if}
 		</div>
 	</form>
+
+	<!-- Test the draft's filter BEFORE saving. An empty filter matches every
+	     request — nothing to dry-run, so the panel only shows once one exists. -->
+	{#if draft.filter.trim()}
+		<hr>
+		<WafTestPanel {project} {location} expression={draft.filter} />
+	{/if}
 </div>
 
 <style>

--- a/src/routes/(auth)/(project)/waf/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/manage/+page.svelte
@@ -6,6 +6,7 @@
 	import api from '$lib/api'
 	import DangerZone from '$lib/components/DangerZone.svelte'
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import WafTestPanel from '$lib/components/WafTestPanel.svelte'
 	import type { RuleForm } from '$lib/waf/rules'
 	import { actionLabels, normalizeRules, toApiRules } from '$lib/waf/rules'
 	import type { LimitForm } from '$lib/waf/limits'
@@ -40,6 +41,11 @@
 	})
 
 	let savingDescription = $state(false)
+
+	// The test panel dry-runs the zone AS SAVED (the same rows the tables
+	// show), mapped back to the API shape waf.test expects.
+	const testRules = $derived(toApiRules(rules))
+	const testLimits = $derived(toApiLimits(limits))
 
 	async function reloadZone () {
 		const resp = await api.invoke<Api.WafZone>('waf.get', { project, location }, fetch)
@@ -376,6 +382,12 @@
 				</tfoot>
 			</table>
 		</div>
+
+		<br>
+		<hr>
+		<br>
+
+		<WafTestPanel {project} {location} rules={testRules} limits={testLimits} />
 
 		<DangerZone description="Disable the firewall in this location and permanently remove all of its rules and rate limits.">
 			<GuardedButton permission="waf.delete" class="button is-variant-negative" onclick={deleteZone}>Disable firewall</GuardedButton>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -825,6 +825,63 @@ declare namespace Api {
         total: number
     }
 
+    // waf.test's synthetic sample request. country/asn are simulation inputs
+    // taken verbatim — the server performs NO GeoIP lookup.
+    export type WafTestRequest = {
+        method: string // '' = GET
+        path: string // required, must start with '/'
+        query: string // raw query string, no leading '?'
+        host: string
+        scheme: string // '' = https
+        headers: Record<string, string> // single value per name
+        cookies: Record<string, string>
+        ip: string // request.remote_ip
+        country: string // request.country, e.g. 'TH'; '' = unresolved
+        asn: number // request.asn, e.g. 13335; 0 = unresolved
+    }
+
+    export type WafTestRuleResult = {
+        // echoed input id, or '#<index>' when empty; 'expression' in
+        // expression mode
+        id: string
+        action: WafAction
+        priority: number
+        matched: boolean
+        // false for rules after the terminating allow/block — the engine
+        // short-circuits there; matched is still reported (the dry run
+        // evaluates every rule independently).
+        evaluated: boolean
+        terminal: boolean // this rule decided the outcome
+        error: string // compile or eval error; empty = ok
+    }
+
+    export type WafTestLimitResult = {
+        id: string // echoed input id, or '#<index>'
+        mode: 'enforce' | 'shadow'
+        // the limit's filter selects this request — true when the filter is
+        // empty (limit covers everything) or the filter matches
+        filterMatched: boolean
+        // filterMatched && outcome != 'block' — a rule-blocked request never
+        // reaches the rate limiter, so it burns no rate budget
+        counted: boolean
+        error: string
+    }
+
+    // waf.test dry-run report. Rules come back in evaluation order (ascending
+    // priority, stable) — the same order the engine runs them.
+    export type WafTestResult = {
+        // never 'error': per-rule errors fail open, like the engine
+        outcome: 'pass' | 'allow' | 'block'
+        winningRuleId: string // '' on pass
+        status: number // block only: response status (default 403); else 0
+        message: string // block only: response body; else ''
+        rules: WafTestRuleResult[]
+        limits: WafTestLimitResult[] // input order
+        // false when any rule/limit failed to compile — the same draft would
+        // be rejected by waf.set
+        valid: boolean
+    }
+
     export type CacheAction = 'cache' | 'bypass'
 
     export type CacheOverride = {

--- a/tests/waf-test.spec.js
+++ b/tests/waf-test.spec.js
@@ -1,0 +1,304 @@
+import { test, expect, setMocks, getRequestLog } from './helpers.js'
+
+// The waf.test dry-run panel (WafTestPanel) mounted on the manage page (zone
+// draft mode) and the rule/limit editors (expression mode).
+
+/** Build a WAF zone fixture. */
+function wafZone (overrides = {}) {
+	return {
+		project: 'test-project',
+		location: 'gke',
+		description: '',
+		rules: [],
+		limits: [],
+		status: 'success',
+		action: 'create',
+		createdAt: '2024-01-01T00:00:00Z',
+		createdBy: '[email protected]',
+		...overrides
+	}
+}
+
+/** Build a WAF rule fixture. */
+function wafRule (overrides = {}) {
+	return {
+		id: 'rule-aaaaaa',
+		description: '',
+		expression: 'request.path == "/admin"',
+		action: 'log',
+		priority: 0,
+		...overrides
+	}
+}
+
+/** Build a waf.test result fixture. */
+function wafTestResult (overrides = {}) {
+	return {
+		outcome: 'pass',
+		winningRuleId: '',
+		status: 0,
+		message: '',
+		rules: [],
+		limits: [],
+		valid: true,
+		...overrides
+	}
+}
+
+/** Open the collapsed test panel (its toggle carries the dry-run subtitle). */
+async function openTestPanel (page) {
+	await page.getByRole('button', { name: /Dry-run/ }).click()
+}
+
+test.describe('waf test panel — manage page (zone draft mode)', () => {
+	test('runs the saved zone against a sample request and renders the outcome', async ({ page }) => {
+		await setMocks({
+			'waf.get': {
+				ok: true,
+				result: wafZone({
+					rules: [
+						wafRule({ id: 'rule-block1', expression: 'request.path.startsWith("/admin")', action: 'block', status: 403, message: 'Forbidden', priority: 0 }),
+						wafRule({ id: 'rule-log1', expression: 'request.method == "GET"', action: 'log', priority: 1 })
+					],
+					limits: [
+						{ id: 'per-ip', description: '', key: ['ip'], rate: 100, window: '1m', mode: 'enforce', filter: '' }
+					]
+				})
+			},
+			'waf.test': {
+				ok: true,
+				result: wafTestResult({
+					outcome: 'block',
+					winningRuleId: 'rule-block1',
+					status: 403,
+					message: 'Forbidden',
+					rules: [
+						{ id: 'rule-block1', action: 'block', priority: 0, matched: true, evaluated: true, terminal: true, error: '' },
+						{ id: 'rule-log1', action: 'log', priority: 1, matched: true, evaluated: false, terminal: false, error: '' }
+					],
+					limits: [
+						{ id: 'per-ip', mode: 'enforce', filterMatched: true, counted: false, error: '' }
+					]
+				})
+			}
+		})
+
+		await page.goto('/waf/manage?project=test-project&location=gke')
+		await openTestPanel(page)
+
+		await page.locator('#waf-test-path').fill('/admin')
+		await page.getByRole('button', { name: 'Run test' }).click()
+
+		// Outcome banner + per-rule badges.
+		await expect(page.getByText('Blocked by rule rule-block1 — 403 Forbidden')).toBeVisible()
+		// Both rules matched — assert on the badge count, not a unique element.
+		await expect(page.getByText('Matched', { exact: true })).toHaveCount(2)
+		await expect(page.getByText('Not evaluated', { exact: true })).toBeVisible()
+		await expect(page.getByText('Decided the outcome', { exact: true })).toBeVisible()
+		// The limit's filter selects the request, but a blocked request is
+		// never counted against the limit.
+		await expect(page.getByText('Matches the filter — not counted (request blocked by rule rule-block1).')).toBeVisible()
+
+		// The payload is a zone draft (rules + limits, no expression) carrying
+		// the sample request.
+		const testReq = (await getRequestLog()).find((r) => r.path === '/waf.test')
+		const body = JSON.parse(testReq?.body ?? '{}')
+		expect(body.project).toBe('test-project')
+		expect(body.location).toBe('gke')
+		expect(body.expression).toBeUndefined()
+		expect(body.rules).toHaveLength(2)
+		expect(body.limits).toHaveLength(1)
+		expect(body.request.method).toBe('GET')
+		expect(body.request.path).toBe('/admin')
+	})
+
+	test('renders per-rule compile errors and the rejected-on-save note', async ({ page }) => {
+		await setMocks({
+			'waf.get': {
+				ok: true,
+				result: wafZone({ rules: [wafRule({ id: 'rule-bad', expression: 'request.path ==' })] })
+			},
+			'waf.test': {
+				ok: true,
+				result: wafTestResult({
+					rules: [
+						{ id: 'rule-bad', action: 'log', priority: 0, matched: false, evaluated: true, terminal: false, error: 'compile error: unexpected token' }
+					],
+					valid: false
+				})
+			}
+		})
+
+		await page.goto('/waf/manage?project=test-project&location=gke')
+		await openTestPanel(page)
+		await page.getByRole('button', { name: 'Run test' }).click()
+
+		await expect(page.getByText('Passed — no rule terminated this request')).toBeVisible()
+		await expect(page.getByText('Error', { exact: true })).toBeVisible()
+		await expect(page.getByText('compile error: unexpected token')).toBeVisible()
+		await expect(page.getByText('Some expressions failed to compile — this draft would be rejected on save.')).toBeVisible()
+	})
+
+	test('renders per-item validate errors when the RPC rejects the run', async ({ page }) => {
+		await setMocks({
+			'waf.get': {
+				ok: true,
+				result: wafZone({ rules: [wafRule()] })
+			},
+			'waf.test': {
+				ok: false,
+				error: {
+					message: 'api: validate error',
+					items: ['request: use the host field instead of a host header', 'request: asn must not be negative']
+				}
+			}
+		})
+
+		await page.goto('/waf/manage?project=test-project&location=gke')
+		await openTestPanel(page)
+		await page.getByRole('button', { name: 'Run test' }).click()
+
+		// The per-item messages surface inline — not the bare envelope message —
+		// and no stale result renders alongside them.
+		await expect(page.getByText('request: use the host field instead of a host header')).toBeVisible()
+		await expect(page.getByText('request: asn must not be negative')).toBeVisible()
+		await expect(page.getByText('api: validate error')).toHaveCount(0)
+		await expect(page.getByText('Passed — no rule terminated this request')).toHaveCount(0)
+	})
+
+	test('disables itself when the zone has no rules and no limits', async ({ page }) => {
+		// An empty zone is a legal waf.set state but an always-invalid waf.test
+		// payload (ambiguous mode) — the panel must not offer to run it.
+		await setMocks({
+			'waf.get': { ok: true, result: wafZone() }
+		})
+
+		await page.goto('/waf/manage?project=test-project&location=gke')
+		await openTestPanel(page)
+
+		await expect(page.getByText('No rules or limits to test.')).toBeVisible()
+		await expect(page.getByRole('button', { name: 'Run test' })).toHaveCount(0)
+	})
+})
+
+test.describe('waf test panel — rule editor (expression mode)', () => {
+	test('tests the unsaved draft expression, sending expression (not rules)', async ({ page }) => {
+		await setMocks({
+			'waf.test': {
+				ok: true,
+				result: wafTestResult({
+					rules: [
+						{ id: 'expression', action: 'log', priority: 0, matched: true, evaluated: true, terminal: false, error: '' }
+					]
+				})
+			}
+		})
+
+		await page.goto('/waf/edit?project=test-project&location=gke')
+
+		// Build a condition in the visual builder (retry across hydration).
+		const addCondition = page.getByRole('button', { name: 'Add condition' })
+		const value = page.locator('#waf-value')
+		await expect(async () => {
+			await addCondition.click()
+			await expect(value).toBeVisible({ timeout: 1000 })
+		}).toPass()
+		await value.fill('/admin')
+
+		await openTestPanel(page)
+		await page.getByRole('button', { name: 'Run test' }).click()
+
+		await expect(page.getByText('Passed — no rule terminated this request')).toBeVisible()
+		await expect(page.getByText('Matched', { exact: true })).toBeVisible()
+
+		// Expression mode payload: the draft's CEL travels as `expression`;
+		// no zone draft fields.
+		const testReq = (await getRequestLog()).find((r) => r.path === '/waf.test')
+		const body = JSON.parse(testReq?.body ?? '{}')
+		expect(body.expression).toBe('request.path == "/admin"')
+		expect(body.rules).toBeUndefined()
+		expect(body.limits).toBeUndefined()
+		expect(body.request.path).toBe('/')
+	})
+
+	test('is disabled until the draft has a condition', async ({ page }) => {
+		await page.goto('/waf/edit?project=test-project&location=gke')
+		await openTestPanel(page)
+
+		await expect(page.getByText('Nothing to test yet — add a condition first.')).toBeVisible()
+		await expect(page.getByRole('button', { name: 'Run test' })).toHaveCount(0)
+	})
+
+	test('hides a stale result the moment the tested draft changes', async ({ page }) => {
+		await setMocks({
+			'waf.test': {
+				ok: true,
+				result: wafTestResult({
+					rules: [
+						{ id: 'expression', action: 'log', priority: 0, matched: true, evaluated: true, terminal: false, error: '' }
+					]
+				})
+			}
+		})
+
+		await page.goto('/waf/edit?project=test-project&location=gke')
+
+		const addCondition = page.getByRole('button', { name: 'Add condition' })
+		const value = page.locator('#waf-value')
+		await expect(async () => {
+			await addCondition.click()
+			await expect(value).toBeVisible({ timeout: 1000 })
+		}).toPass()
+		await value.fill('/admin')
+
+		await openTestPanel(page)
+		await page.getByRole('button', { name: 'Run test' }).click()
+		const banner = page.getByText('Passed — no rule terminated this request')
+		await expect(banner).toBeVisible()
+
+		// The result fingerprints the draft it ran against — editing the draft
+		// must hide the now-stale verdict rather than let it mislead.
+		await value.fill('/other')
+		await expect(banner).toHaveCount(0)
+	})
+})
+
+test.describe('waf test panel — limit editor (filter expression mode)', () => {
+	test('appears once the filter has a condition and sends it as expression', async ({ page }) => {
+		await setMocks({
+			'waf.test': {
+				ok: true,
+				result: wafTestResult({
+					rules: [
+						{ id: 'expression', action: 'log', priority: 0, matched: true, evaluated: true, terminal: false, error: '' }
+					]
+				})
+			}
+		})
+
+		await page.goto('/waf/limit?project=test-project&location=gke')
+
+		// An empty filter matches every request — nothing to dry-run, so the
+		// panel is absent until a condition exists.
+		await expect(page.getByRole('button', { name: /Dry-run/ })).toHaveCount(0)
+
+		const addCondition = page.getByRole('button', { name: 'Add condition' })
+		const value = page.locator('#waf-value')
+		await expect(async () => {
+			await addCondition.click()
+			await expect(value).toBeVisible({ timeout: 1000 })
+		}).toPass()
+		await value.fill('/api')
+
+		await openTestPanel(page)
+		await page.getByRole('button', { name: 'Run test' }).click()
+		await expect(page.getByText('Passed — no rule terminated this request')).toBeVisible()
+
+		// The filter travels as `expression` — no zone draft fields.
+		const testReq = (await getRequestLog()).find((r) => r.path === '/waf.test')
+		const body = JSON.parse(testReq?.body ?? '{}')
+		expect(body.expression).toBe('request.path == "/api"')
+		expect(body.rules).toBeUndefined()
+		expect(body.limits).toBeUndefined()
+	})
+})


### PR DESCRIPTION
## What

Console leg (PR 3) of the **`waf.test` dry-run** feature (design doc: `PLAN-waf-test.md`, workspace root). A collapsible **Test** panel on the firewall pages answers "what would my zone do to this request?" via the read-only `waf.test` RPC — nothing is stored, nothing reaches the cluster.

One reusable `WafTestPanel`, three mounts:

- **`/waf/manage`** — zone-draft mode: tests the zone as saved (`rules` + `limits`, the same payload shape as `waf.set`). Disables itself on an empty zone (an always-invalid `waf.test` payload — ambiguous mode).
- **`/waf/edit`** — expression mode: tests the rule draft **before** saving (covers both rule create and edit; `/waf/edit` without `?rule` is create mode). This is the headline UX win.
- **`/waf/limit`** — expression mode on the limit's filter; hidden while the filter is empty (an empty filter matches everything — nothing to dry-run).

The sample request form covers method / path / host / query / **scheme** / client IP / country / ASN plus header and cookie key-value rows. Country/ASN are simulation inputs — production resolves them via GeoIP at the edge (the panel says so). Header names are lowercased to match the engine's request map; cookie names keep their case.

Results render:
- an outcome banner (pass / allow / block with status + winning rule),
- per-rule rows in evaluation order with **Matched / Not matched / Not evaluated / Error / Decided the outcome** badges and inline compile-error text,
- per-limit phrasing keyed off `counted` ("counts toward this limit" vs "matches the filter — not counted (request blocked by rule X)") plus a shadow tag,
- a "this draft would be rejected on save" note when `valid: false`.

Robustness details:
- A **draft fingerprint** hides stale results *and* stale errors the moment the tested draft changes underneath a verdict.
- A validate-error response surfaces its **per-item messages** inline (e.g. which sample field was rejected), not the bare `api: validate error` envelope.

## Changes

- `src/lib/components/WafTestPanel.svelte` (new)
- `src/lib/waf/test.ts` (new) — pure helpers: sample form model, payload mapping, result phrasing, last-used-sample module state (per SPA session, not persisted)
- `src/types/api.d.ts` — `Api.WafTestRequest` / `Api.WafTestResult` / `Api.WafTestRuleResult` / `Api.WafTestLimitResult`
- `waf/manage`, `waf/edit`, `waf/limit` `+page.svelte` — panel mounts
- `src/lib/server/mock.ts` — `waf.test` handler so the panel feels live under `bun dev:mock`; documented as an offline approximation (visual-builder-representable CEL only, JS RegExp not RE2, no eval errors) — never engine truth. The seed zone's expressions now use the builder's emitted grammar (double-quoted literals, `request.remote_ip` instead of the invalid `request.ip`) so the offline evaluator can actually evaluate them.
- `tests/waf-test.spec.js` (new) — all three mounts, payload shapes (draft vs expression), compile- and validate-error rendering, the stale-result guard, both disabled states

## Tests

- `bun lint` / `bun check` green (0 errors)
- Playwright: **339 passed** (full suite), including the 8 new `waf-test.spec.js` tests

## Rollout / post-merge

- **Deploy order** (plan §5): merge api → apiserver → console; deploy the **apiserver binary before this console rebuild goes live** — until then the panel's RPC returns unknown-action (harmless, but ship in order).
- At launch, seed the per-(project,action) API quota `'*'` row for `waf.test` (plan §6 — cheapest authenticated CPU-burn surface).
- No migration, no new permission (`waf.test` requires `waf.get`), no deployer involvement.

## Screenshots

Captured against the mock server (`bun dev:mock` seed zone) via Playwright.

**Manage page — zone-draft mode** (`GET /admin` blocked by `block-admin`; later rules not evaluated; `per-ip` matches its filter but is not counted because the request is blocked; `login-burst` shadow):

| light | dark |
| --- | --- |
| ![manage light](https://raw.githubusercontent.com/deploys-app/console/screenshots/328-manage.png) | ![manage dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/328-manage-dark.png) |

**Rule editor — expression mode** (unsaved draft condition dry-run before save):

![rule editor](https://raw.githubusercontent.com/deploys-app/console/screenshots/328-editor.png)
