### PR TITLE
waf: recent sampled match events on the metrics page

### DIFF
--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -596,6 +596,129 @@ function wafLimitMetrics (timeRange?: string) {
 	return { series, total }
 }
 
+// Crockford base32 (the ULID alphabet — no I, L, O, U). Event ids must be
+// lexicographically time-ordered because waf.events pages with `id < before`.
+const ULID_ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+
+/** Mint a ULID-shaped id: 10 chars of ms timestamp + 16 random chars. */
+function mockUlid (ms: number): string {
+	let t = ''
+	let x = ms
+	for (let i = 0; i < 10; i++) {
+		t = ULID_ALPHABET[x % 32] + t
+		x = Math.floor(x / 32)
+	}
+	let r = ''
+	for (let i = 0; i < 16; i++) r += ULID_ALPHABET[Math.floor(Math.random() * 32)]
+	return t + r
+}
+
+type MockWafEvent = {
+	id: string
+	at: string
+	ruleId: string
+	action: string
+	status: number
+	clientIp: string
+	country: string
+	asn: number
+	method: string
+	host: string
+	path: string
+}
+
+// Sampled match events for the seed zone, generated once per dev session so
+// keyset pagination stays coherent across requests. Spread over the 3-day
+// retention window, newest first. IPs are documentation ranges (RFC 5737) —
+// realistic-looking, never real. Includes events for `old-block-php`, a rule
+// id that no longer exists in the zone, to exercise the deleted-rule fallback.
+let wafEventsSeed: MockWafEvent[] | undefined
+
+function wafEventsAll (): MockWafEvent[] {
+	if (wafEventsSeed) return wafEventsSeed
+
+	const now = Date.now()
+	const pick = <T>(xs: T[]): T => xs[Math.floor(Math.random() * xs.length)]
+	const events: MockWafEvent[] = []
+
+	const host = `acme.${DOMAIN_SUFFIX}`
+
+	// One noisy /24 probing admin paths (the "it's one /24 in RU" story).
+	for (let i = 0; i < 70; i++) {
+		const ms = now - Math.floor(Math.random() * 3 * 86400_000)
+		events.push({
+			id: mockUlid(ms),
+			at: new Date(ms).toISOString(),
+			ruleId: 'block-admin',
+			action: 'block',
+			status: 403,
+			clientIp: `203.0.113.${10 + Math.floor(Math.random() * 40)}`,
+			country: pick(['RU', 'RU', 'RU', 'CN', 'VN']),
+			asn: pick([12389, 4134, 45899]),
+			method: pick(['POST', 'GET', 'POST']),
+			host,
+			path: pick(['/admin', '/admin/login', '/admin/config.php', '/admin/.env'])
+		})
+	}
+	// Bot traffic that only gets logged.
+	for (let i = 0; i < 40; i++) {
+		const ms = now - Math.floor(Math.random() * 3 * 86400_000)
+		events.push({
+			id: mockUlid(ms),
+			at: new Date(ms).toISOString(),
+			ruleId: 'log-bots',
+			action: 'log',
+			status: 0,
+			clientIp: `198.51.100.${1 + Math.floor(Math.random() * 250)}`,
+			country: pick(['US', 'DE', 'SG', 'FR', '']),
+			asn: pick([15169, 16509, 14061, 0]),
+			method: 'GET',
+			host,
+			path: pick(['/', '/robots.txt', '/sitemap.xml', '/api/items', '/products'])
+		})
+	}
+	// The office allow rule firing.
+	for (let i = 0; i < 8; i++) {
+		const ms = now - Math.floor(Math.random() * 3 * 86400_000)
+		events.push({
+			id: mockUlid(ms),
+			at: new Date(ms).toISOString(),
+			ruleId: 'allow-office',
+			action: 'allow',
+			status: 0,
+			clientIp: '203.0.113.7',
+			country: 'TH',
+			asn: 7470,
+			method: pick(['GET', 'POST']),
+			host,
+			path: pick(['/admin', '/admin/metrics'])
+		})
+	}
+	// Events from a rule that was since deleted (waf.set regenerates unknown
+	// ids) — the console must render these unlinked with a tooltip.
+	for (let i = 0; i < 6; i++) {
+		const ms = now - Math.floor(Math.random() * 3 * 86400_000)
+		events.push({
+			id: mockUlid(ms),
+			at: new Date(ms).toISOString(),
+			ruleId: 'old-block-php',
+			action: 'block',
+			status: 403,
+			clientIp: `192.0.2.${1 + Math.floor(Math.random() * 250)}`,
+			country: pick(['BR', 'IN']),
+			asn: pick([26599, 9829]),
+			method: 'GET',
+			host,
+			path: pick(['/wp-login.php', '/xmlrpc.php'])
+		})
+	}
+
+	// Newest first — ULIDs are time-ordered, so id desc == time desc.
+	events.sort((a, b) => (a.id < b.id ? 1 : -1))
+	wafEventsSeed = events
+	return events
+}
+
 // Locations (besides the seed LOCATION_ID) that have had a firewall created in
 // this dev session, mapped to { description, polls }. `polls` counts how many
 // times the zone has been read while pending; the deployer is simulated by
@@ -2190,6 +2313,20 @@ const handlers: Record<string, (args: any) => object> = {
 		const location = args?.location ?? LOCATION_ID
 		if (location === LOCATION_ID) return ok(wafLimitMetrics(args?.timeRange))
 		return ok({ series: [], total: 0 })
+	},
+	// Mirrors the server's read semantics: newest first, rule/action filters,
+	// keyset `before` cursor (id < before), `next` set only when the page is
+	// exactly `limit` long.
+	'waf.events': (args) => {
+		const location = args?.location ?? LOCATION_ID
+		if (location !== LOCATION_ID) return ok({ items: [], next: '' })
+		let items = wafEventsAll()
+		if (args?.ruleId) items = items.filter((e) => e.ruleId === args.ruleId)
+		if (args?.action) items = items.filter((e) => e.action === args.action)
+		if (args?.before) items = items.filter((e) => e.id < args.before)
+		const limit = Math.min(Math.max(Number(args?.limit) || 50, 1), 200)
+		const page = items.slice(0, limit)
+		return ok({ items: page, next: page.length === limit ? page[page.length - 1].id : '' })
 	},
 	'waf.delete': (args) => {
 		if (args?.location) wafConfigured.delete(args.location)

--- a/src/lib/waf/countries.ts
+++ b/src/lib/waf/countries.ts
@@ -270,3 +270,12 @@ export function countryLabel (code: string): string {
 	const name = nameByCode[c]
 	return name ? `${c} — ${name}` : code
 }
+
+/**
+ * English short name only, e.g. `"Thailand"`. Falls back to the bare code for
+ * unknown values (and '' for unresolved).
+ */
+export function countryName (code: string): string {
+	const c = String(code ?? '').toUpperCase()
+	return nameByCode[c] ?? code
+}

--- a/src/routes/(auth)/(project)/waf/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/manage/+page.svelte
@@ -249,7 +249,8 @@
 				</thead>
 				<tbody>
 					{#each rules as rule, i (rule.id)}
-						<tr>
+						<!-- Anchor target for the metrics page's event-table rule links. -->
+						<tr id={`waf-rule-${rule.id}`}>
 							<td>
 								<span class="font-mono text-sm text-content/60">{rule.id}</span>
 							</td>

--- a/src/routes/(auth)/(project)/waf/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/metrics/+page.svelte
@@ -304,6 +304,12 @@
 			events = reset ? items : [...events, ...items]
 			eventsNext = res.result?.next ?? ''
 			eventsError = null
+		} catch (e) {
+			// api.invoke synthesizes an error envelope for non-JSON bodies but still
+			// rejects when fetch itself fails (offline, connection reset). Without
+			// this, the empty state would claim "No events in the last 3 days" —
+			// a false statement about the data — on a plain network failure.
+			if (token === eventsToken) eventsError = e
 		} finally {
 			if (token === eventsToken) {
 				eventsLoading = false
@@ -355,7 +361,7 @@
 		...EVENT_ACTIONS.map((a) => ({ value: a, label: actionLabels[a] ?? a }))
 	]
 
-	const eventsSpinner = $derived(eventsLoading && events.length === 0)
+	const eventsSpinner = $derived(eventsLoading && events.length === 0 && !eventsError)
 	const eventsEmpty = $derived(!eventsLoading && !eventsError && events.length === 0)
 </script>
 
@@ -578,11 +584,13 @@
 						<div class="events-error" title={(eventsError as { message?: string })?.message ?? ''}>
 							<i class="fa-solid fa-exclamation-triangle text-warning"></i>
 							<p class="text-content/70">Something went wrong while loading events. Please try again later.</p>
+							<!-- When pages are already loaded the failure was a "Load more" —
+							     retry re-issues the cursor fetch instead of discarding them. -->
 							<button
 								type="button"
 								class="button is-variant-secondary is-size-small"
-								class:is-loading={eventsLoading}
-								onclick={() => fetchEvents(true)}>
+								class:is-loading={eventsLoading || eventsMoreLoading}
+								onclick={() => fetchEvents(events.length === 0)}>
 								Try again
 							</button>
 						</div>
@@ -595,7 +603,10 @@
 		</table>
 	</div>
 
-	{#if eventsNext}
+	<!-- Suppressed while the error row shows: a failed "Load more" keeps the old
+	     cursor, and two competing buttons (one of which used to discard every
+	     loaded page) is worse than the single retry affordance. -->
+	{#if eventsNext && !eventsError}
 		<div class="events-more">
 			<button
 				type="button"

--- a/src/routes/(auth)/(project)/waf/metrics/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/metrics/+page.svelte
@@ -9,10 +9,13 @@
 	import * as format from '$lib/format'
 	import { actionLabels } from '$lib/waf/rules'
 	import { describeKey, modeLabels } from '$lib/waf/limits'
+	import { countryName } from '$lib/waf/countries'
 	import { RANGE_SECONDS, RANGE_LABEL, BUCKET_SECONDS } from '$lib/metrics'
 	import RangeSwitch from '$lib/components/RangeSwitch.svelte'
 	import WafActivityChart from '$lib/components/WafActivityChart.svelte'
 	import LineChart from '$lib/components/LineChart.svelte'
+	import Select from '$lib/components/Select.svelte'
+	import NoDataRow from '$lib/components/NoDataRow.svelte'
 
 	const { data }: { data: PageData } = $props()
 
@@ -242,6 +245,118 @@
 	const isEmpty = $derived(!loading && total === 0)
 	const limitSpinner = $derived(loading && !limitResult)
 	const limitEmpty = $derived(!limitSpinner && limitShareSeries.length === 0)
+
+	// --- Recent events -------------------------------------------------------
+	// Sampled match events (waf.events), newest first, keyset-paginated with
+	// `before`. Fetched client-side after hydration; filters are server-side
+	// and mirrored in the query string (?ruleId=&action=) so a filtered view is
+	// shareable — and so a DELETED rule's events stay reachable by hand-editing
+	// ?ruleId=, which the rule select can't offer (it lists current rules only).
+
+	const EVENTS_PAGE_SIZE = 50
+	const EVENT_ACTIONS: Api.WafAction[] = ['log', 'allow', 'block']
+
+	function isWafAction (s: string): s is Api.WafAction {
+		return (EVENT_ACTIONS as string[]).includes(s)
+	}
+
+	// Writable $deriveds (admin#18 pattern): editable locally by the filter
+	// selects, re-seeded whenever navigation changes the URL params.
+	let eventRule = $derived($page.url.searchParams.get('ruleId') ?? '')
+	let eventAction = $derived.by(() => {
+		const a = $page.url.searchParams.get('action') ?? ''
+		return isWafAction(a) ? a : ''
+	})
+
+	let events = $state<Api.WafEvent[]>([])
+	let eventsNext = $state('')
+	let eventsLoading = $state(true)
+	let eventsMoreLoading = $state(false)
+	let eventsError = $state<unknown>(null)
+	// Bumped on every (re)fetch so a stale in-flight response (filter or
+	// project/location changed underneath it) is discarded, not appended.
+	let eventsToken = 0
+
+	async function fetchEvents (reset: boolean) {
+		const token = ++eventsToken
+		if (reset) {
+			eventsLoading = true
+		} else {
+			eventsMoreLoading = true
+		}
+		// Filters are read untracked: the events $effect below must key on
+		// project+location only (filter changes refetch via applyEventFilters,
+		// and range changes also rewrite $page.url — they must not refetch this).
+		const ruleId = untrack(() => eventRule)
+		const action = untrack(() => eventAction)
+		const args: Api.WafEventsRequest = { project, location, limit: EVENTS_PAGE_SIZE }
+		if (ruleId) args.ruleId = ruleId
+		if (action && isWafAction(action)) args.action = action
+		if (!reset && eventsNext) args.before = eventsNext
+		try {
+			const res = await api.invoke<Api.WafEventsResult>('waf.events', args, fetch)
+			if (token !== eventsToken) return
+			if (!res.ok) {
+				eventsError = res.error
+				return
+			}
+			const items = res.result?.items ?? []
+			events = reset ? items : [...events, ...items]
+			eventsNext = res.result?.next ?? ''
+			eventsError = null
+		} finally {
+			if (token === eventsToken) {
+				eventsLoading = false
+				eventsMoreLoading = false
+			}
+		}
+	}
+
+	// Same params-keyed pattern as fetchMetrics: refetch when project/location
+	// change (this page is reused across ?location= navigations without a
+	// remount). fetchEvents reads project + location synchronously before its
+	// first await, so the effect tracks them.
+	$effect(() => {
+		events = []
+		eventsNext = ''
+		fetchEvents(true)
+	})
+
+	// Reflect the filters into the URL, then refetch page 1. replaceState (not
+	// goto): a filter tweak shouldn't grow history or re-run load().
+	function applyEventFilters () {
+		const u = new URL($page.url)
+		if (eventRule) u.searchParams.set('ruleId', eventRule)
+		else u.searchParams.delete('ruleId')
+		if (eventAction) u.searchParams.set('action', eventAction)
+		else u.searchParams.delete('action')
+		replaceState(u, {})
+		events = []
+		eventsNext = ''
+		fetchEvents(true)
+	}
+
+	const eventRuleOptions = $derived.by(() => {
+		const opts = [{ value: '', label: 'All rules' }]
+		const rules = (data.zone?.rules ?? []) as Api.WafRule[]
+		for (const r of rules) {
+			opts.push({ value: r.id, label: r.description || r.id })
+		}
+		// A hand-edited ?ruleId= may name a rule that no longer exists — keep the
+		// active filter visible in the select instead of showing a blank trigger.
+		if (eventRule && !rules.some((r) => r.id === eventRule)) {
+			opts.push({ value: eventRule, label: `${eventRule} (deleted)` })
+		}
+		return opts
+	})
+
+	const eventActionOptions = [
+		{ value: '', label: 'All actions' },
+		...EVENT_ACTIONS.map((a) => ({ value: a, label: actionLabels[a] ?? a }))
+	]
+
+	const eventsSpinner = $derived(eventsLoading && events.length === 0)
+	const eventsEmpty = $derived(!eventsLoading && !eventsError && events.length === 0)
 </script>
 
 <div class="breadcrumb">
@@ -380,6 +495,118 @@
 		</div>
 	</div>
 {/if}
+
+<div class="panel is-level-300 events-panel">
+	<div class="panel-head events-head">
+		<div>
+			<h6><strong>Recent events</strong></h6>
+			<p class="page-sub">
+				Sampled — a bounded number of events per firewall (up to 60/min per
+				ingress instance) is kept for 3 days. Counts in the chart above are exact.
+			</p>
+		</div>
+		<div class="events-filters">
+			<Select
+				id="events-filter-rule"
+				bind:value={eventRule}
+				options={eventRuleOptions}
+				onchange={applyEventFilters} />
+			<Select
+				id="events-filter-action"
+				bind:value={eventAction}
+				options={eventActionOptions}
+				onchange={applyEventFilters} />
+		</div>
+	</div>
+
+	<div class="table-container">
+		<table class="table is-variant-compact">
+			<thead>
+				<tr>
+					<th>Time</th>
+					<th>Action</th>
+					<th>Rule</th>
+					<th>IP</th>
+					<th>Country</th>
+					<th>Method</th>
+					<th>Host</th>
+					<th>Path</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each events as ev (ev.id)}
+					{@const meta = ruleMeta.get(ev.ruleId)}
+					<tr>
+						<td class="whitespace-nowrap" title={format.datetime(ev.at)}>{format.fromNow(ev.at)}</td>
+						<td>
+							<span class="act-badge" data-action={ev.action}>{actionLabels[ev.action] ?? ev.action}</span>
+						</td>
+						<td>
+							{#if meta}
+								<a
+									class="link font-mono text-sm"
+									href={`${managePath}#waf-rule-${encodeURIComponent(ev.ruleId)}`}
+									title={meta.description || ev.ruleId}>{ev.ruleId}</a>
+							{:else}
+								<!-- Events outlive rules by up to 3 days (and waf.set
+								     regenerates unknown ids) — never a dead link. -->
+								<span class="font-mono text-sm text-content/55" title="rule no longer exists">{ev.ruleId}</span>
+							{/if}
+						</td>
+						<td class="font-mono text-sm whitespace-nowrap">{ev.clientIp}</td>
+						<td class="whitespace-nowrap">
+							{#if ev.country}
+								{countryName(ev.country)}
+							{:else}
+								<span class="text-content/40">—</span>
+							{/if}
+						</td>
+						<td class="font-mono text-sm">{ev.method}</td>
+						<td class="font-mono text-sm event-trunc" title={ev.host}>{ev.host}</td>
+						<td class="font-mono text-sm event-trunc" title={ev.path}>{ev.path}</td>
+					</tr>
+				{/each}
+				{#if eventsSpinner}
+					<tr><td colspan="8" class="text-center text-content/40">
+						<i class="fa-solid fa-spinner-third fa-spin"></i>
+					</td></tr>
+				{/if}
+				<!-- Not ErrorRow: its retry re-runs load(), which can't reach this
+				     client-side fetch — retry here re-invokes waf.events directly. -->
+				{#if eventsError}
+					<tr><td colspan="8">
+						<div class="events-error" title={(eventsError as { message?: string })?.message ?? ''}>
+							<i class="fa-solid fa-exclamation-triangle text-warning"></i>
+							<p class="text-content/70">Something went wrong while loading events. Please try again later.</p>
+							<button
+								type="button"
+								class="button is-variant-secondary is-size-small"
+								class:is-loading={eventsLoading}
+								onclick={() => fetchEvents(true)}>
+								Try again
+							</button>
+						</div>
+					</td></tr>
+				{/if}
+				{#if eventsEmpty}
+					<NoDataRow span={8} icon="fa-shield-halved" message="No events in the last 3 days." />
+				{/if}
+			</tbody>
+		</table>
+	</div>
+
+	{#if eventsNext}
+		<div class="events-more">
+			<button
+				type="button"
+				class="button is-variant-secondary is-size-small"
+				class:is-loading={eventsMoreLoading}
+				onclick={() => fetchEvents(false)}>
+				Load more
+			</button>
+		</div>
+	{/if}
+</div>
 
 {#if hasLimits}
 	<div class="panel is-level-300 limit-panel">
@@ -709,6 +936,51 @@
 	.act-badge[data-action='allow'] {
 		color: hsl(var(--hsl-positive));
 		background-color: hsl(var(--hsl-positive) / 0.12);
+	}
+
+	/* Recent events */
+	.events-panel {
+		margin-top: 1rem;
+	}
+
+	.events-head {
+		align-items: flex-start;
+	}
+
+	.events-filters {
+		display: flex;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+	}
+
+	/* Select defaults to width:100% (form layouts) — pin the filters to a
+	   readable fixed width so they sit side by side in the panel head. */
+	.events-filters :global(.select-box) {
+		width: 12rem;
+	}
+
+	/* Attacker-chosen strings — cap the cell, full value in the title. */
+	.event-trunc {
+		max-width: 16rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.events-more {
+		display: flex;
+		justify-content: center;
+		margin-top: 0.75rem;
+	}
+
+	.events-error {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		padding: 1.5rem 1rem;
+		text-align: center;
 	}
 
 	/* Rate limit activity */

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -907,6 +907,7 @@ declare namespace Api {
     export type WafListListResult = {
         project: string
         items: WafListItem[]
+    }
 
     // waf.events request — recent sampled match events for a zone, newest
     // first. Events are SAMPLES (bounded capture per controller pod) retained

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -907,6 +907,47 @@ declare namespace Api {
     export type WafListListResult = {
         project: string
         items: WafListItem[]
+
+    // waf.events request — recent sampled match events for a zone, newest
+    // first. Events are SAMPLES (bounded capture per controller pod) retained
+    // 3 days; waf.metrics remains the exact count.
+    export type WafEventsRequest = {
+        project: string
+        location: string
+        // optional filter, short project-local rule id
+        ruleId?: string
+        // optional filter
+        action?: WafAction
+        // keyset cursor: events with id < before (ids are time-ordered ULIDs)
+        before?: string
+        // 0 = 50, max 200
+        limit?: number
+    }
+
+    export type WafEventsResult = {
+        items: WafEvent[]
+        // pass as `before` for the next page; '' = exhausted
+        next: string
+    }
+
+    // One sampled match. ruleId is the short, project-local id joining to
+    // WafRule.id — but events outlive rules by up to 3 days (and waf.set
+    // regenerates unknown ids), so it may match nothing in the current zone.
+    export type WafEvent = {
+        id: string
+        at: string
+        ruleId: string
+        action: WafAction
+        status: number
+        clientIp: string
+        // ISO 3166-1 alpha-2, '' if unresolved
+        country: string
+        // 0 if unresolved
+        asn: number
+        method: string
+        host: string
+        // URL path only (no query)
+        path: string
     }
 
     export type CacheAction = 'cache' | 'bypass'

--- a/tests/waf-events.spec.js
+++ b/tests/waf-events.spec.js
@@ -236,4 +236,115 @@ test.describe('firewall recent events', () => {
 		// Exhausted → the button goes away.
 		await expect(page.getByRole('button', { name: 'Load more' })).toHaveCount(0)
 	})
+
+	test('refetches when navigating between locations without a remount', async ({ page }) => {
+		// The WAF list links here per location, so ?location=A -> ?location=B is a
+		// client-side navigation that REUSES this component (console#303 bug
+		// class): an onMount-only fetch would keep A's events under B's header.
+		const zone = wafZone({ rules: [wafRule()] })
+		const locB = { ...wafLocation, id: 'sgp' }
+		await setMocks({
+			...metricsMocks(zone, {
+				items: [wafEvent({ id: eventId(2), path: '/from-location-a' })],
+				next: ''
+			}),
+			'location.list': { ok: true, result: { items: [wafLocation, locB] } }
+		})
+
+		await page.goto('/waf/metrics?project=test-project&location=gke')
+		const panel = page.locator('.events-panel')
+		await expect(panel.getByText('/from-location-a')).toBeVisible()
+
+		await setMocks({
+			'waf.events': {
+				ok: true,
+				result: { items: [wafEvent({ id: eventId(3), path: '/from-location-b' })], next: '' }
+			}
+		})
+
+		// Navigate via an in-page anchor click so SvelteKit's router handles it
+		// client-side (goto would be a full document load — a remount). The click
+		// is dispatched in-page — the layout's menu overlays a body-appended
+		// element, so a pointer click can't reach it; SvelteKit's document-level
+		// click handler intercepts the synthetic event all the same. The marker
+		// surviving the navigation proves the document was reused.
+		await page.evaluate(() => {
+			/** @type {any} */ (window).__wafSpaMarker = true
+			const a = document.createElement('a')
+			a.href = '/waf/metrics?project=test-project&location=sgp'
+			a.textContent = 'location b'
+			document.body.appendChild(a)
+			a.click()
+		})
+
+		await expect(panel.getByText('/from-location-b')).toBeVisible()
+		await expect(panel.getByText('/from-location-a')).toHaveCount(0)
+		expect(await page.evaluate(() => /** @type {any} */ (window).__wafSpaMarker)).toBe(true)
+
+		// The refetch carried the new location.
+		const reqs = (await getRequestLog()).filter((r) => r.path === '/waf.events')
+		expect(JSON.parse(reqs[reqs.length - 1].body || '{}').location).toBe('sgp')
+	})
+
+	test('shows the error row on failure — never the empty state — and Try again recovers', async ({ page }) => {
+		const zone = wafZone({ rules: [wafRule()] })
+		await setMocks({
+			...metricsMocks(zone, { items: [], next: '' }),
+			'waf.events': { ok: false, error: { message: 'boom' } }
+		})
+
+		await page.goto('/waf/metrics?project=test-project&location=gke')
+		const panel = page.locator('.events-panel')
+
+		// A failed fetch must read as a failure, not as verified absence of events.
+		await expect(panel.getByText('Something went wrong while loading events. Please try again later.')).toBeVisible()
+		await expect(panel.getByText('No events in the last 3 days.')).toHaveCount(0)
+
+		await setMocks({
+			'waf.events': { ok: true, result: { items: [wafEvent({ id: eventId(1) })], next: '' } }
+		})
+		await panel.getByRole('button', { name: 'Try again' }).click()
+
+		await expect(panel.getByText('203.0.113.9')).toBeVisible()
+		await expect(panel.getByText('Something went wrong while loading events. Please try again later.')).toHaveCount(0)
+	})
+
+	test('a failed load more keeps loaded pages and retries the cursor fetch', async ({ page }) => {
+		const zone = wafZone({ rules: [wafRule()] })
+		const first = Array.from({ length: 50 }, (_, i) => wafEvent({
+			id: eventId(100 - i),
+			path: `/admin/page-${i}`
+		}))
+		await setMocks(metricsMocks(zone, { items: first, next: first[first.length - 1].id }))
+
+		await page.goto('/waf/metrics?project=test-project&location=gke')
+		const panel = page.locator('.events-panel')
+		await expect(panel.getByText('/admin/page-0')).toBeVisible()
+
+		await setMocks({ 'waf.events': { ok: false, error: { message: 'boom' } } })
+		await page.getByRole('button', { name: 'Load more' }).click()
+
+		// One affordance, not two: the error row's retry — Load more is suppressed
+		// while the error shows, and the loaded pages stay on screen.
+		await expect(panel.getByText('Something went wrong while loading events. Please try again later.')).toBeVisible()
+		await expect(page.getByRole('button', { name: 'Load more' })).toHaveCount(0)
+		await expect(panel.getByText('/admin/page-0')).toBeVisible()
+
+		await setMocks({
+			'waf.events': {
+				ok: true,
+				result: { items: [wafEvent({ id: eventId(1), path: '/admin/last' })], next: '' }
+			}
+		})
+		await panel.getByRole('button', { name: 'Try again' }).click()
+
+		// Retry resumed from the cursor: pages preserved, next page appended.
+		await expect(panel.getByText('/admin/last')).toBeVisible()
+		await expect(panel.getByText('/admin/page-0')).toBeVisible()
+
+		const reqs = (await getRequestLog()).filter((r) => r.path === '/waf.events')
+		expect(reqs.length).toBe(3)
+		expect(JSON.parse(reqs[1].body || '{}').before).toBe(eventId(51))
+		expect(JSON.parse(reqs[2].body || '{}').before).toBe(eventId(51))
+	})
 })

--- a/tests/waf-events.spec.js
+++ b/tests/waf-events.spec.js
@@ -1,0 +1,239 @@
+import { test, expect, setMocks, getRequestLog, pickSelect } from './helpers.js'
+import { defaultLocation } from './fixtures/mocks.js'
+
+// A WAF-capable location (the default fixture location has no `waf` feature).
+const wafLocation = { ...defaultLocation, id: 'gke', features: { waf: true } }
+
+/** Build a WAF zone fixture. */
+function wafZone (overrides = {}) {
+	return {
+		project: 'test-project',
+		location: 'gke',
+		description: '',
+		rules: [],
+		limits: [],
+		status: 'success',
+		action: 'create',
+		createdAt: '2024-01-01T00:00:00Z',
+		createdBy: '[email protected]',
+		...overrides
+	}
+}
+
+/** Build a WAF rule fixture. */
+function wafRule (overrides = {}) {
+	return {
+		id: 'rule-block1',
+		description: 'block admin',
+		expression: 'request.path.startsWith("/admin")',
+		action: 'block',
+		status: 403,
+		message: 'Forbidden',
+		priority: 0,
+		...overrides
+	}
+}
+
+/**
+ * 26-char, Crockford-base32-shaped event id whose lexicographic order follows
+ * `n` — bigger n sorts later, so pages can be built newest-first.
+ * @param {number} n
+ */
+function eventId (n) {
+	return '01J' + String(n).padStart(23, '0')
+}
+
+/** Build a WAF event fixture. */
+function wafEvent (overrides = {}) {
+	return {
+		id: eventId(1),
+		at: new Date().toISOString(),
+		ruleId: 'rule-block1',
+		action: 'block',
+		status: 403,
+		clientIp: '203.0.113.9',
+		country: 'TH',
+		asn: 7470,
+		method: 'POST',
+		host: 'acme.example.com',
+		path: '/admin/login',
+		...overrides
+	}
+}
+
+/** Default mocks for a metrics page visit with the given zone + events page. */
+function metricsMocks (zone, eventsResult) {
+	return {
+		'location.list': { ok: true, result: { items: [wafLocation] } },
+		'waf.get': { ok: true, result: zone },
+		'waf.metrics': { ok: true, result: { series: [], total: 0 } },
+		'waf.events': { ok: true, result: eventsResult }
+	}
+}
+
+test.describe('firewall recent events', () => {
+	test('renders sampled events with rule links and the sampling caption', async ({ page }) => {
+		const zone = wafZone({ rules: [wafRule()] })
+		await setMocks(metricsMocks(zone, {
+			items: [
+				wafEvent({ id: eventId(2) }),
+				wafEvent({
+					id: eventId(1),
+					ruleId: 'rule-log1',
+					action: 'log',
+					status: 0,
+					clientIp: '198.51.100.4',
+					country: '',
+					method: 'GET',
+					path: '/robots.txt'
+				})
+			],
+			next: ''
+		}))
+
+		await page.goto('/waf/metrics?project=test-project&location=gke')
+		const panel = page.locator('.events-panel')
+
+		await expect(panel.getByRole('heading', { name: 'Recent events' })).toBeVisible()
+		// The permanent sampling caption, worded per the spec.
+		await expect(panel.getByText('Sampled — a bounded number of events per firewall')).toBeVisible()
+
+		// Row content: IP (mono), country name, method, host, path.
+		await expect(panel.getByText('203.0.113.9')).toBeVisible()
+		await expect(panel.getByText('Thailand')).toBeVisible()
+		await expect(panel.getByText('/admin/login')).toBeVisible()
+		await expect(panel.getByText('/robots.txt')).toBeVisible()
+
+		// Action badges.
+		await expect(panel.locator('.act-badge', { hasText: 'Block' })).toHaveCount(1)
+		await expect(panel.locator('.act-badge', { hasText: 'Log' })).toHaveCount(1)
+
+		// A live rule renders as a link to its row on the manage page, tooltip =
+		// the rule description from waf.get.
+		const ruleLink = panel.locator('a', { hasText: 'rule-block1' })
+		await expect(ruleLink).toHaveAttribute('href', '/waf/manage?project=test-project&location=gke#waf-rule-rule-block1')
+		await expect(ruleLink).toHaveAttribute('title', 'block admin')
+	})
+
+	test('renders a deleted rule id unlinked with a tooltip', async ({ page }) => {
+		// The event's rule id matches nothing in waf.get (events outlive rules by
+		// up to 3 days) — it must render as plain text, never a dead link.
+		const zone = wafZone({ rules: [wafRule()] })
+		await setMocks(metricsMocks(zone, {
+			items: [wafEvent({ id: eventId(1), ruleId: 'rule-gone' })],
+			next: ''
+		}))
+
+		await page.goto('/waf/metrics?project=test-project&location=gke')
+		const panel = page.locator('.events-panel')
+
+		const deleted = panel.getByText('rule-gone', { exact: true })
+		await expect(deleted).toBeVisible()
+		await expect(deleted).toHaveAttribute('title', 'rule no longer exists')
+		await expect(panel.locator('a', { hasText: 'rule-gone' })).toHaveCount(0)
+	})
+
+	test('shows the empty state when the zone has no events', async ({ page }) => {
+		await setMocks(metricsMocks(wafZone({ rules: [wafRule()] }), { items: [], next: '' }))
+
+		await page.goto('/waf/metrics?project=test-project&location=gke')
+
+		await expect(page.getByText('No events in the last 3 days.')).toBeVisible()
+	})
+
+	test('passes a hand-edited ?ruleId= straight to waf.events and keeps it selectable', async ({ page }) => {
+		// A deleted rule is absent from the rule select's options, but its events
+		// stay filterable via the query param, which maps 1:1 onto the RPC filter.
+		await setMocks(metricsMocks(wafZone({ rules: [wafRule()] }), { items: [], next: '' }))
+
+		await page.goto('/waf/metrics?project=test-project&location=gke&ruleId=rule-gone')
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/waf.events')
+		}).toBe(true)
+
+		const req = (await getRequestLog()).find((r) => r.path === '/waf.events')
+		const body = JSON.parse(req?.body ?? '{}')
+		expect(body.ruleId).toBe('rule-gone')
+		expect(body.limit).toBe(50)
+
+		// The active filter stays visible in the select rather than a blank trigger.
+		await expect(page.locator('#events-filter-rule')).toContainText('rule-gone (deleted)')
+	})
+
+	test('action filter refetches server-side and lands in the URL', async ({ page }) => {
+		const zone = wafZone({ rules: [wafRule()] })
+		await setMocks(metricsMocks(zone, {
+			items: [wafEvent({ id: eventId(1) })],
+			next: ''
+		}))
+
+		await page.goto('/waf/metrics?project=test-project&location=gke')
+		await expect(page.locator('.events-panel').getByText('203.0.113.9')).toBeVisible()
+
+		await pickSelect(page, 'events-filter-action', 'Block')
+
+		// The filter maps onto the waf.events `action` param — server-side, not
+		// client-side.
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/waf.events' && JSON.parse(r.body || '{}').action === 'block')
+		}).toBe(true)
+
+		// And is reflected into the query string for shareable URLs.
+		await expect(page).toHaveURL(/action=block/)
+	})
+
+	test('rule filter refetches with the short rule id', async ({ page }) => {
+		const zone = wafZone({ rules: [wafRule({ id: 'rule-block1', description: 'block admin' })] })
+		await setMocks(metricsMocks(zone, { items: [], next: '' }))
+
+		await page.goto('/waf/metrics?project=test-project&location=gke')
+		await expect(page.getByText('No events in the last 3 days.')).toBeVisible()
+
+		// Options come from waf.get's current rules, labeled by description.
+		await pickSelect(page, 'events-filter-rule', 'block admin')
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/waf.events' && JSON.parse(r.body || '{}').ruleId === 'rule-block1')
+		}).toBe(true)
+
+		await expect(page).toHaveURL(/ruleId=rule-block1/)
+	})
+
+	test('load more pages with the keyset cursor', async ({ page }) => {
+		const zone = wafZone({ rules: [wafRule()] })
+		// A full first page (50 = the page size) with `next` set → Load more shows.
+		const first = Array.from({ length: 50 }, (_, i) => wafEvent({
+			id: eventId(100 - i),
+			path: `/admin/page-${i}`
+		}))
+		await setMocks(metricsMocks(zone, { items: first, next: first[first.length - 1].id }))
+
+		await page.goto('/waf/metrics?project=test-project&location=gke')
+		const rows = page.locator('.events-panel tbody tr')
+		await expect(rows).toHaveCount(50)
+
+		// Second page appended after the first.
+		await setMocks({
+			'waf.events': {
+				ok: true,
+				result: { items: [wafEvent({ id: eventId(1), path: '/admin/last' })], next: '' }
+			}
+		})
+		await page.getByRole('button', { name: 'Load more' }).click()
+
+		await expect(rows).toHaveCount(51)
+		await expect(page.locator('.events-panel').getByText('/admin/last')).toBeVisible()
+
+		// The second request carried the cursor: before = previous page's next.
+		const reqs = (await getRequestLog()).filter((r) => r.path === '/waf.events')
+		expect(reqs.length).toBe(2)
+		expect(JSON.parse(reqs[1].body || '{}').before).toBe(eventId(51))
+
+		// Exhausted → the button goes away.
+		await expect(page.getByRole('button', { name: 'Load more' })).toHaveCount(0)
+	})
+})


### PR DESCRIPTION
Implements the console workstream of **SPEC-waf-events.md** (§G, step 5 in the §J rollout table): the `/waf/metrics?project=&location=` page gains a **Recent events** panel under the match chart — recent sampled WAF match events served by the new `waf.events` RPC.

## What

- **Table** (`table is-variant-compact`): time (relative, absolute on hover), action badge (block=danger, log=neutral, allow=success), rule (short id linked to its row on `/waf/manage`, tooltip = description from the already-loaded `waf.get`), IP (mono), country name, method, host, path (mono, truncated, full value in `title`).
- **Filters**: action (all/log/allow/block) + rule (from `waf.get`'s current rules), both **server-side** — they map 1:1 onto `waf.events` params — and mirrored into the query string (writable-`$derived` URL-params pattern, admin#18) so a filtered view is shareable. A hand-edited `?ruleId=` naming a deleted rule passes straight through to the RPC and stays visible as `<id> (deleted)` in the select.
- **Deleted-rule fallback**: events outlive rules by up to 3 days (and `waf.set` regenerates unknown ids), so an event's rule id may match nothing in `waf.get` — such ids render unlinked with a *"rule no longer exists"* tooltip, never a dead link.
- **Pagination**: keyset — "Load more" sends `before = next`, page size 50; the server sets `next` only on an exactly-full page.
- **Sampling caption** (verbatim per spec §G): *"Sampled — a bounded number of events per firewall (up to 60/min per ingress instance) is kept for 3 days. Counts in the chart above are exact."*
- **Fetch lifecycle**: client-side after hydration, keyed on `(project, location)` via the params-keyed `$effect` pattern (console#303) — `?location=A → ?location=B` reuses this component without a remount and must refetch. Filter/range `replaceState` writes don't re-trigger it; stale in-flight responses are discarded via a token bump.
- **Failure handling**: a rejected fetch (offline, connection reset) or an error envelope renders an error row with a single retry affordance — never the "No events in the last 3 days." empty state, which would be a false claim about the data. A failed "Load more" keeps the loaded pages, suppresses the Load more button while the error shows, and "Try again" re-issues the cursor fetch instead of discarding pages.

Also: `waf/manage` rule rows gain `id="waf-rule-<id>"` anchor targets for the event-table links; `src/types/api.d.ts` mirrors the `waf.events` wire types (request/result/`WafEvent`); the dev mock (`bun dev:mock`) seeds ~3 days of events — RFC 5737 documentation IPs only — and replicates the server's exact filter/cursor semantics, including a deleted-rule id.

## Screenshots

Generated via the Playwright harness against `bun dev:mock` (documentation IPs only). The seed data includes `old-block-php`, a rule that no longer exists in the zone — visible in the panel as the muted, unlinked id.

The metrics page with the new panel in context (dark):

![metrics page with recent events, dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/330-metrics-page-dark.png)

Panel close-up (light) — badges, deleted-rule fallback, country names, truncated mono host/path:

![recent events panel, light](https://raw.githubusercontent.com/deploys-app/console/screenshots/330-events-panel-light.png)

Filtered to Block via the server-side action filter (`?action=block` reflected in the URL), dark:

![recent events filtered to block, dark](https://raw.githubusercontent.com/deploys-app/console/screenshots/330-events-filtered-block-dark.png)

## Test evidence

`tests/waf-events.spec.js` — 10 tests against the mock server:

- render: rows, badges, country names, rule links + tooltips, sampling caption
- deleted-rule id renders unlinked with tooltip
- empty state
- hand-edited `?ruleId=` passthrough + "(deleted)" select option
- action filter refetches server-side and lands in the URL
- rule filter refetches with the short rule id
- keyset cursor: full page → Load more sends `before = next`, appends, button disappears on exhaustion
- `?location=A → ?location=B` same-component SPA navigation refetches (document reuse asserted via a window marker)
- fetch failure shows the error row — never the empty state — and Try again recovers
- failed Load more keeps loaded pages, offers one retry affordance, retry re-issues the same cursor

Full local verification: `bun lint` 0 errors · `bun check` 0 errors · full Playwright suite **341 passed** (`bun run test`).

## Rollout (SPEC §J — every step inert alone)

This PR is **step 5 of 7**. Safe order: **apiserver migration → apiserver binary → parapet image + `WAF_EVENTS_TOKEN` Secret → collector envs → console/docs.**

1. parapet-ingress-controller — `wafevent` ring + bearer-authed `:9188` cursor endpoint + headless Service (moonrhythm/parapet-ingress-controller#182); endpoint off until both envs set, inert until polled
2. api — `Collector.SetWAFEvents` + `WAF.Events` types; tag after merge (this repo consumes the API only via the hand-written type mirror — the api re-pin gate applies to the Go consumers, not console)
3. apiserver — `waf_events` DDL (**apply migration before binary**, house rule) + `collector.setWAFEvents` + `waf.events`
4. collector — `syncWAFEvents`; enabled only when `waf_events_target` + `waf_events_token` are set (same Secret value as the controller), so the binary can ship early
5. **console (this PR)** — **merge gate: step 3 deployed**, otherwise the panel shows the error row in prod. Until events flow it degrades to the empty state; rollback = revert, no data to unwind
6. mcp / CLI, 7. docs — follow separately

## Notes

- **Expected merge conflicts**: `waf-test` and `waf-ip-lists` are open on this repo and also touch `src/lib/server/mock.ts`, `src/types/api.d.ts`, and `waf/manage/+page.svelte` (adjacent additions — trivial resolution; whichever lands second rebases).
- **Open question for the spec author**: this table fetches once per `(project, location)` with no periodic refresh, while the chart above self-refreshes every 60s on short ranges. Spec §G specifies the one-shot load and §A's non-goals exclude live tail; joining the 60s tick would clobber a paginated view mid-inspection, so this PR keeps fetch-once (filters / Try again / navigation all refetch). If "poll-refresh table" in §A meant periodic re-poll, that's a small follow-up.
- PII: client IPs are display-only; attacker-chosen strings (method/host/path) are Svelte-escaped and truncated with the full value in `title`. Mock and tests use RFC 5737 documentation IPs exclusively.
