### PR TITLE
waf: named IP lists — lists page, ipInList builder support, list chips

### DIFF
--- a/src/lib/components/WafConditionBuilder.svelte
+++ b/src/lib/components/WafConditionBuilder.svelte
@@ -1,14 +1,34 @@
 <script lang="ts">
 	import { untrack } from 'svelte'
+	import api from '$lib/api'
+	import { getPermissionContext } from '$lib/permission'
 	import WafConditionRow from '$lib/components/WafConditionRow.svelte'
 	import { buildGroup, parseExpression } from '$lib/waf/expression'
 	import type { ExpressionSpec, Combinator } from '$lib/waf/expression'
 
 	interface Props {
 		expression?: string // bindable CEL expression — kept in two-way sync with the rows
+		project?: string // enables the named-IP-list picker (fed by wafList.list)
 	}
 
-	let { expression = $bindable('') }: Props = $props()
+	let { expression = $bindable(''), project = '' }: Props = $props()
+
+	const { can } = getPermissionContext()
+	// Console permission pre-flight: without wafList.list the picker renders
+	// disabled with a permission hint instead of failing the fetch.
+	const listsDenied = $derived(!can('wafList.list'))
+
+	// The project's named IP lists, feeding the in_ip_list / not_in_ip_list
+	// value Select. Keyed on `project` (not fetched in onMount) so an SPA
+	// project switch refetches instead of showing the previous project's lists.
+	let listNames = $state<string[]>([])
+	$effect(() => {
+		const p = project
+		if (!p || listsDenied) return
+		api.invoke<Api.WafListListResult>('wafList.list', { project: p }, fetch).then((res) => {
+			listNames = (res.result?.items ?? []).map((it) => it.name)
+		})
+	})
 
 	/** A fresh blank condition row. */
 	function blankCondition (): ExpressionSpec {
@@ -114,7 +134,8 @@
 							{combinator === 'or' ? 'OR' : 'AND'}
 						</div>
 					{/if}
-					<WafConditionRow bind:condition={conditions[i]} onremove={() => removeCondition(i)} />
+					<WafConditionRow bind:condition={conditions[i]} onremove={() => removeCondition(i)}
+						{project} {listNames} {listsDenied} />
 				</div>
 			{/each}
 		</div>

--- a/src/lib/components/WafConditionBuilder.svelte
+++ b/src/lib/components/WafConditionBuilder.svelte
@@ -20,14 +20,24 @@
 
 	// The project's named IP lists, feeding the in_ip_list / not_in_ip_list
 	// value Select. Keyed on `project` (not fetched in onMount) so an SPA
-	// project switch refetches instead of showing the previous project's lists.
+	// project switch refetches instead of showing the previous project's lists;
+	// the cleanup flag drops an out-of-order response from the previous project.
 	let listNames = $state<string[]>([])
 	$effect(() => {
 		const p = project
+		listNames = []
 		if (!p || listsDenied) return
+		let stale = false
 		api.invoke<Api.WafListListResult>('wafList.list', { project: p }, fetch).then((res) => {
+			if (stale) return
 			listNames = (res.result?.items ?? []).map((it) => it.name)
+		}).catch(() => {
+			// network-level failure — best-effort picker stays empty (a name an
+			// existing rule already references remains selectable via listOptions).
 		})
+		return () => {
+			stale = true
+		}
 	})
 
 	/** A fresh blank condition row. */

--- a/src/lib/components/WafConditionRow.svelte
+++ b/src/lib/components/WafConditionRow.svelte
@@ -11,14 +11,19 @@
 		parseList
 	} from '$lib/waf/expression'
 	import type { ExpressionSpec } from '$lib/waf/expression'
+	import { validListName } from '$lib/waf/lists'
+	import { denyTooltip } from '$lib/permission'
 
 	interface Props {
 		condition: ExpressionSpec // bindable structured condition
 		onremove: () => void // remove this row
 		removable?: boolean // show the remove button (default true)
+		project?: string // for the manage-lists hint link
+		listNames?: string[] // the project's named IP lists (wafList.list)
+		listsDenied?: boolean // caller lacks wafList.list → picker disabled with a hint
 	}
 
-	let { condition = $bindable(), onremove, removable = true }: Props = $props()
+	let { condition = $bindable(), onremove, removable = true, project = '', listNames = [], listsDenied = false }: Props = $props()
 
 	const fieldMeta = $derived(getField(condition.field))
 	const fieldType = $derived(fieldMeta?.type ?? 'string')
@@ -36,6 +41,22 @@
 		!!fieldMeta?.suggestions &&
 		(condition.operator === 'equals' || condition.operator === 'not_equals')
 	)
+	// Named-IP-list membership — the value is a list name picked from the
+	// project's wafList.list result rather than free text.
+	const isListName = $derived(
+		operators.find((o) => o.value === condition.operator)?.valueKind === 'listName'
+	)
+	// Keep an already-referenced name selectable even when it's missing from the
+	// fetched set (e.g. still loading, or the caller can't list) so opening an
+	// existing rule never silently rewrites its list reference. Only a valid
+	// list NAME is injected — a leftover value from another operator (e.g. a
+	// CIDR) must not masquerade as a list.
+	const listOptions = $derived.by(() => {
+		const names = [...listNames]
+		const v = (condition.value ?? '').trim()
+		if (v && validListName(v) && !names.includes(v)) names.unshift(v)
+		return names.map((n) => ({ value: n, label: n }))
+	})
 
 	const fieldOptions = fields.map((f) => ({ value: f.value, label: f.label }))
 	const operatorOptions = $derived(operators.map((o) => ({ value: o.value, label: o.label })))
@@ -127,6 +148,25 @@
 						placeholder={fieldType === 'asn'
 							? 'e.g. 13335, press Enter to add'
 							: 'Type a value, press Enter to add'} />
+				</div>
+			{:else if isListName}
+				<div class="field">
+					<label for="waf-list-name">IP list</label>
+					{#if listsDenied}
+						<span class="inline-flex" title={denyTooltip('wafList.list')}>
+							<Select id="waf-list-name" disabled options={[]} placeholder="No permission to view IP lists" />
+						</span>
+					{:else}
+						<Select id="waf-list-name" value={condition.value ?? ''}
+							options={listOptions}
+							disabled={listOptions.length === 0}
+							placeholder={listOptions.length ? 'Select an IP list' : 'No IP lists yet'}
+							onchange={(v) => (condition.value = String(v))} />
+						<p class="helper">
+							Reusable named lists, managed on the
+							<a class="link" href={`/waf/lists?project=${project}`}>IP lists</a> page.
+						</p>
+					{/if}
 				</div>
 			{:else if useCombobox}
 				<div class="field">

--- a/src/lib/components/WafListModal.svelte
+++ b/src/lib/components/WafListModal.svelte
@@ -77,6 +77,10 @@
 			}
 			close()
 			onsaved()
+		} catch {
+			// api.invoke only rejects on a network-level fetch failure (non-JSON
+			// bodies are already normalized into an error envelope).
+			errorMessage = 'Failed to save the list — network error. Try again.'
 		} finally {
 			saving = false
 		}

--- a/src/lib/components/WafListModal.svelte
+++ b/src/lib/components/WafListModal.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+	import api from '$lib/api'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import {
+		WAF_LIST_MAX_ENTRIES,
+		WAF_LIST_NAME_MAX,
+		WAF_LIST_NAME_MIN,
+		parseIPListEntries,
+		validListName
+	} from '$lib/waf/lists'
+
+	interface Props {
+		project: string
+		/** called after a successful wafList.set so the page can reload its data */
+		onsaved: () => void
+	}
+
+	const { project, onsaved }: Props = $props()
+
+	let isActive = $state(false)
+	// Editing keeps the name immutable — the name is the reference key every
+	// ipInList macro points at; renaming is delete + recreate by design.
+	let editing = $state(false)
+	let name = $state('')
+	let description = $state('')
+	let entriesText = $state('')
+	let saving = $state(false)
+	let errorMessage = $state('')
+
+	const entriesPlaceholder = 'One IP or CIDR per line, e.g.\n203.0.113.0/24\n198.51.100.7\n2001:db8::/48'
+
+	const parsed = $derived(parseIPListEntries(entriesText))
+	const nameOk = $derived(validListName(name.trim()))
+	const canSave = $derived((editing || nameOk) && parsed.errors.length === 0 && !saving)
+
+	// Keep the error list scannable — the textarea can hold hundreds of lines.
+	const shownErrors = $derived(parsed.errors.slice(0, 5))
+	const moreErrors = $derived(parsed.errors.length - shownErrors.length)
+
+	export function open (list?: Api.WafListItem): void {
+		editing = !!list
+		name = list?.name ?? ''
+		description = list?.description ?? ''
+		entriesText = (list?.entries ?? []).join('\n')
+		saving = false
+		errorMessage = ''
+		isActive = true
+	}
+
+	function close () {
+		isActive = false
+	}
+
+	function onBackdrop (e: MouseEvent) {
+		if (e.target === e.currentTarget) close()
+	}
+
+	async function save (e: Event) {
+		e.preventDefault()
+		if (!canSave) return
+
+		saving = true
+		errorMessage = ''
+		try {
+			const resp = await api.invoke('wafList.set', {
+				project,
+				name: name.trim(),
+				description,
+				type: 'ip',
+				entries: parsed.entries
+			}, fetch)
+			if (!resp.ok) {
+				// Surface the server's message verbatim (e.g. an expanded-size cap
+				// naming the zone/rule the update would overflow).
+				errorMessage = (resp.error?.validate ?? [resp.error?.message ?? 'Failed to save the list.']).join('\n')
+				return
+			}
+			close()
+			onsaved()
+		} finally {
+			saving = false
+		}
+	}
+</script>
+
+<div class="modal" onclick={onBackdrop} class:is-active={isActive} aria-hidden={!isActive}>
+	<div class="modal-panel">
+		<div class="modal-close" onclick={close} onkeypress={close} tabindex="0" role="button">✕</div>
+		<h4><strong>{editing ? 'Edit IP list' : 'New IP list'}</strong></h4>
+		<p class="text-content/50 text-sm mt-1">
+			A named set of IPs/CIDRs, referenced from rule conditions and rate-limit
+			filters as <code class="font-mono">ipInList(request.remote_ip, "{name.trim() || 'name'}")</code>.
+			Editing re-applies every firewall that references it.
+		</p>
+
+		<form class="grid gap-4 mt-4" onsubmit={save}>
+			<div class="field">
+				<label for="waf-list-modal-name">Name</label>
+				<div class="input">
+					<input id="waf-list-modal-name" class="font-mono" bind:value={name}
+						readonly={editing} placeholder="office-ips">
+				</div>
+				{#if editing}
+					<p class="text-content/50 text-sm mt-1">
+						The name is what rules reference — it can't change. Create a new
+						list to rename.
+					</p>
+				{:else}
+					<p class="{name.trim() !== '' && !nameOk ? 'text-negative' : 'text-content/50'} text-sm mt-1">
+						{WAF_LIST_NAME_MIN}–{WAF_LIST_NAME_MAX} characters; lowercase
+						letters, numbers, and hyphens, starting with a letter and ending
+						with a letter or number.
+					</p>
+				{/if}
+			</div>
+
+			<div class="field">
+				<label for="waf-list-modal-description">Description</label>
+				<div class="input">
+					<input id="waf-list-modal-description" bind:value={description} placeholder="Optional description">
+				</div>
+			</div>
+
+			<div class="field">
+				<label for="waf-list-modal-entries">Entries</label>
+				<div class="textarea">
+					<textarea id="waf-list-modal-entries" class="font-mono" rows="8" bind:value={entriesText}
+						placeholder={entriesPlaceholder}></textarea>
+				</div>
+				<p class="text-content/50 text-sm mt-1">
+					{parsed.entries.length} {parsed.entries.length === 1 ? 'entry' : 'entries'}
+					(max {WAF_LIST_MAX_ENTRIES}). An empty list never matches.
+				</p>
+				{#if shownErrors.length}
+					<ul class="text-negative text-sm mt-1 grid gap-0.5">
+						{#each shownErrors as err (err)}
+							<li>{err}</li>
+						{/each}
+						{#if moreErrors > 0}
+							<li class="text-content/50">…and {moreErrors} more.</li>
+						{/if}
+					</ul>
+				{/if}
+			</div>
+
+			{#if errorMessage}
+				<p class="text-negative text-sm whitespace-pre-line">{errorMessage}</p>
+			{/if}
+
+			<div class="flex items-center gap-3 mt-2">
+				<GuardedButton permission="wafList.set" type="submit" loading={saving} disabled={!canSave}
+					title={canSave ? undefined : 'Enter a valid name and fix the entry errors first'}>
+					Save
+				</GuardedButton>
+				<button type="button" class="button is-variant-secondary" disabled={saving} onclick={close}>
+					Cancel
+				</button>
+			</div>
+		</form>
+	</div>
+</div>
+
+<style>
+	.modal-panel {
+		width: 100%;
+		max-width: 36rem;
+	}
+</style>

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -3,7 +3,7 @@
 // src/routes/api/registry/[fn]/+server.js) so the console can run fully
 // offline without the real api.deploys.app backend or an OAuth token.
 
-import { type ExpressionSpec, parseExpression, parseList } from '$lib/waf/expression'
+import { type ExpressionSpec, parseExpression, parseList, wafListRefs } from '$lib/waf/expression'
 
 const CREATED_AT = '2026-05-01T08:00:00Z'
 const LOCATION_ID = 'gke.cluster-rcf2'
@@ -480,8 +480,10 @@ const wafZone = {
 		},
 		{
 			id: 'allow-office',
-			description: 'Always allow the office egress IP',
-			expression: 'request.remote_ip == "203.0.113.7"',
+			description: 'Always allow the office IP list',
+			// References the seed named IP list, so the manage page shows the
+			// list chip and wafList.delete exercises the in-use guard offline.
+			expression: 'ipInList(request.remote_ip, "office-ips")',
 			action: 'allow',
 			priority: 30
 		}
@@ -741,6 +743,53 @@ function wafEvalExpression (expr: string, req: WafTestSample): boolean | null {
 	if (group.conditions.length === 0) return true
 	const results = group.conditions.map((c) => wafEvalCondition(c, req))
 	return group.combinator === 'or' ? results.some(Boolean) : results.every(Boolean)
+}
+
+// Named IP lists (wafList.*). Session-mutable so the lists page CRUD flows
+// work offline. `office-ips` is referenced by the seed zone's allow rule, so
+// deleting it exercises the in-use guard.
+interface MockWafList {
+	name: string
+	description: string
+	type: 'ip'
+	entries: string[]
+	createdAt: string
+	createdBy: string
+	updatedAt: string
+}
+
+const wafLists = new Map<string, MockWafList>([
+	['office-ips', {
+		name: 'office-ips',
+		description: 'Office egress ranges',
+		type: 'ip',
+		entries: ['198.51.100.7', '203.0.113.0/24', '2001:db8::/48'],
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL,
+		updatedAt: CREATED_AT
+	}],
+	['monitoring', {
+		name: 'monitoring',
+		description: 'Uptime probes exempt from rate limits',
+		type: 'ip',
+		entries: ['192.0.2.10', '192.0.2.11'],
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL,
+		updatedAt: CREATED_AT
+	}]
+])
+
+// Locations of the seed zone's rules/limits referencing `name` — the mock twin
+// of the server's ReferencedBy scan over stored expressions.
+function wafListReferencedBy (name: string): string[] {
+	const referenced =
+		wafZone.rules.some((r) => wafListRefs(r.expression).includes(name)) ||
+		wafZone.limits.some((l) => 'filter' in l && wafListRefs(l.filter ?? '').includes(name))
+	return referenced ? [LOCATION_ID] : []
+}
+
+function wafListItem (l: MockWafList) {
+	return { project: 'acme', ...l, referencedBy: wafListReferencedBy(l.name) }
 }
 
 const cacheZone = {
@@ -2226,6 +2275,44 @@ const handlers: Record<string, (args: any) => object> = {
 			limits: limitResults,
 			valid: ruleResults.every((r) => !r.error)
 		})
+	},
+
+	// Named IP lists — session-mutable CRUD. Delete refuses while the seed
+	// zone still references the list, mirroring the server's in-use guard.
+	'wafList.list': () => ok({
+		project: 'acme',
+		items: [...wafLists.values()]
+			.sort((a, b) => a.name.localeCompare(b.name))
+			.map(wafListItem)
+	}),
+	'wafList.get': (args) => {
+		const l = wafLists.get(args?.name ?? '')
+		if (!l) return err('api: waf list not found')
+		return ok(wafListItem(l))
+	},
+	'wafList.set': (args) => {
+		const name = String(args?.name ?? '')
+		const existing = wafLists.get(name)
+		wafLists.set(name, {
+			name,
+			description: args?.description ?? '',
+			type: 'ip',
+			entries: [...(args?.entries ?? [])],
+			createdAt: existing?.createdAt ?? new Date().toISOString(),
+			createdBy: existing?.createdBy ?? USER_EMAIL,
+			updatedAt: new Date().toISOString()
+		})
+		return ok({})
+	},
+	'wafList.delete': (args) => {
+		const name = String(args?.name ?? '')
+		if (!wafLists.has(name)) return err('api: waf list not found')
+		const refs = wafListReferencedBy(name)
+		if (refs.length > 0) {
+			return err(`waf list "${name}" is in use by the waf zone at ${refs.join(', ')} (rules: "Always allow the office IP list")`)
+		}
+		wafLists.delete(name)
+		return ok({})
 	},
 
 	// The seed location starts configured and live; every other location is

--- a/src/lib/waf/expression.ts
+++ b/src/lib/waf/expression.ts
@@ -575,6 +575,12 @@ function parseMethodCall (s: string): ExpressionSpec | null {
  * spec. Strict, mirroring the generator: ip-type accessor only, plain
  * double-quoted valid list name, no extra whitespace. Returns the spec or
  * `null`.
+ *
+ * Deliberately stricter than the chip scanner (`parseWafListMacro` below),
+ * which tolerates arbitrary whitespace and any operand: a valid raw-authored
+ * usage like `ipInList(request.remote_ip,"x")` still shows a list chip on the
+ * manage page but keeps the edit page in Raw mode — the same round-trip
+ * fidelity bar as `in_cidr`.
  */
 function matchIpInList (part: string): ExpressionSpec | null {
 	let negate = false
@@ -778,7 +784,11 @@ export function parseExpression (cel: string): ExpressionGroup | null {
 // ---------------------------------------------------------------------------
 // ipInList macro scanner — TS mirror of the api package's waflistmacro.go.
 // Used to decorate rules/limits that reference a named IP list; the server
-// remains authoritative for validation. Keep the two implementations in sync.
+// remains authoritative for validation. Keep the two implementations in sync —
+// the one behavior that must match exactly is never treating an `ipInList`
+// token INSIDE a string literal as a reference (string-skipping rules);
+// divergence on malformed input (e.g. a raw newline in a single-quoted
+// literal, which cel-go rejects outright) is cosmetic, chips only.
 
 function isMacroIdentStart (c: string): boolean {
 	return c === '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')

--- a/src/lib/waf/expression.ts
+++ b/src/lib/waf/expression.ts
@@ -7,6 +7,14 @@
 //
 // This module is a pure, side-effect-free helper so it can be unit-tested and
 // the modal UI stays thin.
+//
+// `ipInList(<field>, "<list-name>")` is a PLATFORM macro (see SPEC-waf-ip-lists),
+// not engine CEL: the apiserver expands it into an ipInCidr || chain at
+// materialization time, and the stored form is always the unexpanded macro.
+// This module mirrors the api package's macro scanner (`wafListRefs`) and
+// builds/parses the macro form like any other operator.
+
+import { validListName } from '$lib/waf/lists'
 
 /**
  * Escape a JS string for use inside a CEL double-quoted string literal. Returns
@@ -65,6 +73,7 @@ export interface OperatorMeta {
 	value: string
 	label: string
 	multi?: boolean // true → operand is a list of values (textarea)
+	valueKind?: 'listName' // operand is a named WAF IP list (Select fed by wafList.list)
 }
 
 const stringOperators: OperatorMeta[] = [
@@ -99,7 +108,10 @@ const operatorByMethod: Record<string, string> = Object.fromEntries(
 
 const ipOperators: OperatorMeta[] = [
 	{ value: 'in_cidr', label: 'in CIDR' },
-	{ value: 'ip_equals', label: 'equals' }
+	{ value: 'ip_equals', label: 'equals' },
+	// Named-list membership via the platform macro ipInList(<field>, "<name>").
+	{ value: 'in_ip_list', label: 'in IP list', valueKind: 'listName' },
+	{ value: 'not_in_ip_list', label: 'not in IP list', valueKind: 'listName' }
 ]
 
 /**
@@ -226,6 +238,12 @@ export function buildExpression (spec: ExpressionSpec): string {
 			snippet = `ipInCidr(${accessor}, ${quote(v)})`
 		} else if (spec.operator === 'ip_equals') {
 			snippet = `${accessor} == ${quote(v)}`
+		} else if (spec.operator === 'in_ip_list' || spec.operator === 'not_in_ip_list') {
+			// The macro's name literal admits no escapes — only a valid list name
+			// (the same grammar wafList.set accepts) may be spliced.
+			if (!validListName(v)) return ''
+			const call = `ipInList(${accessor}, "${v}")`
+			snippet = spec.operator === 'not_in_ip_list' ? `!${call}` : call
 		} else {
 			return ''
 		}
@@ -552,6 +570,40 @@ function parseMethodCall (s: string): ExpressionSpec | null {
 }
 
 /**
+ * Parse the `ipInList(<accessor>, "<name>")` platform-macro form — optionally
+ * negated with a leading `!` — back into an `in_ip_list` / `not_in_ip_list`
+ * spec. Strict, mirroring the generator: ip-type accessor only, plain
+ * double-quoted valid list name, no extra whitespace. Returns the spec or
+ * `null`.
+ */
+function matchIpInList (part: string): ExpressionSpec | null {
+	let negate = false
+	let body = part
+	if (body.startsWith('!')) {
+		negate = true
+		body = body.slice(1)
+	}
+	const head = 'ipInList('
+	if (!body.startsWith(head)) return null
+	const acc = matchAccessor(body.slice(head.length))
+	if (!acc) return null
+	const field = getField(acc.field)
+	if (!field || field.type !== 'ip') return null
+	let i = head.length + acc.end
+	if (body.slice(i, i + 2) !== ', ') return null
+	i += 2
+	// Name literal: plain double-quoted, no escapes (the macro grammar; a valid
+	// list name can't contain a quote or backslash anyway).
+	if (body[i] !== '"') return null
+	const close = body.indexOf('"', i + 1)
+	if (close < 0) return null
+	const name = body.slice(i + 1, close)
+	if (!validListName(name)) return null
+	if (body.slice(close + 1) !== ')') return null
+	return { field: acc.field, operator: negate ? 'not_in_ip_list' : 'in_ip_list', value: name }
+}
+
+/**
  * Parse exactly one CEL condition (a single conjunct) back into an
  * `ExpressionSpec`. Strict: only forms `buildExpression` can emit are accepted.
  * Returns `null` for anything else.
@@ -564,6 +616,10 @@ function parseCondition (part: string): ExpressionSpec | null {
 	// optionally negated with a leading `!`.
 	const method = parseMethodCall(s)
 	if (method) return method
+
+	// Platform-macro form: `ipInList(<accessor>, "<name>")`, optionally negated.
+	const ipList = matchIpInList(s)
+	if (ipList) return ipList
 
 	// Negated membership: `!(<accessor> in [...])` → `not_in_list`.
 	if (s.startsWith('!(') && s.endsWith(')')) {
@@ -717,4 +773,176 @@ export function parseExpression (cel: string): ExpressionGroup | null {
 	}
 
 	return { combinator: split.op ?? 'and', conditions }
+}
+
+// ---------------------------------------------------------------------------
+// ipInList macro scanner — TS mirror of the api package's waflistmacro.go.
+// Used to decorate rules/limits that reference a named IP list; the server
+// remains authoritative for validation. Keep the two implementations in sync.
+
+function isMacroIdentStart (c: string): boolean {
+	return c === '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+function isMacroIdentChar (c: string): boolean {
+	return isMacroIdentStart(c) || (c >= '0' && c <= '9')
+}
+
+/** CEL string-literal prefix: r/R (raw), b/B (bytes), or one of each in either order. */
+function isCelStringPrefix (ident: string): boolean {
+	if (ident.length === 1) return /[rRbB]/.test(ident)
+	if (ident.length === 2) {
+		return (/[rR]/.test(ident[0]) && /[bB]/.test(ident[1])) ||
+			(/[bB]/.test(ident[0]) && /[rR]/.test(ident[1]))
+	}
+	return false
+}
+
+/**
+ * Index just past the CEL string literal starting at `expr[i]` (a quote).
+ * Handles single- and triple-quoted forms; escapes honored unless `raw`. An
+ * unterminated literal consumes to end of input — the scanner is structural,
+ * it only must never find the token inside literal text.
+ */
+function skipCelStringLiteral (expr: string, i: number, raw: boolean): number {
+	const n = expr.length
+	const q = expr[i]
+	if (i + 2 < n && expr[i + 1] === q && expr[i + 2] === q) {
+		// triple-quoted
+		i += 3
+		while (i < n) {
+			if (!raw && expr[i] === '\\') {
+				i += 2
+				continue
+			}
+			if (expr[i] === q && i + 2 < n && expr[i + 1] === q && expr[i + 2] === q) return i + 3
+			i++
+		}
+		return n
+	}
+	i++
+	while (i < n) {
+		if (!raw && expr[i] === '\\') {
+			i += 2
+		} else if (expr[i] === q) {
+			return i + 1
+		} else if (expr[i] === '\n') {
+			// single-line literal cannot span a newline; resume scanning after it
+			return i + 1
+		} else {
+			i++
+		}
+	}
+	return n
+}
+
+/**
+ * Parse one macro immediately after its identifier token (`i` points just past
+ * "ipInList"). Grammar (whitespace allowed between the punctuation):
+ *
+ *	ipInList( <ident>(.<ident> | ["<key>"])* , "<list-name>" )
+ *
+ * Returns the list name and the index just past the closing paren, or `null`
+ * when the usage doesn't match (the server rejects such expressions; here a
+ * malformed usage simply carries no resolvable ref).
+ */
+function parseWafListMacro (expr: string, i: number): { name: string, end: number } | null {
+	const n = expr.length
+	const skipWS = (j: number): number => {
+		while (j < n && (expr[j] === ' ' || expr[j] === '\t' || expr[j] === '\n' || expr[j] === '\r')) j++
+		return j
+	}
+
+	i = skipWS(i)
+	if (expr[i] !== '(') return null
+	i = skipWS(i + 1)
+
+	// operand := ident (("." ident) | ("[" dq-string "]"))* — no inner whitespace
+	if (i >= n || !isMacroIdentStart(expr[i])) return null
+	while (i < n && isMacroIdentChar(expr[i])) i++
+	let selectors = true
+	while (selectors && i < n) {
+		if (expr[i] === '.') {
+			i++
+			if (i >= n || !isMacroIdentStart(expr[i])) return null
+			while (i < n && isMacroIdentChar(expr[i])) i++
+		} else if (expr[i] === '[') {
+			i++
+			if (expr[i] !== '"') return null
+			i++
+			while (i < n && expr[i] !== '"') {
+				if (expr[i] === '\\' || expr[i] === '\n' || expr[i] === '\r') return null
+				i++
+			}
+			if (i >= n) return null
+			i++ // closing quote
+			if (expr[i] !== ']') return null
+			i++
+		} else {
+			selectors = false
+		}
+	}
+
+	i = skipWS(i)
+	if (expr[i] !== ',') return null
+	i = skipWS(i + 1)
+
+	// name := plain double-quoted valid list name, no escapes
+	if (expr[i] !== '"') return null
+	i++
+	const nameStart = i
+	while (i < n && expr[i] !== '"') {
+		if (expr[i] === '\\' || expr[i] === '\n' || expr[i] === '\r') return null
+		i++
+	}
+	if (i >= n) return null
+	const name = expr.slice(nameStart, i)
+	i++ // closing quote
+	if (!validListName(name)) return null
+
+	i = skipWS(i)
+	if (expr[i] !== ')') return null
+	return { name, end: i + 1 }
+}
+
+/**
+ * The sorted, de-duplicated list names referenced by well-formed ipInList
+ * macros in a rule expression or limit filter. Skips string literals (all CEL
+ * forms: `"…"`, `'…'`, triple-quoted, with r/R raw and b/B bytes prefixes,
+ * honoring escapes in non-raw forms) and `//` comments, so a token inside
+ * literal text is never a reference.
+ */
+export function wafListRefs (expr: string): string[] {
+	const names = new Set<string>()
+	const s = String(expr ?? '')
+	const n = s.length
+	let i = 0
+	while (i < n) {
+		const c = s[i]
+		if (c === '/' && s[i + 1] === '/') {
+			const j = s.indexOf('\n', i)
+			if (j < 0) break
+			i = j + 1
+		} else if (c === '"' || c === '\'') {
+			i = skipCelStringLiteral(s, i, false)
+		} else if (isMacroIdentStart(c)) {
+			const start = i
+			while (i < n && isMacroIdentChar(s[i])) i++
+			const ident = s.slice(start, i)
+			if (i < n && (s[i] === '"' || s[i] === '\'') && isCelStringPrefix(ident)) {
+				i = skipCelStringLiteral(s, i, /[rR]/.test(ident))
+				continue
+			}
+			if (ident === 'ipInList') {
+				const m = parseWafListMacro(s, i)
+				if (m) {
+					names.add(m.name)
+					i = m.end
+				}
+			}
+		} else {
+			i++
+		}
+	}
+	return [...names].sort()
 }

--- a/src/lib/waf/lists.ts
+++ b/src/lib/waf/lists.ts
@@ -1,0 +1,128 @@
+// WAF named IP lists (wafList.*) helpers. Pure, side-effect-free (no Svelte/
+// SvelteKit imports) so the lists page stays thin and the helpers unit-test
+// without a browser.
+//
+// Validation here is a best-effort client-side mirror of the api library's
+// WAFListSet.Valid(): the server is authoritative (it also canonicalizes IPv6
+// and detects post-normalization duplicates, which plain text comparison
+// can't).
+
+// Mirrors the api repo's ReValidName + MinNameLength..MaxNameLength — the same
+// grammar the ipInList macro's name literal accepts, so a valid list is always
+// referenceable.
+export const WAF_LIST_NAME_MIN = 3
+export const WAF_LIST_NAME_MAX = 26
+export const reValidListName = /^[a-z][a-z0-9-]*[a-z0-9]$/
+
+// Mirrors the api repo's WAF-list constraint constants.
+export const WAF_LIST_MAX_ENTRIES = 1000
+export const WAF_LIST_MAX_ENTRY_LENGTH = 64
+
+export function validListName (name: string): boolean {
+	return name.length >= WAF_LIST_NAME_MIN &&
+		name.length <= WAF_LIST_NAME_MAX &&
+		reValidListName.test(name)
+}
+
+/** IPv4 dotted quad, netip-strict: no leading zeros, each octet 0-255. */
+function validIPv4 (s: string): boolean {
+	const parts = s.split('.')
+	if (parts.length !== 4) return false
+	return parts.every((p) =>
+		/^\d{1,3}$/.test(p) && Number(p) <= 255 && (p.length === 1 || p[0] !== '0'))
+}
+
+/**
+ * Count the 16-bit groups in one side of an IPv6 text (either side of `::`).
+ * Returns -1 when malformed. `v4Tail` allows an embedded IPv4 as the last
+ * segment (counts as two groups).
+ */
+function ipv6Groups (part: string, v4Tail: boolean): number {
+	if (part === '') return 0
+	const segs = part.split(':')
+	let count = 0
+	for (let i = 0; i < segs.length; i++) {
+		const seg = segs[i]
+		if (v4Tail && i === segs.length - 1 && seg.includes('.')) {
+			if (!validIPv4(seg)) return -1
+			count += 2
+			continue
+		}
+		if (!/^[0-9a-fA-F]{1,4}$/.test(seg)) return -1
+		count += 1
+	}
+	return count
+}
+
+/** IPv6, zoned addresses rejected (a zone is host-local, meaningless at the edge). */
+function validIPv6 (s: string): boolean {
+	if (s.includes('%')) return false
+	const i = s.indexOf('::')
+	if (i >= 0) {
+		if (s.includes('::', i + 1)) return false
+		const head = ipv6Groups(s.slice(0, i), false)
+		const tail = ipv6Groups(s.slice(i + 2), true)
+		// `::` must compress at least one group.
+		return head >= 0 && tail >= 0 && head + tail <= 7
+	}
+	return ipv6Groups(s, true) === 8
+}
+
+/** One v1 "ip" list entry: an IPv4/IPv6 address or CIDR. */
+export function validIPListEntry (e: string): boolean {
+	const slash = e.indexOf('/')
+	if (slash >= 0) {
+		const addr = e.slice(0, slash)
+		const bits = e.slice(slash + 1)
+		if (!/^\d{1,3}$/.test(bits) || (bits.length > 1 && bits[0] === '0')) return false
+		const n = Number(bits)
+		if (validIPv4(addr)) return n <= 32
+		if (validIPv6(addr)) return n <= 128
+		return false
+	}
+	return validIPv4(e) || validIPv6(e)
+}
+
+export interface ParsedIPListEntries {
+	/** Trimmed, non-empty lines in input order (valid or not — what a save would send). */
+	entries: string[]
+	/** Human-readable problems, each naming the offending line. Empty ⇒ saveable. */
+	errors: string[]
+}
+
+/**
+ * Parse a lists-modal textarea (one IP or CIDR per line) into entries plus
+ * per-line validation errors. Duplicate detection is best-effort (exact text,
+ * case-insensitive) — the server canonicalizes IPv6 and catches the rest.
+ */
+export function parseIPListEntries (raw: string): ParsedIPListEntries {
+	const entries: string[] = []
+	const errors: string[] = []
+	const seen = new Map<string, number>()
+	const lines = String(raw ?? '').split('\n')
+	for (let i = 0; i < lines.length; i++) {
+		const e = lines[i].trim()
+		if (!e) continue
+		entries.push(e)
+		const no = i + 1
+		if (e.length > WAF_LIST_MAX_ENTRY_LENGTH) {
+			errors.push(`line ${no}: entry must not exceed ${WAF_LIST_MAX_ENTRY_LENGTH} characters`)
+			continue
+		}
+		if (!validIPListEntry(e)) {
+			errors.push(`line ${no}: "${e}" is not an IP address or CIDR`)
+			continue
+		}
+		const key = e.toLowerCase()
+		const first = seen.get(key)
+		if (first !== undefined) {
+			errors.push(`line ${no}: duplicate of line ${first}`)
+			continue
+		}
+		seen.set(key, no)
+	}
+	if (entries.length > WAF_LIST_MAX_ENTRIES) {
+		errors.push(`lists are capped at ${WAF_LIST_MAX_ENTRIES} entries (got ${entries.length})`)
+	}
+	return { entries, errors }
+}

--- a/src/routes/(auth)/(project)/waf/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/+page.svelte
@@ -21,14 +21,23 @@
 
 	const { can } = getPermissionContext()
 	$effect(() => {
-		if (!can('waf.set')) return
-		return registerPageActions([{
-			id: 'waf-list:create',
-			label: 'Create firewall',
-			icon: 'fa-plus',
-			keywords: 'create new add firewall waf',
-			href: `/waf/create?project=${project}`
-		}])
+		const actions = [{
+			id: 'waf-list:lists',
+			label: 'IP lists',
+			icon: 'fa-list',
+			keywords: 'waf firewall ip lists allowlist blocklist cidr',
+			href: `/waf/lists?project=${project}`
+		}]
+		if (can('waf.set')) {
+			actions.unshift({
+				id: 'waf-list:create',
+				label: 'Create firewall',
+				icon: 'fa-plus',
+				keywords: 'create new add firewall waf',
+				href: `/waf/create?project=${project}`
+			})
+		}
+		return registerPageActions(actions)
 	})
 
 	const hasPending = $derived(firewalls.some((fw: Api.WafZone) => fw.status === 'pending'))
@@ -105,10 +114,16 @@
 			{firewalls.length} {firewalls.length === 1 ? 'firewall' : 'firewalls'}
 		</p>
 	</div>
-	<GuardedButton permission="waf.set" class="button is-icon-left" href={`/waf/create?project=${project}`}>
-		<i class="fa-solid fa-plus"></i>
-		Create firewall
-	</GuardedButton>
+	<div class="flex flex-wrap gap-2">
+		<a class="button is-variant-secondary is-icon-left" href={`/waf/lists?project=${project}`}>
+			<i class="fa-solid fa-list"></i>
+			IP lists
+		</a>
+		<GuardedButton permission="waf.set" class="button is-icon-left" href={`/waf/create?project=${project}`}>
+			<i class="fa-solid fa-plus"></i>
+			Create firewall
+		</GuardedButton>
+	</div>
 </div>
 
 <div class="panel is-level-300">

--- a/src/routes/(auth)/(project)/waf/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/+page.svelte
@@ -9,7 +9,7 @@
 	import api from '$lib/api'
 	import * as format from '$lib/format'
 	import { getPermissionContext } from '$lib/permission'
-	import { registerPageActions } from '$lib/pageactions/store.svelte'
+	import { registerPageActions, type PageAction } from '$lib/pageactions/store.svelte'
 
 	const { data }: { data: PageData } = $props()
 
@@ -21,13 +21,16 @@
 
 	const { can } = getPermissionContext()
 	$effect(() => {
-		const actions = [{
-			id: 'waf-list:lists',
-			label: 'IP lists',
-			icon: 'fa-list',
-			keywords: 'waf firewall ip lists allowlist blocklist cidr',
-			href: `/waf/lists?project=${project}`
-		}]
+		const actions: PageAction[] = []
+		if (can('wafList.list')) {
+			actions.push({
+				id: 'waf-list:lists',
+				label: 'IP lists',
+				icon: 'fa-list',
+				keywords: 'waf firewall ip lists allowlist blocklist cidr',
+				href: `/waf/lists?project=${project}`
+			})
+		}
 		if (can('waf.set')) {
 			actions.unshift({
 				id: 'waf-list:create',
@@ -115,10 +118,11 @@
 		</p>
 	</div>
 	<div class="flex flex-wrap gap-2">
-		<a class="button is-variant-secondary is-icon-left" href={`/waf/lists?project=${project}`}>
+		<GuardedButton permission="wafList.list" class="button is-variant-secondary is-icon-left"
+			href={`/waf/lists?project=${project}`}>
 			<i class="fa-solid fa-list"></i>
 			IP lists
-		</a>
+		</GuardedButton>
 		<GuardedButton permission="waf.set" class="button is-icon-left" href={`/waf/create?project=${project}`}>
 			<i class="fa-solid fa-plus"></i>
 			Create firewall

--- a/src/routes/(auth)/(project)/waf/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/edit/+page.svelte
@@ -213,7 +213,7 @@
 			</div>
 
 			{#if mode === 'visual'}
-				<WafConditionBuilder bind:this={builder} bind:expression={draft.expression} />
+				<WafConditionBuilder bind:this={builder} bind:expression={draft.expression} {project} />
 			{:else}
 				<p class="text-content/60 text-sm">
 					Match on

--- a/src/routes/(auth)/(project)/waf/limit/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/limit/+page.svelte
@@ -240,7 +240,7 @@
 			</div>
 
 			{#if filterMode === 'visual'}
-				<WafConditionBuilder bind:this={filterBuilder} bind:expression={draft.filter} />
+				<WafConditionBuilder bind:this={filterBuilder} bind:expression={draft.filter} {project} />
 			{:else}
 				<p class="text-content/60 text-sm">
 					Match on

--- a/src/routes/(auth)/(project)/waf/lists/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/lists/+page.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+	import type { PageData } from './$types'
+	import api from '$lib/api'
+	import * as format from '$lib/format'
+	import * as modal from '$lib/modal'
+	import NoDataRow from '$lib/components/NoDataRow.svelte'
+	import ErrorRow from '$lib/components/ErrorRow.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import WafListModal from '$lib/components/WafListModal.svelte'
+	import { getPermissionContext } from '$lib/permission'
+	import { registerPageActions } from '$lib/pageactions/store.svelte'
+
+	const { data }: { data: PageData } = $props()
+
+	const project = $derived(data.project)
+	const lists = $derived(data.lists)
+	const error = $derived(data.error)
+
+	let listModal = $state<{ open:(list?: Api.WafListItem) => void }>()
+
+	const { can } = getPermissionContext()
+	$effect(() => {
+		if (!can('wafList.set')) return
+		return registerPageActions([{
+			id: 'waf-lists:create',
+			label: 'New IP list',
+			icon: 'fa-plus',
+			keywords: 'create new add ip list waf firewall allowlist blocklist',
+			run: () => listModal?.open()
+		}])
+	})
+
+	function reload () {
+		api.invalidate('wafList.list')
+	}
+
+	function removeList (list: Api.WafListItem) {
+		modal.confirm({
+			title: `Delete the IP list "${list.name}"? Rules can no longer reference it.`,
+			yes: 'Delete',
+			callback: async () => {
+				const resp = await api.invoke('wafList.delete', { project, name: list.name }, fetch)
+				if (!resp.ok) {
+					// An in-use delete is refused server-side with an error naming
+					// every referencing rule/limit — surface it verbatim.
+					modal.error({ error: resp.error })
+					return
+				}
+				reload()
+			}
+		})
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/waf?project=${project}`} class="link"><h6>Firewall</h6></a>
+	</div>
+	<div class="breadcrumb-item">
+		<h6>IP lists</h6>
+	</div>
+</div>
+
+<br>
+
+<div class="page-head">
+	<div>
+		<h4><strong>IP lists</strong></h4>
+		<p class="page-sub">
+			{lists.length} {lists.length === 1 ? 'list' : 'lists'} — named IP/CIDR sets
+			shared by rule conditions and rate-limit filters via
+			<code class="font-mono">ipInList(…)</code>. Editing a list re-applies every
+			firewall that references it.
+		</p>
+	</div>
+	<GuardedButton permission="wafList.set" class="button is-icon-left" onclick={() => listModal?.open()}>
+		<i class="fa-solid fa-plus"></i>
+		New list
+	</GuardedButton>
+</div>
+
+<div class="panel is-level-300">
+	<div class="table-container">
+		<table class="table is-variant-compact">
+			<thead>
+				<tr>
+					<th>Name</th>
+					<th class="is-hide-mobile">Type</th>
+					<th>Entries</th>
+					<th>Referenced by</th>
+					<th class="is-hide-mobile">Updated</th>
+					<th class="is-collapse is-align-right"></th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each lists as list (list.name)}
+					<tr>
+						<td>
+							<span class="font-mono">{list.name}</span>
+							{#if list.description}
+								<div class="text-content/50 text-sm mt-0.5">{list.description}</div>
+							{/if}
+						</td>
+						<td class="is-hide-mobile"><span class="font-mono text-sm text-content/60">{list.type}</span></td>
+						<td>{list.entries.length}</td>
+						<td>
+							{#if (list.referencedBy ?? []).length > 0}
+								<div class="flex flex-wrap gap-x-3 gap-y-1">
+									{#each list.referencedBy as loc (loc)}
+										<a class="link font-mono text-sm"
+											href={`/waf/manage?project=${project}&location=${encodeURIComponent(loc)}`}>{loc}</a>
+									{/each}
+								</div>
+							{:else}
+								<span class="text-content/40">—</span>
+							{/if}
+						</td>
+						<td class="is-hide-mobile">
+							<span class="text-content/60 text-sm" title={format.datetime(list.updatedAt)}>
+								{format.fromNow(list.updatedAt) || '—'}
+							</span>
+						</td>
+						<td>
+							<div class="flex gap-1 justify-end">
+								<GuardedButton permission="wafList.set" class="icon-button" aria-label="Edit IP list"
+									onclick={() => listModal?.open(list)}>
+									<i class="fa-solid fa-pencil"></i>
+								</GuardedButton>
+								<GuardedButton permission="wafList.delete" class="icon-button" aria-label="Delete IP list"
+									onclick={() => removeList(list)}>
+									<i class="fa-solid fa-trash-alt"></i>
+								</GuardedButton>
+							</div>
+						</td>
+					</tr>
+				{/each}
+				<NoDataRow
+					span={6}
+					list={lists}
+					icon="fa-list"
+					message="No IP lists yet"
+					hint="Create a list to reuse the same IPs across firewall rules and rate limits."
+					{error} />
+				<ErrorRow span={6} {error} />
+			</tbody>
+		</table>
+	</div>
+</div>
+
+<WafListModal bind:this={listModal} {project} onsaved={reload} />

--- a/src/routes/(auth)/(project)/waf/lists/+page.ts
+++ b/src/routes/(auth)/(project)/waf/lists/+page.ts
@@ -1,0 +1,14 @@
+import api from '$lib/api'
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async ({ parent, fetch }) => {
+	const { project } = await parent()
+
+	const res = await api.invoke<Api.WafListListResult>('wafList.list', { project }, fetch)
+
+	return {
+		project,
+		lists: res.result?.items ?? [],
+		error: res.error
+	}
+}

--- a/src/routes/(auth)/(project)/waf/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/manage/+page.svelte
@@ -12,6 +12,7 @@
 	import { actionLabels, normalizeRules, toApiRules } from '$lib/waf/rules'
 	import type { LimitForm } from '$lib/waf/limits'
 	import { describeKey, keyRowToApi, modeLabels, normalizeLimits, toApiLimits } from '$lib/waf/limits'
+	import { wafListRefs } from '$lib/waf/expression'
 
 	const { data }: { data: PageData } = $props()
 
@@ -258,6 +259,12 @@
 								{:else}
 									<span class="text-content/40">—</span>
 								{/if}
+								{#each wafListRefs(rule.expression) as ref (ref)}
+									<a class="list-chip" href={`/waf/lists?project=${project}`}
+										title={`References the IP list "${ref}"`}>
+										<i class="fa-solid fa-list"></i>{ref}
+									</a>
+								{/each}
 							</td>
 							<td>
 								<span class="action-badge" data-action={rule.action}>
@@ -350,6 +357,12 @@
 									<div class="font-mono text-xs text-content/50 mt-1 truncate max-w-56" title={limit.filter}>
 										<i class="fa-solid fa-filter mr-1"></i>{limit.filter}
 									</div>
+									{#each wafListRefs(limit.filter) as ref (ref)}
+										<a class="list-chip" href={`/waf/lists?project=${project}`}
+											title={`References the IP list "${ref}"`}>
+											<i class="fa-solid fa-list"></i>{ref}
+										</a>
+									{/each}
 								{/if}
 							</td>
 							<td>
@@ -446,5 +459,26 @@
 	.mode-badge[data-mode='shadow'] {
 		color: hsl(var(--hsl-content) / 0.5);
 		background-color: hsl(var(--hsl-content) / 0.05);
+	}
+
+	/* Marks a rule/limit whose expression references a named IP list; links to
+	   the lists page. */
+	.list-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+		margin-left: 0.4rem;
+		padding: 0.125rem 0.5rem;
+		border-radius: 9999px;
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		font-weight: 600;
+		line-height: 1.5;
+		color: hsl(var(--hsl-primary));
+		background-color: hsl(var(--hsl-primary) / 0.1);
+	}
+
+	.list-chip:hover {
+		background-color: hsl(var(--hsl-primary) / 0.18);
 	}
 </style>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -882,6 +882,33 @@ declare namespace Api {
         valid: boolean
     }
 
+    // wafList.* — named, reusable IP/CIDR lists referenced from rule
+    // expressions and limit filters via the platform macro
+    // ipInList(<field>, "<name>"). Project-scoped pure data (no location, no
+    // status lifecycle); the apiserver expands references at materialization
+    // time, so stored expressions always carry the unexpanded macro.
+    export type WafListType = 'ip'
+
+    export type WafListItem = {
+        project: string
+        name: string
+        description: string
+        type: WafListType
+        // IPs / CIDRs, normalized server-side
+        entries: string[]
+        // Locations of the project's zones whose rules/limits reference this
+        // list. Read-only (computed server-side); what a blocked delete reports.
+        referencedBy: string[]
+        createdAt: string
+        createdBy: string
+        updatedAt: string
+    }
+
+    export type WafListListResult = {
+        project: string
+        items: WafListItem[]
+    }
+
     export type CacheAction = 'cache' | 'bypass'
 
     export type CacheOverride = {

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -152,6 +152,12 @@ export function defaultMocks () {
 			ok: true,
 			result: { items: [] }
 		},
+		// Named WAF IP lists — the lists page load and the condition builder's
+		// list picker both read this; default to none.
+		'/wafList.list': {
+			ok: true,
+			result: { items: [] }
+		},
 		'/dropbox.list': {
 			ok: true,
 			result: { items: [] }
@@ -346,6 +352,18 @@ export const sampleEnvGroup = {
 	},
 	createdAt: now,
 	createdBy: '[email protected]'
+}
+
+export const sampleWafList = {
+	project: 'test-project',
+	name: 'office-ips',
+	description: 'Office egress ranges',
+	type: 'ip',
+	entries: ['198.51.100.7', '203.0.113.0/24', '2001:db8::/48'],
+	referencedBy: [],
+	createdAt: now,
+	createdBy: '[email protected]',
+	updatedAt: now
 }
 
 export const sampleEmailDomain = {

--- a/tests/waf-expression.spec.js
+++ b/tests/waf-expression.spec.js
@@ -16,8 +16,14 @@ import {
 	buildExpression,
 	combineExpression,
 	buildGroup,
-	parseExpression
+	parseExpression,
+	wafListRefs
 } from '../src/lib/waf/expression.js'
+import {
+	parseIPListEntries,
+	validIPListEntry,
+	validListName
+} from '../src/lib/waf/lists.js'
 import {
 	ruleForm,
 	genId,
@@ -66,7 +72,7 @@ test.describe('waf expression: operatorsForField', () => {
 
 	test('ip / numeric / membership / tls field types map to their operator sets', () => {
 		expect(operatorsForField(getField('remote_ip')).map((o) => o.value))
-			.toEqual(['in_cidr', 'ip_equals'])
+			.toEqual(['in_cidr', 'ip_equals', 'in_ip_list', 'not_in_ip_list'])
 		expect(operatorsForField(getField('content_length')).map((o) => o.value))
 			.toEqual(['num_eq', 'num_ne', 'num_lt', 'num_gt', 'num_le', 'num_ge'])
 		expect(operatorsForField(getField('country')).map((o) => o.value))
@@ -135,6 +141,19 @@ test.describe('waf expression: buildExpression', () => {
 			.toBe('ipInCidr(request.remote_ip, "10.0.0.0/8")')
 		expect(buildExpression({ field: 'remote_ip', operator: 'ip_equals', value: '1.2.3.4' }))
 			.toBe('request.remote_ip == "1.2.3.4"')
+	})
+
+	test('named IP list operators emit the ipInList platform macro', () => {
+		expect(buildExpression({ field: 'remote_ip', operator: 'in_ip_list', value: 'office-ips' }))
+			.toBe('ipInList(request.remote_ip, "office-ips")')
+		expect(buildExpression({ field: 'remote_ip', operator: 'not_in_ip_list', value: 'office-ips' }))
+			.toBe('!ipInList(request.remote_ip, "office-ips")')
+		// The macro's name literal admits no escapes — only a valid list name may
+		// be spliced (same grammar wafList.set accepts).
+		expect(buildExpression({ field: 'remote_ip', operator: 'in_ip_list', value: 'a"b' })).toBe('')
+		expect(buildExpression({ field: 'remote_ip', operator: 'in_ip_list', value: 'ab' })).toBe('') // too short
+		expect(buildExpression({ field: 'remote_ip', operator: 'in_ip_list', value: 'Office' })).toBe('') // uppercase
+		expect(buildExpression({ field: 'remote_ip', operator: 'in_ip_list', value: '' })).toBe('')
 	})
 
 	test('numeric operators', () => {
@@ -226,6 +245,10 @@ test.describe('waf expression: parseExpression round-trips', () => {
 		// ip
 		'ipInCidr(request.remote_ip, "10.0.0.0/8")',
 		'request.remote_ip == "1.2.3.4"',
+		// named IP lists (platform macro)
+		'ipInList(request.remote_ip, "office-ips")',
+		'!ipInList(request.remote_ip, "office-ips")',
+		'ipInList(request.remote_ip, "office-ips") && request.path == "/admin"',
 		// numeric
 		'request.content_length > 1048576',
 		'request.content_length <= 0',
@@ -281,7 +304,11 @@ test.describe('waf expression: parseExpression rejects non-representable input',
 		'request.path = "/a"', // not a valid operator
 		'request.unknown == "x"', // unknown accessor
 		'request.path in []', // empty list never emitted
-		'request.asn == abc' // non-numeric asn operand
+		'request.asn == abc', // non-numeric asn operand
+		'ipInList(request.path, "office-ips")', // non-ip accessor
+		'ipInList(request.remote_ip, "ab")', // list name too short
+		'ipInList(request.remote_ip, "a\\"b")', // escaped name never emitted
+		'ipInList(request.remote_ip, "office-ips", "extra")' // extra argument
 	]
 
 	for (const cel of complex) {
@@ -352,5 +379,124 @@ test.describe('waf rules helpers', () => {
 		// Block rules fall back to the defaults when unset.
 		expect(blockDefault.status).toBe(DEFAULT_STATUS)
 		expect(blockDefault.message).toBe(DEFAULT_MESSAGE)
+	})
+})
+
+test.describe('waf lists: wafListRefs (macro scanner)', () => {
+	test('extracts, de-duplicates, and sorts referenced names', () => {
+		expect(wafListRefs('ipInList(request.remote_ip, "office-ips")'))
+			.toEqual(['office-ips'])
+		expect(wafListRefs(
+			'ipInList(request.remote_ip, "zeta") && !ipInList(request.remote_ip, "alpha") || ipInList(request.headers["x-real-ip"], "zeta")'
+		)).toEqual(['alpha', 'zeta'])
+		expect(wafListRefs('request.path == "/admin"')).toEqual([])
+		expect(wafListRefs('')).toEqual([])
+	})
+
+	test('tolerates whitespace inside the macro punctuation', () => {
+		expect(wafListRefs('ipInList( request.remote_ip ,\n\t"office-ips" )'))
+			.toEqual(['office-ips'])
+	})
+
+	test('ignores the token inside string literals and comments', () => {
+		// double- and single-quoted literals
+		expect(wafListRefs('request.query == "ipInList(a, \\"office-ips\\")"')).toEqual([])
+		expect(wafListRefs("request.query == 'ipInList(request.remote_ip, \"office-ips\")'")).toEqual([])
+		// raw string literal (no escape processing)
+		expect(wafListRefs('regexMatch(request.path, r"ipInList(request.remote_ip, \\"office-ips\\")")')).toEqual([])
+		// triple-quoted literal
+		expect(wafListRefs('request.query == """ipInList(request.remote_ip, "office-ips")"""')).toEqual([])
+		// comment to end of line
+		expect(wafListRefs('// ipInList(request.remote_ip, "office-ips")\nrequest.path == "/"')).toEqual([])
+	})
+
+	test('a longer identifier containing the token is not a macro', () => {
+		expect(wafListRefs('myipInList(request.remote_ip, "office-ips")')).toEqual([])
+		expect(wafListRefs('ipInListX(request.remote_ip, "office-ips")')).toEqual([])
+	})
+
+	test('malformed usages carry no resolvable ref', () => {
+		expect(wafListRefs('ipInList(request.remote_ip)')).toEqual([]) // missing name
+		expect(wafListRefs('ipInList(request.remote_ip, office)')).toEqual([]) // unquoted name
+		expect(wafListRefs('ipInList(lower(request.path), "office-ips")')).toEqual([]) // call operand
+		expect(wafListRefs('ipInList(request.remote_ip, "ab")')).toEqual([]) // name too short
+		expect(wafListRefs('ipInList')).toEqual([]) // bare token
+	})
+})
+
+test.describe('waf lists: validListName', () => {
+	test('accepts the wafList.set name grammar (3..26, lowercase/digits/hyphens)', () => {
+		expect(validListName('office-ips')).toBe(true)
+		expect(validListName('abc')).toBe(true)
+		expect(validListName('a2c')).toBe(true)
+		expect(validListName('ab')).toBe(false) // too short
+		expect(validListName('a'.repeat(27))).toBe(false) // too long
+		expect(validListName('Office')).toBe(false) // uppercase
+		expect(validListName('1abc')).toBe(false) // starts with a digit
+		expect(validListName('abc-')).toBe(false) // ends with a hyphen
+		expect(validListName('a b')).toBe(false)
+	})
+})
+
+test.describe('waf lists: entry validation', () => {
+	test('accepts IPv4/IPv6 addresses and CIDRs', () => {
+		expect(validIPListEntry('203.0.113.7')).toBe(true)
+		expect(validIPListEntry('203.0.113.0/24')).toBe(true)
+		expect(validIPListEntry('0.0.0.0/0')).toBe(true)
+		expect(validIPListEntry('2001:db8::1')).toBe(true)
+		expect(validIPListEntry('2001:db8::/48')).toBe(true)
+		expect(validIPListEntry('::1')).toBe(true)
+		expect(validIPListEntry('::')).toBe(true)
+		expect(validIPListEntry('::ffff:192.0.2.1')).toBe(true)
+		expect(validIPListEntry('1:2:3:4:5:6:7:8')).toBe(true)
+	})
+
+	test('rejects garbage, zoned addresses, and out-of-range prefixes', () => {
+		expect(validIPListEntry('not-an-ip')).toBe(false)
+		expect(validIPListEntry('256.1.1.1')).toBe(false)
+		expect(validIPListEntry('01.2.3.4')).toBe(false) // leading zero (netip-strict)
+		expect(validIPListEntry('1.2.3')).toBe(false)
+		expect(validIPListEntry('fe80::1%eth0')).toBe(false) // zoned
+		expect(validIPListEntry('10.0.0.0/33')).toBe(false)
+		expect(validIPListEntry('2001:db8::/129')).toBe(false)
+		expect(validIPListEntry('10.0.0.0/08')).toBe(false) // leading-zero bits
+		expect(validIPListEntry('1:2:3:4:5:6:7:8:9')).toBe(false) // too many groups
+		expect(validIPListEntry('1::2::3')).toBe(false) // double '::'
+	})
+})
+
+test.describe('waf lists: parseIPListEntries', () => {
+	test('splits lines, trims, drops empties, keeps input order', () => {
+		const { entries, errors } = parseIPListEntries('  203.0.113.7 \n\n2001:db8::/48\n')
+		expect(entries).toEqual(['203.0.113.7', '2001:db8::/48'])
+		expect(errors).toEqual([])
+	})
+
+	test('reports invalid lines by line number', () => {
+		const { entries, errors } = parseIPListEntries('203.0.113.7\nnope\n10.0.0.0/8')
+		expect(entries).toEqual(['203.0.113.7', 'nope', '10.0.0.0/8'])
+		expect(errors).toHaveLength(1)
+		expect(errors[0]).toContain('line 2')
+		expect(errors[0]).toContain('nope')
+	})
+
+	test('flags duplicates against the first occurrence', () => {
+		const { errors } = parseIPListEntries('203.0.113.7\n10.0.0.0/8\n203.0.113.7')
+		expect(errors).toHaveLength(1)
+		expect(errors[0]).toContain('line 3')
+		expect(errors[0]).toContain('line 1')
+	})
+
+	test('flags over-long entries and oversize lists', () => {
+		const long = '1'.repeat(65)
+		expect(parseIPListEntries(long).errors[0]).toContain('64')
+		const big = Array.from({ length: 1001 }, (_, i) => `10.${Math.floor(i / 250)}.${Math.floor(i / 10) % 25}.${(i % 10) + 1}/32`).join('\n')
+		const { errors } = parseIPListEntries(big)
+		expect(errors.some((e) => e.includes('1000'))).toBe(true)
+	})
+
+	test('empty input parses to an empty, error-free list', () => {
+		expect(parseIPListEntries('')).toEqual({ entries: [], errors: [] })
+		expect(parseIPListEntries('  \n ')).toEqual({ entries: [], errors: [] })
 	})
 })

--- a/tests/waf-lists.spec.js
+++ b/tests/waf-lists.spec.js
@@ -1,0 +1,328 @@
+import { test, expect, setMocks, getRequestLog, pickSelect } from './helpers.js'
+import { sampleWafList } from './fixtures/mocks.js'
+
+/** Build a WAF zone fixture (same shape the waf spec uses). */
+function wafZone (overrides = {}) {
+	return {
+		project: 'test-project',
+		location: 'gke',
+		description: '',
+		rules: [],
+		limits: [],
+		status: 'success',
+		action: 'create',
+		createdAt: '2024-01-01T00:00:00Z',
+		createdBy: 'test@example.com',
+		...overrides
+	}
+}
+
+test.describe('waf ip lists page', () => {
+	test('renders lists with entry counts and referenced-by links', async ({ page }) => {
+		await setMocks({
+			'wafList.list': {
+				ok: true,
+				result: {
+					project: 'test-project',
+					items: [
+						{ ...sampleWafList, referencedBy: ['gke'] },
+						{ ...sampleWafList, name: 'monitoring', description: '', entries: ['192.0.2.10'], referencedBy: [] }
+					]
+				}
+			}
+		})
+
+		await page.goto('/waf/lists?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		await expect(main.getByRole('heading', { name: 'IP lists', level: 4 })).toBeVisible()
+		await expect(main.getByText('office-ips')).toBeVisible()
+		await expect(main.getByText('Office egress ranges')).toBeVisible()
+		await expect(main.getByText('monitoring')).toBeVisible()
+		// office-ips has 3 entries; the referencing zone links to its manage page.
+		await expect(main.getByRole('link', { name: 'gke', exact: true }))
+			.toHaveAttribute('href', /\/waf\/manage\?project=test-project&location=gke/)
+	})
+
+	test('shows the empty state when there are no lists', async ({ page }) => {
+		await page.goto('/waf/lists?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('No IP lists yet')).toBeVisible()
+	})
+
+	test('creates a list via the modal', async ({ page }) => {
+		await setMocks({ 'wafList.set': { ok: true, result: {} } })
+
+		await page.goto('/waf/lists?project=test-project')
+		await page.getByRole('button', { name: 'New list' }).click()
+
+		const name = page.locator('#waf-list-modal-name')
+		await expect(name).toBeVisible()
+		await name.fill('office-ips')
+		await page.locator('#waf-list-modal-description').fill('Office egress ranges')
+		await page.locator('#waf-list-modal-entries').fill('203.0.113.0/24\n198.51.100.7')
+		await expect(page.getByText('2 entries (max 1000).')).toBeVisible()
+
+		await page.getByRole('button', { name: 'Save' }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/wafList.set')
+		}).toBe(true)
+
+		const setReq = (await getRequestLog()).find((r) => r.path === '/wafList.set')
+		const body = JSON.parse(setReq?.body ?? '{}')
+		expect(body.project).toBe('test-project')
+		expect(body.name).toBe('office-ips')
+		expect(body.description).toBe('Office egress ranges')
+		expect(body.type).toBe('ip')
+		expect(body.entries).toEqual(['203.0.113.0/24', '198.51.100.7'])
+	})
+
+	test('validates entries live and gates Save on them', async ({ page }) => {
+		await page.goto('/waf/lists?project=test-project')
+		await page.getByRole('button', { name: 'New list' }).click()
+
+		await page.locator('#waf-list-modal-name').fill('office-ips')
+		await page.locator('#waf-list-modal-entries').fill('203.0.113.7\nnot-an-ip')
+
+		// Line-level error names the offending line; Save stays disabled.
+		await expect(page.getByText('line 2: "not-an-ip" is not an IP address or CIDR')).toBeVisible()
+		await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled()
+
+		// Fixing the entry re-enables Save.
+		await page.locator('#waf-list-modal-entries').fill('203.0.113.7')
+		await expect(page.getByRole('button', { name: 'Save' })).toBeEnabled()
+
+		// An invalid name also gates Save.
+		await page.locator('#waf-list-modal-name').fill('AB')
+		await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled()
+	})
+
+	test('editing keeps the name immutable and echoes the stored entries', async ({ page }) => {
+		await setMocks({
+			'wafList.list': {
+				ok: true,
+				result: { project: 'test-project', items: [sampleWafList] }
+			},
+			'wafList.set': { ok: true, result: {} }
+		})
+
+		await page.goto('/waf/lists?project=test-project')
+		await page.getByRole('button', { name: 'Edit IP list' }).click()
+
+		const name = page.locator('#waf-list-modal-name')
+		await expect(name).toBeVisible()
+		await expect(name).toHaveValue('office-ips')
+		await expect(name).toHaveAttribute('readonly', '')
+		await expect(page.locator('#waf-list-modal-entries'))
+			.toHaveValue('198.51.100.7\n203.0.113.0/24\n2001:db8::/48')
+
+		await page.locator('#waf-list-modal-entries').fill('198.51.100.7')
+		await page.getByRole('button', { name: 'Save' }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/wafList.set')
+		}).toBe(true)
+
+		const setReq = (await getRequestLog()).find((r) => r.path === '/wafList.set')
+		const body = JSON.parse(setReq?.body ?? '{}')
+		expect(body.name).toBe('office-ips')
+		expect(body.entries).toEqual(['198.51.100.7'])
+	})
+
+	test('delete confirms then calls wafList.delete', async ({ page }) => {
+		await setMocks({
+			'wafList.list': {
+				ok: true,
+				result: { project: 'test-project', items: [sampleWafList] }
+			},
+			'wafList.delete': { ok: true, result: {} }
+		})
+
+		await page.goto('/waf/lists?project=test-project')
+		await page.getByRole('button', { name: 'Delete IP list' }).click()
+		await page.locator('#app-modal-confirm').click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/wafList.delete')
+		}).toBe(true)
+
+		const delReq = (await getRequestLog()).find((r) => r.path === '/wafList.delete')
+		expect(JSON.parse(delReq?.body ?? '{}').name).toBe('office-ips')
+	})
+
+	test('an in-use delete surfaces the server referent list verbatim', async ({ page }) => {
+		const inUse = 'waf list "office-ips" is in use by the waf zone at gke (rules: "office allowlist"; limits: "api limit")'
+		await setMocks({
+			'wafList.list': {
+				ok: true,
+				result: { project: 'test-project', items: [{ ...sampleWafList, referencedBy: ['gke'] }] }
+			},
+			'wafList.delete': { ok: false, error: { message: inUse } }
+		})
+
+		await page.goto('/waf/lists?project=test-project')
+		await page.getByRole('button', { name: 'Delete IP list' }).click()
+		await page.locator('#app-modal-confirm').click()
+
+		await expect(page.getByText(inUse)).toBeVisible()
+	})
+
+	test('write affordances are disabled without wafList permissions', async ({ page }) => {
+		await setMocks({
+			'me.permissions': {
+				ok: true,
+				// Reads only — waf.* deliberately does NOT imply wafList.* access.
+				result: { permissions: ['waf.*', 'wafList.get', 'wafList.list'], admin: false }
+			},
+			'wafList.list': {
+				ok: true,
+				result: { project: 'test-project', items: [sampleWafList] }
+			}
+		})
+
+		await page.goto('/waf/lists?project=test-project')
+
+		const newList = page.getByRole('button', { name: 'New list' })
+		await expect(newList).toBeDisabled()
+		await expect(page.getByRole('button', { name: 'Edit IP list' })).toBeDisabled()
+		await expect(page.getByRole('button', { name: 'Delete IP list' })).toBeDisabled()
+	})
+})
+
+test.describe('waf condition builder ip list picker', () => {
+	test('builds an ipInList condition from the picker and saves it', async ({ page }) => {
+		await setMocks({
+			'wafList.list': {
+				ok: true,
+				result: { project: 'test-project', items: [sampleWafList] }
+			}
+		})
+
+		await page.goto('/waf/edit?project=test-project&location=gke')
+
+		// Visual builder starts with no rows — add a blank condition (retry until
+		// the row appears; see waf.spec.js for the hydration rationale).
+		const addCondition = page.getByRole('button', { name: 'Add condition' })
+		const value = page.locator('#waf-value')
+		await expect(async () => {
+			await addCondition.click()
+			await expect(value).toBeVisible({ timeout: 1000 })
+		}).toPass()
+
+		await pickSelect(page, 'waf-field', 'Remote IP')
+		await pickSelect(page, 'waf-operator', 'in IP list')
+		await pickSelect(page, 'waf-list-name', 'office-ips')
+
+		const save = page.getByRole('button', { name: 'Save' })
+		await expect(save).toBeEnabled()
+		await save.click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/waf.set')
+		}).toBe(true)
+
+		const setReq = (await getRequestLog()).find((r) => r.path === '/waf.set')
+		const body = JSON.parse(setReq?.body ?? '{}')
+		expect(body.rules).toHaveLength(1)
+		expect(body.rules[0].expression).toBe('ipInList(request.remote_ip, "office-ips")')
+	})
+
+	test('an existing ipInList rule round-trips into the visual builder', async ({ page }) => {
+		await setMocks({
+			'waf.get': {
+				ok: true,
+				result: wafZone({
+					rules: [{
+						id: 'rule-list1',
+						description: 'office allowlist',
+						expression: '!ipInList(request.remote_ip, "office-ips")',
+						action: 'block',
+						status: 403,
+						message: 'Forbidden',
+						priority: 0
+					}]
+				})
+			},
+			'wafList.list': {
+				ok: true,
+				result: { project: 'test-project', items: [sampleWafList] }
+			}
+		})
+
+		await page.goto('/waf/edit?project=test-project&location=gke&rule=rule-list1')
+
+		// The macro form is representable, so the Visual tab is active and the
+		// picker shows the referenced list.
+		await expect(page.getByRole('tab', { name: 'Visual' })).toBeEnabled()
+		await expect(page.locator('#waf-list-name')).toContainText('office-ips')
+	})
+
+	test('the picker is disabled with a hint when wafList.list is missing', async ({ page }) => {
+		await setMocks({
+			'me.permissions': {
+				ok: true,
+				// Full waf.* rule management but no wafList.* grants at all.
+				result: { permissions: ['waf.*'], admin: false }
+			}
+		})
+
+		await page.goto('/waf/edit?project=test-project&location=gke')
+
+		const addCondition = page.getByRole('button', { name: 'Add condition' })
+		const value = page.locator('#waf-value')
+		await expect(async () => {
+			await addCondition.click()
+			await expect(value).toBeVisible({ timeout: 1000 })
+		}).toPass()
+
+		await pickSelect(page, 'waf-field', 'Remote IP')
+		await pickSelect(page, 'waf-operator', 'in IP list')
+
+		// Console permission pre-flight: the picker renders disabled with the
+		// missing-permission hint instead of failing the fetch.
+		const picker = page.locator('#waf-list-name')
+		await expect(picker).toBeDisabled()
+		await expect(page.locator('span[title*="wafList.list"]')).toBeVisible()
+	})
+})
+
+test.describe('waf manage ip list chips', () => {
+	test('rules and limits referencing a list show a chip linking to the lists page', async ({ page }) => {
+		await setMocks({
+			'waf.get': {
+				ok: true,
+				result: wafZone({
+					rules: [{
+						id: 'rule-list1',
+						description: 'office allowlist',
+						expression: 'ipInList(request.remote_ip, "office-ips")',
+						action: 'allow',
+						priority: 0
+					}],
+					limits: [{
+						id: 'limit-1',
+						description: 'api limit',
+						key: ['ip'],
+						rate: 600,
+						window: '1m',
+						mode: 'enforce',
+						filter: '!ipInList(request.remote_ip, "monitoring")'
+					}]
+				})
+			}
+		})
+
+		await page.goto('/waf/manage?project=test-project&location=gke')
+		const main = page.locator('.content-wrapper')
+
+		const ruleChip = main.getByRole('link', { name: 'office-ips' })
+		await expect(ruleChip).toBeVisible()
+		await expect(ruleChip).toHaveAttribute('href', /\/waf\/lists\?project=test-project/)
+		await expect(main.getByRole('link', { name: 'monitoring' })).toBeVisible()
+	})
+})


### PR DESCRIPTION
## What

Console row of **SPEC-waf-ip-lists.md** (§8 Console UX, §13 per-repo breakdown): reusable named IP/CIDR lists (`wafList.*`) surfaced across the firewall UI.

- **`/waf/lists`** — new IP lists page: table (name, type, entry count, referenced-by chips linking to each referencing zone's manage page, updated), create/edit modal (`WafListModal`, name immutable on edit, client-side entry validation mirroring netip strictness, caps 3–26 name / 1000 entries), delete with in-use guard surfaced verbatim from the server.
- **Builder** — `in IP list` / `not in IP list` operators on ip-type fields; the value is a picker fed by `wafList.list` (project-keyed, stale-response-guarded). Generates the platform macro `ipInList(request.remote_ip, "name")`, round-trips it (incl. negation) back into the visual builder; also usable as a rate-limit filter via the shared builder.
- **Manage page** — list-reference chips on rules and limits (`wafListRefs` scanner, TS mirror of the api package's `waflistmacro.go` per spec §2.2), linking to `/waf/lists`.
- **Entry points** — "IP lists" header button + palette action on `/waf`, both gated on `wafList.list` (permission pre-flight convention).
- Mock fixtures (`wafList.*` session-mutable handlers incl. the in-use delete guard) + 100 Playwright specs across `waf-lists.spec.js` / `waf-expression.spec.js`.

## Deploy order — DO NOT MERGE YET

Per spec §11: console ships **after** the api + apiserver `wafList.*` PRs are live (those PRs don't exist yet — this PR is ahead of the chain). Against today's server every `wafList.*` call is an unknown action and a stored `ipInList(...)` macro is not valid engine CEL.

Composition with **apiserver#238** (server-side CEL compile validation in `waf.set`): the apiserver wafList PR must expand `ipInList(...)` **before** #238's `compileWAFZoneCEL` runs — the compile gate must only ever see the expanded expression, never the raw macro form. No file overlap with #238 in this repo; no merge conflict expected here.

No schema migration in this repo; no permission changes beyond consuming the new `wafList.*` grants.

## Tests

`bun lint` / `bun check` green. Playwright: **364 passed** (full suite, incl. 100 new/extended specs in `waf-lists.spec.js` + `waf-expression.spec.js`).

## Screenshots

| Firewall overview — new IP lists entry point | IP lists page |
| --- | --- |
| ![waf overview](https://raw.githubusercontent.com/deploys-app/console/screenshots/329-waf-overview.png) | ![lists page](https://raw.githubusercontent.com/deploys-app/console/screenshots/329-lists-page.png) |

| New/Edit list modal | Builder list picker (`in IP list`) |
| --- | --- |
| ![list modal](https://raw.githubusercontent.com/deploys-app/console/screenshots/329-list-modal.png) | ![builder picker](https://raw.githubusercontent.com/deploys-app/console/screenshots/329-builder-picker.png) |

| Manage page — list chips on rules and rate limits |
| --- |
| ![manage chips](https://raw.githubusercontent.com/deploys-app/console/screenshots/329-manage-chips.png) |
