### PR TITLE
waf: managed rules (OWASP Core Rule Set) card, feature-flag pre-flight, CRS column

### DIFF
--- a/src/lib/components/TagInput.svelte
+++ b/src/lib/components/TagInput.svelte
@@ -6,9 +6,11 @@
 		placeholder?: string
 		/** id for the inner input (label association) */
 		id?: string
+		/** freeze the control — chips stay visible but nothing is editable */
+		disabled?: boolean
 	}
 
-	let { tags = $bindable([]), placeholder = '', id }: Props = $props()
+	let { tags = $bindable([]), placeholder = '', id, disabled = false }: Props = $props()
 
 	let draft = $state('')
 
@@ -16,6 +18,7 @@
 
 	// Commit the current draft as a chip: trim, ignore empties, de-dupe.
 	function commit () {
+		if (disabled) return
 		const v = draft.trim()
 		draft = ''
 		if (!v) return
@@ -45,7 +48,7 @@
 	{#each tags as tag, i (tag)}
 		<span class="chip">
 			<span class="chip-label">{tag}</span>
-			<button type="button" class="chip-remove" aria-label={`Remove ${tag}`} onclick={(e) => { e.stopPropagation(); remove(i) }}>
+			<button type="button" class="chip-remove" aria-label={`Remove ${tag}`} {disabled} onclick={(e) => { e.stopPropagation(); remove(i) }}>
 				<i class="fa-solid fa-xmark"></i>
 			</button>
 		</span>
@@ -53,6 +56,7 @@
 	<input
 		bind:this={inputEl}
 		{id}
+		{disabled}
 		class="chip-field"
 		bind:value={draft}
 		placeholder={tags.length === 0 ? placeholder : ''}
@@ -104,9 +108,13 @@
 		transition: background-color var(--timing-faster) ease, color var(--timing-faster) ease;
 	}
 
-	.chip-remove:hover {
+	.chip-remove:hover:not(:disabled) {
 		background-color: hsl(var(--hsl-content) / 0.12);
 		color: hsl(var(--hsl-content));
+	}
+
+	.chip-remove:disabled {
+		cursor: default;
 	}
 
 	.chip-field {

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -162,7 +162,10 @@ const locations = [
 		cname: 'rcf2.deploys.app.',
 		cpuAllocatable: ['100m', '250m', '500m', '1000m', '2000m'],
 		memoryAllocatable: ['128Mi', '256Mi', '512Mi', '1Gi', '2Gi'],
-		features: { workloadIdentity: true, disk: {}, waf: {}, cache: {}, transform: {} },
+		// Only the seed location offers managed rules (OWASP CRS); sg1 keeps the
+		// bare waf flag so the manage page's "Not available in this location"
+		// card state is reachable in dev.
+		features: { workloadIdentity: true, disk: {}, waf: { managedRules: true }, cache: {}, transform: {} },
 		createdAt: CREATED_AT
 	},
 	{
@@ -517,6 +520,17 @@ const wafZone = {
 	createdBy: USER_EMAIL
 }
 
+// Managed-rules (OWASP CRS) block for the seed zone. Session-mutable so the
+// manage page's card round-trips (enable → save → reload) within a dev
+// session; null = never configured / cleared by a set that omitted it.
+let wafSeedManagedRules: object | null = {
+	enabled: true,
+	mode: 'enforce',
+	paranoiaLevel: 1,
+	anomalyThreshold: 5,
+	excludedRules: [942100]
+}
+
 const wafRangeSeconds: Record<string, number> = { '1h': 3600, '6h': 21600, '12h': 43200, '1d': 86400, '7d': 604800, '30d': 2592000 }
 
 // Synthetic match metrics for the seed zone, so the firewall index sparkline +
@@ -601,7 +615,7 @@ function wafLimitMetrics (timeRange?: string) {
 // times the zone has been read while pending; the deployer is simulated by
 // flipping the zone from pending → success after the first poll, so the index
 // spinner visibly resolves on its own. Lets create → manage flow work too.
-const wafConfigured = new Map<string, { description: string, polls: number }>()
+const wafConfigured = new Map<string, { description: string, polls: number, managedRules?: object | null }>()
 
 /**
  * Build a WAF zone for a session-created location. `advance` simulates the
@@ -623,6 +637,7 @@ function wafConfiguredZone (location: string, advance = false) {
 		description: entry.description,
 		rules: [],
 		limits: [],
+		managedRules: entry.managedRules ?? null,
 		status,
 		action: 'create',
 		createdAt: CREATED_AT,
@@ -1671,7 +1686,9 @@ const handlers: Record<string, (args: any) => object> = {
 	},
 
 	'location.list': () => list(locations),
-	'location.get': (args) => ok(locations.find((l) => l.id === args?.location) ?? locations[0]),
+	// Callers pass the location as `id` (matching the real API); `location` is
+	// kept as a legacy fallback.
+	'location.get': (args) => ok(locations.find((l) => l.id === (args?.id ?? args?.location)) ?? locations[0]),
 
 	'deployment.list': () => list(deployments.map(toDeploymentListItem)),
 	// revision > 0 returns that revision's historical spec (like the real
@@ -2158,7 +2175,7 @@ const handlers: Record<string, (args: any) => object> = {
 	// wafConfiguredZone), so the index spinner resolves on its own. waf.set and
 	// waf.delete keep the index/create/manage flows coherent within a session.
 	'waf.list': () => {
-		const items = [{ ...wafZone, location: LOCATION_ID }]
+		const items = [{ ...wafZone, location: LOCATION_ID, managedRules: wafSeedManagedRules }]
 		for (const location of wafConfigured.keys()) {
 			items.push(wafConfiguredZone(location, true))
 		}
@@ -2166,7 +2183,7 @@ const handlers: Record<string, (args: any) => object> = {
 	},
 	'waf.get': (args) => {
 		const location = args?.location ?? LOCATION_ID
-		if (location === LOCATION_ID) return ok({ ...wafZone, location: LOCATION_ID })
+		if (location === LOCATION_ID) return ok({ ...wafZone, location: LOCATION_ID, managedRules: wafSeedManagedRules })
 		if (wafConfigured.has(location)) {
 			return ok(wafConfiguredZone(location))
 		}
@@ -2174,8 +2191,16 @@ const handlers: Record<string, (args: any) => object> = {
 	},
 	'waf.set': (args) => {
 		const location = args?.location
-		if (location && location !== LOCATION_ID) {
-			wafConfigured.set(location, { description: args?.description ?? '', polls: 0 })
+		// waf.set replaces the whole zone: an omitted managedRules clears the
+		// block (whole-replace semantics), so ?? null — not "keep".
+		if (location === LOCATION_ID) {
+			wafSeedManagedRules = args?.managedRules ?? null
+		} else if (location) {
+			wafConfigured.set(location, {
+				description: args?.description ?? '',
+				polls: 0,
+				managedRules: args?.managedRules ?? null
+			})
 		}
 		return ok({})
 	},

--- a/src/lib/waf/managed.ts
+++ b/src/lib/waf/managed.ts
@@ -1,0 +1,96 @@
+// Shared managed-rules (OWASP CRS) helpers for the firewall manage page —
+// form ⇄ api normalization, mirroring limits.ts. The block is typed knobs
+// only: the platform generates the SecLang document server-side, so the form
+// never handles raw rules, just ints and CRS rule ids.
+
+export interface ManagedForm {
+	enabled: boolean
+	mode: 'enforce' | 'detect'
+	paranoiaLevel: number
+	anomalyThreshold: number
+	// Chip strings as typed; parsed/validated via excludedRuleError below.
+	excludedRules: string[]
+}
+
+export const DEFAULT_PARANOIA_LEVEL = 1
+export const DEFAULT_ANOMALY_THRESHOLD = 5
+
+// Exclusion bounds mirror the api contract: only CRS detection-rule ids —
+// below the floor sit the platform SecActions + CRS setup, at/above the
+// ceiling the anomaly scoring machinery.
+export const EXCLUDED_RULE_ID_MIN = 911100
+export const EXCLUDED_RULE_ID_MAX = 948999
+export const MAX_EXCLUDED_RULES = 50
+
+export const paranoiaLevels: { value: number, label: string, description: string }[] = [
+	{ value: 1, label: '1', description: 'Baseline, minimal false positives' },
+	{ value: 2, label: '2', description: 'Elevated — some false positives' },
+	{ value: 3, label: '3', description: 'Strict — expect to tune exclusions' },
+	{ value: 4, label: '4', description: 'Paranoid, expect false positives' }
+]
+
+export const modeOptions: { value: 'enforce' | 'detect', label: string }[] = [
+	{ value: 'enforce', label: 'Enforce (block)' },
+	{ value: 'detect', label: 'Detect only (log, never block)' }
+]
+
+/**
+ * Map an API managed-rules block (or its absence) to form state, rendering
+ * the server-side defaults (0 = PL1 / threshold 5) explicitly.
+ */
+export function managedForm (m?: Api.WafManagedRules | null): ManagedForm {
+	return {
+		enabled: m?.enabled ?? false,
+		mode: m?.mode === 'detect' ? 'detect' : 'enforce',
+		paranoiaLevel: m?.paranoiaLevel || DEFAULT_PARANOIA_LEVEL,
+		anomalyThreshold: m?.anomalyThreshold || DEFAULT_ANOMALY_THRESHOLD,
+		excludedRules: (m?.excludedRules ?? []).map((id) => String(id))
+	}
+}
+
+/**
+ * Validation message for one excluded-rule chip, or '' when valid.
+ */
+export function excludedRuleError (raw: string): string {
+	const trimmed = raw.trim()
+	if (!/^\d+$/.test(trimmed)) return `${raw} is not a CRS rule id`
+	const id = Number(trimmed)
+	if (id < EXCLUDED_RULE_ID_MIN || id > EXCLUDED_RULE_ID_MAX) {
+		return `${raw} is out of range (${EXCLUDED_RULE_ID_MIN}–${EXCLUDED_RULE_ID_MAX})`
+	}
+	return ''
+}
+
+/**
+ * First validation problem across the whole form, or '' when saveable.
+ */
+export function managedFormError (f: ManagedForm): string {
+	if (f.excludedRules.length > MAX_EXCLUDED_RULES) {
+		return `At most ${MAX_EXCLUDED_RULES} excluded rules`
+	}
+	for (const raw of f.excludedRules) {
+		const err = excludedRuleError(raw)
+		if (err) return err
+	}
+	const threshold = Number(f.anomalyThreshold)
+	if (!Number.isInteger(threshold) || threshold < 1 || threshold > 100) {
+		return 'Anomaly threshold must be 1–100'
+	}
+	return ''
+}
+
+/**
+ * Map form state back to the API block. Only call on a valid form
+ * (managedFormError === ''). Exclusions are deduped and sorted so repeated
+ * saves are byte-identical.
+ */
+export function toApiManaged (f: ManagedForm): Api.WafManagedRules {
+	const ids = [...new Set(f.excludedRules.map((raw) => Number(raw.trim())))].sort((a, b) => a - b)
+	return {
+		enabled: f.enabled,
+		mode: f.mode === 'detect' ? 'detect' : 'enforce',
+		paranoiaLevel: Number(f.paranoiaLevel) || DEFAULT_PARANOIA_LEVEL,
+		anomalyThreshold: Number(f.anomalyThreshold) || DEFAULT_ANOMALY_THRESHOLD,
+		excludedRules: ids
+	}
+}

--- a/src/routes/(auth)/(project)/waf/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/+page.svelte
@@ -140,6 +140,7 @@
 					<th>Description</th>
 					<th>Rules</th>
 					<th>Limits</th>
+					<th>CRS</th>
 					<th>Matches (24h)</th>
 					<th class="is-collapse is-align-right"></th>
 				</tr>
@@ -178,6 +179,17 @@
 						<td>{fw.rules?.length ?? 0}</td>
 						<td>{fw.limits?.length ?? 0}</td>
 						<td>
+							<!-- Mirrors the api Table() CRS column: on = managed rules
+							     enabled, off = disabled but tuning kept, — = never set. -->
+							{#if fw.managedRules?.enabled}
+								<span class="crs-badge is-on">on</span>
+							{:else if fw.managedRules}
+								<span class="crs-badge">off</span>
+							{:else}
+								<span class="text-content/40">—</span>
+							{/if}
+						</td>
+						<td>
 							<!-- Reserve the loaded size in every state so the row/column keeps
 							     its dimensions while the async sparkline fills in (no layout shift). -->
 							<div class="matches-cell">
@@ -213,7 +225,7 @@
 					</tr>
 				{/each}
 				<NoDataRow
-					span={7}
+					span={8}
 					list={firewalls}
 					icon="fa-shield-halved"
 					message="No firewalls yet"
@@ -221,7 +233,7 @@
 					ctaLabel="Create firewall"
 					ctaHref={`/waf/create?project=${project}`}
 					{error} />
-				<ErrorRow span={7} {error} />
+				<ErrorRow span={8} {error} />
 			</tbody>
 		</table>
 	</div>
@@ -250,5 +262,22 @@
 
 	.matches-link:hover {
 		color: hsl(var(--hsl-primary));
+	}
+
+	.crs-badge {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.125rem 0.625rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		line-height: 1.5;
+		color: hsl(var(--hsl-content) / 0.55);
+		background-color: hsl(var(--hsl-content) / 0.06);
+	}
+
+	.crs-badge.is-on {
+		color: hsl(var(--hsl-positive));
+		background-color: hsl(var(--hsl-positive) / 0.12);
 	}
 </style>

--- a/src/routes/(auth)/(project)/waf/edit/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/edit/+page.svelte
@@ -33,9 +33,11 @@
 	// The whole loaded zone's rules (ordered) are held in memory so Save can
 	// rewrite the entire zone with the edited rule in place.
 	const rules = untrack(() => normalizeRules(data.zone?.rules))
-	// waf.set replaces the whole zone, so the zone's limits must be echoed back
-	// untouched — otherwise saving a rule would wipe them.
+	// waf.set replaces the whole zone, so the zone's limits AND managed-rules
+	// block must be echoed back untouched — otherwise saving a rule would wipe
+	// them (an omitted managedRules means "disabled and cleared" server-side).
 	const limits = untrack(() => normalizeLimits(data.zone?.limits))
+	const managedRules = untrack(() => data.zone?.managedRules ?? null)
 	const description = untrack(() => data.zone?.description ?? '')
 	// Index of the rule being edited, or -1 when adding a brand-new rule.
 	const editIndex = untrack(() => (data.ruleId ? rules.findIndex((r) => r.id === data.ruleId) : -1))
@@ -108,7 +110,8 @@
 				location,
 				description,
 				rules: toApiRules(nextRules),
-				limits: toApiLimits(limits)
+				limits: toApiLimits(limits),
+				managedRules: managedRules ?? undefined
 			}, fetch)
 			if (!resp.ok) {
 				modal.error({ error: resp.error })

--- a/src/routes/(auth)/(project)/waf/limit/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/limit/+page.svelte
@@ -44,11 +44,14 @@
 		{ value: 503, label: '503 Service Unavailable' }
 	]
 
-	// The whole loaded zone (rules + limits) is held in memory so Save can
-	// rewrite the entire zone with the edited limit in place — waf.set replaces
-	// the zone, so rules must be echoed back untouched.
+	// The whole loaded zone (rules + limits + managed rules) is held in memory
+	// so Save can rewrite the entire zone with the edited limit in place —
+	// waf.set replaces the zone, so rules and the managed-rules block must be
+	// echoed back untouched (an omitted managedRules means "disabled and
+	// cleared" server-side).
 	const rules = untrack(() => normalizeRules(data.zone?.rules))
 	const limits = untrack(() => normalizeLimits(data.zone?.limits))
+	const managedRules = untrack(() => data.zone?.managedRules ?? null)
 	const description = untrack(() => data.zone?.description ?? '')
 	// Index of the limit being edited, or -1 when adding a brand-new limit.
 	const editIndex = untrack(() => (data.limitId ? limits.findIndex((l) => l.id === data.limitId) : -1))
@@ -136,7 +139,8 @@
 				location,
 				description,
 				rules: toApiRules(rules),
-				limits: toApiLimits(nextLimits)
+				limits: toApiLimits(nextLimits),
+				managedRules: managedRules ?? undefined
 			}, fetch)
 			if (!resp.ok) {
 				modal.error({ error: resp.error })

--- a/src/routes/(auth)/(project)/waf/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/manage/+page.svelte
@@ -124,6 +124,25 @@
 		}
 	}
 
+	// A location can lose the managed-rules feature flag while a zone still
+	// carries an ENABLED block (ops un-flagging, or a block set via CLI). The
+	// server rejects any save echoing enabled:true in an un-flagged location,
+	// which would make every rule/limit save on this page fail — so offer the
+	// one write the gate does accept: enabled:false with the tuning kept.
+	async function disableManagedRules () {
+		if (savingManaged || !savedManaged) return
+		savingManaged = true
+		try {
+			const block = { ...savedManaged, enabled: false }
+			if (await persistZone(rules, limits, block)) {
+				savedManaged = block
+				managed = managedForm(block)
+			}
+		} finally {
+			savingManaged = false
+		}
+	}
+
 	async function moveRule (i: number, dir: -1 | 1) {
 		const j = i + dir
 		if (j < 0 || j >= rules.length) return
@@ -370,6 +389,31 @@
 				<i class="fa-solid fa-circle-info"></i>
 				<span>Not available in this location</span>
 			</div>
+			{#if savedManaged}
+				<p class="text-content/60 text-sm">
+					This zone still carries a stored managed-rules block:
+					<span class="font-mono">{savedManaged.enabled ? 'enabled' : 'disabled'}</span>
+					· {savedManaged.mode === 'detect' ? 'detect' : 'enforce'}
+					· paranoia level {savedManaged.paranoiaLevel || 1}
+					· threshold {savedManaged.anomalyThreshold || 5}
+					{#if savedManaged.excludedRules?.length}
+						· {savedManaged.excludedRules.length} excluded rule{savedManaged.excludedRules.length === 1 ? '' : 's'}
+					{/if}
+				</p>
+				{#if savedManaged.enabled}
+					<p class="text-content/60 text-sm">
+						While the block stays enabled, saves in this location are
+						rejected. Disable it (your tuning is kept) to keep managing
+						rules and rate limits here.
+					</p>
+					<div class="flex justify-self-start">
+						<GuardedButton permission="waf.set" class="button is-variant-secondary is-size-small"
+							loading={savingManaged} onclick={disableManagedRules}>
+							Disable managed rules
+						</GuardedButton>
+					</div>
+				{/if}
+			{/if}
 		{:else}
 			<label class="checkbox">
 				<input id="managed-enabled" type="checkbox" bind:checked={managed.enabled}>
@@ -426,6 +470,7 @@
 				<label for="managed-excluded">Excluded rules</label>
 				<div class="managed-excluded" class:is-disabled={!managed.enabled}>
 					<TagInput id="managed-excluded" bind:tags={managed.excludedRules}
+						disabled={!managed.enabled}
 						placeholder="CRS rule id, e.g. 942100" />
 				</div>
 				<p class="text-content/50 text-sm mt-2">
@@ -660,10 +705,9 @@
 		opacity: 0.5;
 	}
 
-	/* TagInput has no disabled mode; freeze it while the block is off so the
-	   kept tuning stays visible but not editable. */
+	/* The TagInput itself is disabled while the block is off (mouse AND
+	   keyboard); this only mutes the kept-but-frozen tuning visually. */
 	.managed-excluded.is-disabled {
-		pointer-events: none;
 		opacity: 0.55;
 	}
 </style>

--- a/src/routes/(auth)/(project)/waf/manage/+page.svelte
+++ b/src/routes/(auth)/(project)/waf/manage/+page.svelte
@@ -8,16 +8,20 @@
 	import GuardedButton from '$lib/components/GuardedButton.svelte'
 	import WafTestPanel from '$lib/components/WafTestPanel.svelte'
 	import WafCopyModal from '$lib/components/WafCopyModal.svelte'
+	import Select from '$lib/components/Select.svelte'
+	import TagInput from '$lib/components/TagInput.svelte'
 	import type { RuleForm } from '$lib/waf/rules'
 	import { actionLabels, normalizeRules, toApiRules } from '$lib/waf/rules'
 	import type { LimitForm } from '$lib/waf/limits'
 	import { describeKey, keyRowToApi, modeLabels, normalizeLimits, toApiLimits } from '$lib/waf/limits'
 	import { wafListRefs } from '$lib/waf/expression'
+	import { managedForm, managedFormError, modeOptions, paranoiaLevels, toApiManaged } from '$lib/waf/managed'
 
 	const { data }: { data: PageData } = $props()
 
 	const project = $derived(data.project)
 	const location = $derived(data.location)
+	const managedRulesSupported = $derived(data.managedRulesSupported)
 
 	let copyModal = $state<WafCopyModal>()
 
@@ -26,6 +30,11 @@
 	let description = $state(untrack(() => data.zone?.description ?? ''))
 	let rules = $state(untrack(() => normalizeRules(data.zone?.rules)))
 	let limits = $state(untrack(() => normalizeLimits(data.zone?.limits)))
+	let managed = $state(untrack(() => managedForm(data.zone?.managedRules)))
+	// Last-saved managed block, echoed on every rule/limit write so an unsaved
+	// card edit never rides along a rule save (waf.set replaces the whole zone,
+	// so SOMETHING must always be sent for managed rules — the server state).
+	let savedManaged = $state<Api.WafManagedRules | null>(untrack(() => data.zone?.managedRules ?? null))
 
 	let loadedLocation = untrack(() => data.location ?? '')
 
@@ -40,6 +49,8 @@
 				description = next.zone?.description ?? ''
 				rules = normalizeRules(next.zone?.rules)
 				limits = normalizeLimits(next.zone?.limits)
+				managed = managedForm(next.zone?.managedRules)
+				savedManaged = next.zone?.managedRules ?? null
 			}
 		})
 	})
@@ -66,18 +77,24 @@
 		description = zone?.description ?? ''
 		rules = normalizeRules(zone?.rules)
 		limits = normalizeLimits(zone?.limits)
+		managed = managedForm(zone?.managedRules)
+		savedManaged = zone?.managedRules ?? null
 	}
 
 	// Persist the whole zone (priority follows row order). waf.set replaces the
-	// entire zone, so rules and limits must always travel together. On error,
-	// surface it and reload from the server so the UI matches reality.
-	async function persistZone (nextRules: RuleForm[], nextLimits: LimitForm[] = limits) {
+	// entire zone, so rules, limits, and the managed-rules block must always
+	// travel together. On error, surface it and reload from the server so the
+	// UI matches reality.
+	async function persistZone (nextRules: RuleForm[], nextLimits: LimitForm[] = limits, nextManaged: Api.WafManagedRules | null = savedManaged) {
 		const resp = await api.invoke('waf.set', {
 			project,
 			location,
 			description,
 			rules: toApiRules(nextRules),
-			limits: toApiLimits(nextLimits)
+			limits: toApiLimits(nextLimits),
+			// Omitted (undefined) = cleared server-side, which is exactly the
+			// state a null savedManaged mirrors.
+			managedRules: nextManaged ?? undefined
 		}, fetch)
 		if (!resp.ok) {
 			modal.error({ error: resp.error })
@@ -85,6 +102,26 @@
 			return false
 		}
 		return true
+	}
+
+	let savingManaged = $state(false)
+	const managedError = $derived(managedFormError(managed))
+	// Nothing to save while the block is off and the server has none — saving
+	// would only persist untouched defaults as tuning.
+	const managedSaveDisabled = $derived((!managed.enabled && savedManaged == null) || managedError !== '')
+
+	async function saveManagedRules () {
+		if (savingManaged || managedSaveDisabled) return
+		savingManaged = true
+		try {
+			const block = toApiManaged(managed)
+			if (await persistZone(rules, limits, block)) {
+				savedManaged = block
+				managed = managedForm(block)
+			}
+		} finally {
+			savingManaged = false
+		}
 	}
 
 	async function moveRule (i: number, dir: -1 | 1) {
@@ -319,6 +356,99 @@
 		<hr>
 		<br>
 
+		<div>
+			<h6><strong>Managed rules</strong> <span class="text-content/50">(OWASP Core Rule Set)</span></h6>
+			<p class="text-content/50 text-sm mt-1">
+				Curated signatures for SQL injection, XSS, path traversal, and
+				scanner traffic. Runs after your rules, before rate limits — a
+				managed-rule block never consumes rate budget.
+			</p>
+		</div>
+
+		{#if !managedRulesSupported}
+			<div class="managed-unavailable">
+				<i class="fa-solid fa-circle-info"></i>
+				<span>Not available in this location</span>
+			</div>
+		{:else}
+			<label class="checkbox">
+				<input id="managed-enabled" type="checkbox" bind:checked={managed.enabled}>
+				Enabled
+			</label>
+
+			{#if !managed.enabled && savedManaged != null}
+				<p class="text-content/60 text-sm">
+					Disabled — your tuning is kept for re-enable.
+				</p>
+			{/if}
+
+			<div class="grid gap-4 lg:grid-cols-2">
+				<div class="field">
+					<label for="managed-mode">Mode</label>
+					<Select id="managed-mode" bind:value={managed.mode} options={modeOptions}
+						disabled={!managed.enabled} />
+					<p class="text-content/50 text-sm mt-2">
+						Detect-only matches are currently visible to platform operators
+						only (ask support for your zone’s match report); per-project
+						match metrics arrive in a later release.
+					</p>
+				</div>
+
+				<div class="field">
+					<label for="managed-threshold">Anomaly threshold</label>
+					<div class="input">
+						<input id="managed-threshold" type="number" min="1" max="100"
+							bind:value={managed.anomalyThreshold} disabled={!managed.enabled}>
+					</div>
+					<p class="text-content/50 text-sm mt-2">
+						Each critical match scores 5; lower = stricter. Default 5.
+					</p>
+				</div>
+			</div>
+
+			<div class="field">
+				<span class="label">Paranoia level</span>
+				<div class="paranoia-switch" role="group" aria-label="Paranoia level">
+					{#each paranoiaLevels as pl (pl.value)}
+						<button type="button" class="paranoia-btn"
+							class:is-active={managed.paranoiaLevel === pl.value}
+							aria-pressed={managed.paranoiaLevel === pl.value}
+							disabled={!managed.enabled}
+							onclick={() => { managed.paranoiaLevel = pl.value }}>{pl.label}</button>
+					{/each}
+				</div>
+				<p class="text-content/50 text-sm mt-2">
+					{paranoiaLevels.find((pl) => pl.value === managed.paranoiaLevel)?.description}
+				</p>
+			</div>
+
+			<div class="field">
+				<label for="managed-excluded">Excluded rules</label>
+				<div class="managed-excluded" class:is-disabled={!managed.enabled}>
+					<TagInput id="managed-excluded" bind:tags={managed.excludedRules}
+						placeholder="CRS rule id, e.g. 942100" />
+				</div>
+				<p class="text-content/50 text-sm mt-2">
+					CRS rule ids to disable for false-positive relief
+					(<a class="link" href="https://coreruleset.org/docs/" target="_blank" rel="noreferrer">CRS rule reference</a>).
+				</p>
+				{#if managedError}
+					<p class="text-negative text-sm mt-1">{managedError}</p>
+				{/if}
+			</div>
+
+			<div class="flex justify-self-start">
+				<GuardedButton permission="waf.set" class="button is-variant-secondary is-size-small"
+					loading={savingManaged} disabled={managedSaveDisabled} onclick={saveManagedRules}>
+					Save managed rules
+				</GuardedButton>
+			</div>
+		{/if}
+
+		<br>
+		<hr>
+		<br>
+
 		<div class="flex items-center justify-between">
 			<div>
 				<h6><strong>Rate limits</strong></h6>
@@ -480,5 +610,60 @@
 
 	.list-chip:hover {
 		background-color: hsl(var(--hsl-primary) / 0.18);
+	}
+
+	/* Managed rules aren't offered here — an informative dead-end, not an error. */
+	.managed-unavailable {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		padding: 0.75rem 1rem;
+		border-radius: 0.625rem;
+		border: 1px dashed hsl(var(--hsl-line));
+		color: hsl(var(--hsl-content) / 0.55);
+		font-size: 0.875rem;
+	}
+
+	/* Segmented 1–4 picker, visually matching RangeSwitch (which is hardwired
+	   to the metrics time ranges, so it can't be reused directly). */
+	.paranoia-switch {
+		display: inline-flex;
+		padding: 0.1875rem;
+		gap: 0.125rem;
+		border-radius: 0.625rem;
+		background: hsl(var(--hsl-base-200));
+		border: 1px solid hsl(var(--hsl-line) / 0.7);
+		width: fit-content;
+	}
+
+	.paranoia-btn {
+		padding: 0.3125rem 0.875rem;
+		border-radius: 0.4375rem;
+		font-size: 0.75rem;
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+		color: hsl(var(--hsl-content) / 0.6);
+		transition: color var(--timing-fastest) ease, background var(--timing-fastest) ease;
+	}
+
+	.paranoia-btn:hover:not(:disabled) {
+		color: hsl(var(--hsl-content) / 0.9);
+	}
+
+	.paranoia-btn.is-active {
+		color: hsl(var(--hsl-primary-content));
+		background: hsl(var(--hsl-primary));
+	}
+
+	.paranoia-btn:disabled {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+
+	/* TagInput has no disabled mode; freeze it while the block is off so the
+	   kept tuning stays visible but not editable. */
+	.managed-excluded.is-disabled {
+		pointer-events: none;
+		opacity: 0.55;
 	}
 </style>

--- a/src/routes/(auth)/(project)/waf/manage/+page.ts
+++ b/src/routes/(auth)/(project)/waf/manage/+page.ts
@@ -10,7 +10,16 @@ export const load: PageLoad = async ({ url, parent, fetch }) => {
 		redirect(302, `/waf?project=${project}`)
 	}
 
-	const res = await api.invoke<Api.WafZone>('waf.get', { project, location }, fetch)
+	// location.get pre-flight: managed rules (OWASP CRS) are gated per location
+	// (features.waf.managedRules), so the card renders a disabled "Not available
+	// in this location" state instead of letting the user fill it in and hit the
+	// server-side reject on save. Same convention as the me.authorized/can()
+	// permission pre-flight. Best-effort: a lookup failure fails closed to the
+	// unavailable state (the server still enforces the gate).
+	const [res, locRes] = await Promise.all([
+		api.invoke<Api.WafZone>('waf.get', { project, location }, fetch),
+		api.invoke<Api.Location>('location.get', { project, id: location }, fetch)
+	])
 	// You only reach manage for a configured location — a missing zone means the
 	// firewall isn't configured here, so send the user back to the index.
 	if (!res.ok) {
@@ -22,6 +31,7 @@ export const load: PageLoad = async ({ url, parent, fetch }) => {
 	return {
 		project,
 		location,
-		zone: res.result
+		zone: res.result,
+		managedRulesSupported: (locRes.ok && locRes.result?.features?.waf?.managedRules) ?? false
 	}
 }

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -170,7 +170,10 @@ declare namespace Api {
         features: {
             workloadIdentity?: boolean
             disk?: Record<string, never>
-            waf?: Record<string, never>
+            // Non-null = the location supports WAF zones. managedRules gates
+            // the managed-rules (OWASP CRS) block on waf.set — legacy "waf": {}
+            // means supported without managed rules.
+            waf?: { managedRules?: boolean }
             cache?: Record<string, never>
             transform?: Record<string, never>
         }
@@ -780,12 +783,32 @@ declare namespace Api {
         filter?: string
     }
 
+    // Managed signature ruleset (OWASP Core Rule Set via the parapet Coraza
+    // engine, evaluated after the zone's CEL rules and before its rate limits).
+    // waf.set follows the zone's whole-replace semantics: omitting the field
+    // clears the block; enabled:false keeps the tuning stored for re-enable.
+    export type WafManagedRules = {
+        enabled: boolean
+        // '' or 'enforce' = block over-threshold requests (403);
+        // 'detect' = rules evaluate and log but never block.
+        mode?: 'enforce' | 'detect' | ''
+        // 0 = default (1); 1..4. Higher = stricter, more false positives.
+        paranoiaLevel?: number
+        // 0 = default (5); 1..100. Each critical match scores 5.
+        anomalyThreshold?: number
+        // CRS detection-rule ids to disable (911100..948999, max 50).
+        excludedRules?: number[]
+    }
+
     export type WafZone = {
         project: string
         location: string
         description: string
         rules: WafRule[]
         limits: WafLimit[]
+        // null/absent = never configured (or cleared); a disabled block keeps
+        // its tuning and round-trips through waf.get → edit → waf.set.
+        managedRules?: WafManagedRules | null
         status: 'pending' | 'success' | 'error'
         action: 'create' | 'delete'
         createdAt: string

--- a/tests/waf-managed.spec.js
+++ b/tests/waf-managed.spec.js
@@ -1,0 +1,270 @@
+import { test, expect, setMocks, getRequestLog, pickSelect } from './helpers.js'
+import { defaultLocation } from './fixtures/mocks.js'
+
+// A managed-rules-capable location vs a WAF-only one: the manage page's
+// loader pre-flights location.get and renders the card disabled ("Not
+// available in this location") when features.waf.managedRules is false.
+const crsLocation = { ...defaultLocation, id: 'gke', features: { waf: { managedRules: true } } }
+const wafOnlyLocation = { ...defaultLocation, id: 'gke', features: { waf: {} } }
+
+/** Build a WAF zone fixture. */
+function wafZone (overrides = {}) {
+	return {
+		project: 'test-project',
+		location: 'gke',
+		description: '',
+		rules: [],
+		limits: [],
+		status: 'success',
+		action: 'create',
+		createdAt: '2024-01-01T00:00:00Z',
+		createdBy: '[email protected]',
+		...overrides
+	}
+}
+
+/** Fetch the parsed body of the first waf.set request, polling until it exists. */
+async function firstWafSetBody () {
+	await expect.poll(async () => {
+		const log = await getRequestLog()
+		return log.some((r) => r.path === '/waf.set')
+	}).toBe(true)
+	const setReq = (await getRequestLog()).find((r) => r.path === '/waf.set')
+	return JSON.parse(setReq?.body ?? '{}')
+}
+
+test.describe('managed rules card', () => {
+	test('renders disabled "Not available in this location" without the feature flag', async ({ page }) => {
+		await setMocks({
+			'waf.get': { ok: true, result: wafZone() },
+			'location.get': { ok: true, result: wafOnlyLocation }
+		})
+
+		await page.goto('/waf/manage?project=test-project&location=gke')
+		const main = page.locator('.content-wrapper')
+
+		await expect(main.getByRole('heading', { name: 'Managed rules' })).toBeVisible()
+		await expect(main.getByText('Not available in this location')).toBeVisible()
+		// No form controls in the unavailable state.
+		await expect(page.locator('#managed-enabled')).toHaveCount(0)
+		await expect(page.getByRole('button', { name: 'Save managed rules' })).toHaveCount(0)
+	})
+
+	test('enable, tune, and save sends the managedRules block on waf.set', async ({ page }) => {
+		await setMocks({
+			'waf.get': { ok: true, result: wafZone() },
+			'location.get': { ok: true, result: crsLocation },
+			'waf.set': { ok: true, result: {} }
+		})
+
+		await page.goto('/waf/manage?project=test-project&location=gke')
+
+		// Never configured + off → nothing to save yet, controls frozen.
+		const save = page.getByRole('button', { name: 'Save managed rules' })
+		await expect(save).toBeDisabled()
+		await expect(page.locator('#managed-mode')).toBeDisabled()
+		await expect(page.locator('#managed-threshold')).toBeDisabled()
+
+		await page.locator('#managed-enabled').check()
+		await expect(save).toBeEnabled()
+
+		// Tune: paranoia 2, threshold 7, exclude one CRS id.
+		await page.locator('.paranoia-switch').getByRole('button', { name: '2', exact: true }).click()
+		await page.locator('#managed-threshold').fill('7')
+		await page.locator('#managed-excluded').fill('942100')
+		await page.locator('#managed-excluded').press('Enter')
+
+		await save.click()
+
+		const body = await firstWafSetBody()
+		expect(body.location).toBe('gke')
+		expect(body.managedRules).toEqual({
+			enabled: true,
+			mode: 'enforce',
+			paranoiaLevel: 2,
+			anomalyThreshold: 7,
+			excludedRules: [942100]
+		})
+		// waf.set replaces the whole zone — rules/limits are echoed alongside.
+		expect(body.rules).toEqual([])
+		expect(body.limits).toEqual([])
+	})
+
+	test('detect mode round-trips through the mode select', async ({ page }) => {
+		await setMocks({
+			'waf.get': { ok: true, result: wafZone() },
+			'location.get': { ok: true, result: crsLocation },
+			'waf.set': { ok: true, result: {} }
+		})
+
+		await page.goto('/waf/manage?project=test-project&location=gke')
+
+		await page.locator('#managed-enabled').check()
+		await pickSelect(page, 'managed-mode', 'Detect only (log, never block)')
+		await page.getByRole('button', { name: 'Save managed rules' }).click()
+
+		const body = await firstWafSetBody()
+		expect(body.managedRules.mode).toBe('detect')
+	})
+
+	test('a stored zone pre-fills the card and reload keeps it (round-trip)', async ({ page }) => {
+		const stored = {
+			enabled: true,
+			mode: 'enforce',
+			paranoiaLevel: 3,
+			anomalyThreshold: 10,
+			excludedRules: [920420, 942100]
+		}
+		await setMocks({
+			'waf.get': { ok: true, result: wafZone({ managedRules: stored }) },
+			'location.get': { ok: true, result: crsLocation }
+		})
+
+		await page.goto('/waf/manage?project=test-project&location=gke')
+
+		await expect(page.locator('#managed-enabled')).toBeChecked()
+		await expect(page.locator('.paranoia-switch').getByRole('button', { name: '3', exact: true }))
+			.toHaveAttribute('aria-pressed', 'true')
+		await expect(page.locator('#managed-threshold')).toHaveValue('10')
+		await expect(page.getByText('920420')).toBeVisible()
+		await expect(page.getByText('942100')).toBeVisible()
+
+		// A reload re-runs the loader against the same server state — the card
+		// re-seeds identically (the enable→save→reload contract).
+		await page.reload()
+		await expect(page.locator('#managed-enabled')).toBeChecked()
+		await expect(page.locator('#managed-threshold')).toHaveValue('10')
+	})
+
+	test('disabled-but-tuned block keeps fields populated and frozen', async ({ page }) => {
+		await setMocks({
+			'waf.get': {
+				ok: true,
+				result: wafZone({
+					managedRules: { enabled: false, mode: 'enforce', paranoiaLevel: 2, anomalyThreshold: 5, excludedRules: [941100] }
+				})
+			},
+			'location.get': { ok: true, result: crsLocation },
+			'waf.set': { ok: true, result: {} }
+		})
+
+		await page.goto('/waf/manage?project=test-project&location=gke')
+
+		await expect(page.locator('#managed-enabled')).not.toBeChecked()
+		await expect(page.getByText('Disabled — your tuning is kept for re-enable.')).toBeVisible()
+		// Tuning stays visible but not editable while off.
+		await expect(page.locator('#managed-mode')).toBeDisabled()
+		await expect(page.locator('#managed-threshold')).toBeDisabled()
+		await expect(page.locator('.paranoia-switch').getByRole('button', { name: '2', exact: true })).toBeDisabled()
+		await expect(page.getByText('941100')).toBeVisible()
+
+		// Saving while off persists enabled:false WITH the tuning (so re-enable
+		// restores the exclusion list) — not a cleared block.
+		const save = page.getByRole('button', { name: 'Save managed rules' })
+		await expect(save).toBeEnabled()
+		await save.click()
+
+		const body = await firstWafSetBody()
+		expect(body.managedRules).toEqual({
+			enabled: false,
+			mode: 'enforce',
+			paranoiaLevel: 2,
+			anomalyThreshold: 5,
+			excludedRules: [941100]
+		})
+	})
+
+	test('rejects out-of-range excluded rule ids client-side', async ({ page }) => {
+		await setMocks({
+			'waf.get': { ok: true, result: wafZone() },
+			'location.get': { ok: true, result: crsLocation }
+		})
+
+		await page.goto('/waf/manage?project=test-project&location=gke')
+
+		await page.locator('#managed-enabled').check()
+		// 949110 is the anomaly-blocking rule — above the excludable ceiling.
+		await page.locator('#managed-excluded').fill('949110')
+		await page.locator('#managed-excluded').press('Enter')
+
+		await expect(page.getByText('949110 is out of range (911100–948999)')).toBeVisible()
+		await expect(page.getByRole('button', { name: 'Save managed rules' })).toBeDisabled()
+	})
+
+	test('rule edits echo the stored managed block unchanged (whole-replace)', async ({ page }) => {
+		const stored = { enabled: true, mode: 'detect', paranoiaLevel: 1, anomalyThreshold: 5, excludedRules: [942100] }
+		await setMocks({
+			'waf.get': {
+				ok: true,
+				result: wafZone({
+					managedRules: stored,
+					rules: [{ id: 'rule-a', description: '', expression: 'request.path == "/a"', action: 'log', priority: 0 }]
+				})
+			},
+			'location.get': { ok: true, result: crsLocation },
+			'waf.set': { ok: true, result: {} }
+		})
+
+		await page.goto('/waf/manage?project=test-project&location=gke')
+
+		// Delete the rule; the resulting waf.set must carry the SERVER's managed
+		// block — an unrelated write never drops or mutates managed rules.
+		await page.getByRole('button', { name: 'Remove rule' }).click()
+		await page.locator('#app-modal-confirm').click()
+
+		const body = await firstWafSetBody()
+		expect(body.rules).toEqual([])
+		expect(body.managedRules).toEqual(stored)
+	})
+
+	test('never-configured zone omits managedRules on unrelated writes', async ({ page }) => {
+		await setMocks({
+			'waf.get': {
+				ok: true,
+				result: wafZone({
+					rules: [{ id: 'rule-a', description: '', expression: 'request.path == "/a"', action: 'log', priority: 0 }]
+				})
+			},
+			'location.get': { ok: true, result: crsLocation },
+			'waf.set': { ok: true, result: {} }
+		})
+
+		await page.goto('/waf/manage?project=test-project&location=gke')
+
+		await page.getByRole('button', { name: 'Remove rule' }).click()
+		await page.locator('#app-modal-confirm').click()
+
+		const body = await firstWafSetBody()
+		// Whole-replace: omitted = stays cleared. Sending {} would persist tuning.
+		expect(body).not.toHaveProperty('managedRules')
+	})
+})
+
+test.describe('firewall list CRS column', () => {
+	test('shows on / off / — per zone', async ({ page }) => {
+		await setMocks({
+			'waf.list': {
+				ok: true,
+				result: {
+					project: 'test-project',
+					items: [
+						wafZone({ location: 'gke', managedRules: { enabled: true, paranoiaLevel: 1 } }),
+						wafZone({ location: 'sgp', managedRules: { enabled: false, paranoiaLevel: 2 } }),
+						wafZone({ location: 'blr' })
+					]
+				}
+			},
+			'waf.metrics': { ok: true, result: { series: [], total: 0 } }
+		})
+
+		await page.goto('/waf?project=test-project')
+		const main = page.locator('.content-wrapper')
+
+		await expect(main.getByRole('columnheader', { name: 'CRS' })).toBeVisible()
+		await expect(main.getByRole('row', { name: /gke/ }).getByText('on', { exact: true })).toBeVisible()
+		await expect(main.getByRole('row', { name: /sgp/ }).getByText('off', { exact: true })).toBeVisible()
+		// The never-configured zone's CRS cell (6th column) renders the em dash;
+		// scope to the cell since the description and matches cells use it too.
+		await expect(main.getByRole('row', { name: /blr/ }).locator('td').nth(5)).toHaveText('—')
+	})
+})

--- a/tests/waf-managed.spec.js
+++ b/tests/waf-managed.spec.js
@@ -152,10 +152,12 @@ test.describe('managed rules card', () => {
 
 		await expect(page.locator('#managed-enabled')).not.toBeChecked()
 		await expect(page.getByText('Disabled — your tuning is kept for re-enable.')).toBeVisible()
-		// Tuning stays visible but not editable while off.
+		// Tuning stays visible but not editable while off — including for the
+		// keyboard (a real disabled attribute, not just pointer-events).
 		await expect(page.locator('#managed-mode')).toBeDisabled()
 		await expect(page.locator('#managed-threshold')).toBeDisabled()
 		await expect(page.locator('.paranoia-switch').getByRole('button', { name: '2', exact: true })).toBeDisabled()
+		await expect(page.locator('#managed-excluded')).toBeDisabled()
 		await expect(page.getByText('941100')).toBeVisible()
 
 		// Saving while off persists enabled:false WITH the tuning (so re-enable
@@ -237,6 +239,93 @@ test.describe('managed rules card', () => {
 		const body = await firstWafSetBody()
 		// Whole-replace: omitted = stays cleared. Sending {} would persist tuning.
 		expect(body).not.toHaveProperty('managedRules')
+	})
+
+	test('rule editor save echoes the stored managed block (whole-replace)', async ({ page }) => {
+		const stored = { enabled: true, mode: 'enforce', paranoiaLevel: 2, anomalyThreshold: 7, excludedRules: [942100] }
+		await setMocks({
+			'waf.get': {
+				ok: true,
+				result: wafZone({
+					managedRules: stored,
+					rules: [{ id: 'rule-a', description: '', expression: 'request.path == "/a"', action: 'log', priority: 0 }]
+				})
+			},
+			'location.get': { ok: true, result: crsLocation },
+			'waf.set': { ok: true, result: {} }
+		})
+
+		await page.goto('/waf/edit?project=test-project&location=gke&rule=rule-a')
+
+		// Saving a rule rewrites the WHOLE zone — the stored managed block must
+		// ride along untouched, or the server clears it (omitted = cleared).
+		await page.getByRole('button', { name: 'Save', exact: true }).click()
+
+		const body = await firstWafSetBody()
+		expect(body.rules).toHaveLength(1)
+		expect(body.managedRules).toEqual(stored)
+	})
+
+	test('limit editor save echoes the stored managed block (whole-replace)', async ({ page }) => {
+		const stored = { enabled: true, mode: 'detect', paranoiaLevel: 1, anomalyThreshold: 5, excludedRules: [] }
+		await setMocks({
+			'waf.get': {
+				ok: true,
+				result: wafZone({
+					managedRules: stored,
+					limits: [{
+						id: 'limit-a',
+						description: '',
+						key: ['ip'],
+						rate: 100,
+						window: '1m',
+						algorithm: 'fixed',
+						mode: 'enforce',
+						status: 429,
+						message: 'Too Many Requests'
+					}]
+				})
+			},
+			'location.get': { ok: true, result: crsLocation },
+			'waf.set': { ok: true, result: {} }
+		})
+
+		await page.goto('/waf/limit?project=test-project&location=gke&limit=limit-a')
+
+		await page.getByRole('button', { name: 'Save', exact: true }).click()
+
+		const body = await firstWafSetBody()
+		expect(body.limits).toHaveLength(1)
+		expect(body.managedRules).toEqual(stored)
+	})
+
+	test('unsupported location with a stored ENABLED block offers a disable exit', async ({ page }) => {
+		// A location can be un-flagged while a zone still carries an enabled
+		// block. The server rejects saves echoing enabled:true there, so the
+		// card must surface the stored state and the one accepted write:
+		// enabled:false with tuning kept.
+		const stored = { enabled: true, mode: 'enforce', paranoiaLevel: 2, anomalyThreshold: 7, excludedRules: [942100] }
+		await setMocks({
+			'waf.get': { ok: true, result: wafZone({ managedRules: stored }) },
+			'location.get': { ok: true, result: wafOnlyLocation },
+			'waf.set': { ok: true, result: {} }
+		})
+
+		await page.goto('/waf/manage?project=test-project&location=gke')
+
+		await expect(page.getByText('Not available in this location')).toBeVisible()
+		// Stored state is shown read-only — no editable card controls.
+		await expect(page.locator('#managed-enabled')).toHaveCount(0)
+		await expect(page.getByText('This zone still carries a stored managed-rules block')).toBeVisible()
+
+		await page.getByRole('button', { name: 'Disable managed rules' }).click()
+
+		const body = await firstWafSetBody()
+		expect(body.managedRules).toEqual({ ...stored, enabled: false })
+
+		// The disable action is gone once the block is off; the read-only
+		// summary reflects the new state.
+		await expect(page.getByRole('button', { name: 'Disable managed rules' })).toHaveCount(0)
 	})
 })
 


### PR DESCRIPTION
## What

The console slice of **WAF managed rules (OWASP Core Rule Set)** — see `SPEC-waf-managed-rules.md` §5 (console UX) and §14 row 4. The WAF zone gains a typed `managedRules` block (`waf.set`/`waf.get`, whole-replace); this PR is the UI for it. No SecLang anywhere in the console — generation is deployer-side (§4.2); the API surface is typed knobs only.

- **Manage page** (`waf/manage/+page.svelte`): a *Managed rules* card between the rules list and rate limits — enable toggle, Enforce/Detect mode (with the v1 "detect matches are ops-visible only" caveat verbatim from §5), paranoia level 1–4 segmented picker, anomaly threshold, and an excluded-CRS-rule-id chip editor with client-side range validation (911100–948999, max 50). Toggling off keeps the tuning visible-but-frozen ("Disabled — your tuning is kept for re-enable", §2.2 semantics).
- **Whole-replace safety**: every zone rewrite echoes the stored managed block verbatim — the manage page's rule/limit inline edits echo the last-*saved* block (a dirty card edit never rides along), and the **rule and limit editor pages** (`waf/edit`, `waf/limit`) echo `data.zone.managedRules` on save. Omitting the field means "disabled and cleared" server-side, so a missing echo would destroy tuning on any unrelated edit.
- **Feature-flag pre-flight**: the manage loader fetches `location.get` and gates the card on `features.waf.managedRules` — unsupported locations render "Not available in this location" instead of failing on save. If an un-flagged location still carries a stored **enabled** block (ops un-flag, or a block set via CLI), the card shows the stored state read-only and offers **Disable managed rules** (sends `enabled:false` with tuning kept — the one write the server gate accepts; without it every rule/limit save in that location would be rejected).
- **Firewall index** (`waf/+page.svelte`): `CRS` column (on / off / —), mirroring the api `Table()` column.
- `$lib/waf/managed.ts`: form ⇄ api normalization beside `limits.ts`; exclusions dedupe + ascending sort so a rule-only save echoing the server block stays byte-identical (supports the apiserver DeepEqual no-op guard, §3.3).
- `TagInput` gains a real `disabled` prop (inner input + chip-remove buttons) so the frozen exclusion list is keyboard-frozen too, not just `pointer-events: none`.
- Types (`api.d.ts`), dev mock (session-mutable managed block so enable → save → reload round-trips offline), Playwright spec `tests/waf-managed.spec.js` (12 cases).

**Deliberate deviation from spec letter**: §5 says the Enabled toggle itself goes through `GuardedButton`/`can('waf.set')`; here the toggle is a plain checkbox and only **Save managed rules** is permission-guarded — matching this page's existing convention (rule/limit drafts are also freely editable with a guarded submit). The write is gated either way.

## Tests

- `bun run lint` / `bun run check`: 0 errors.
- `bun run test`: **343 passed** (full suite), including `tests/waf-managed.spec.js` 12/12: unavailable state, enable/tune/save payload, detect mode, stored round-trip, disabled-but-tuned freeze (incl. keyboard), exclusion range validation, whole-replace echo from the manage page AND both editor pages, never-configured omission, un-flagged-location disable exit, CRS column.

## Rollout (spec §10; this PR is step 4 — deploy last)

**Everything gates on a parapet release**: [moonrhythm/parapet-ingress-controller#181](https://github.com/moonrhythm/parapet-ingress-controller/pull/181) (unconditional phase-2 evaluation, `zone` label on `parapet_coraza_matches`, resolving Include forms + CRS compile test) must be merged, released, and rolled out with `CORAZA_ENABLED=true` (+ `CORAZA_REQUEST_BODY_LIMIT`) on the flagged clusters **before any deploys-side deploy** — a merely Coraza-capable image is not sufficient (§10 step 0).

Order: parapet release + `CORAZA_ENABLED` → **api** PR → **deployer** binary → **apiserver** (migration `managed_rules` column, then binary) → flip `features.waf.managedRules` per location (ops SQL, by name) → **console (this PR)** / docs / mcp / CLI api re-pin, any order.

Safe to merge/deploy early regardless: pre-flag no location advertises `features.waf.managedRules`, so the card renders "Not available in this location" everywhere and the editors' `managedRules` echo is `undefined` (field omitted) for zones that have no block — byte-identical `waf.set` payloads against an old apiserver.

The **deploys CLI re-pin gate** (§6) applies to the CLI, not this repo: `deploys` must re-pin the api module before `waf set -f zone.yaml` passes the field through; until then CLI zone rewrites drop managed rules the same way the docs warning (§7) describes for scripts.

## Expected conflicts with sibling WAF branches

Sibling branches in flight (api/apiserver: `waf-test`, `waf-ip-lists`, `waf-events`; console worktrees: `waf-copy-zone`, `waf-events`, `waf-ip-lists`, `waf-test`) overlap this diff; first merged wins, the rest rebase with **semantic** resolution:

- `waf/manage/+page.svelte` — touched by all four siblings. Resolution: keep each feature's card/section additive; any zone rewrite they add must echo `managedRules` (the `persistZone(nextRules, nextLimits, nextManaged)` helper here is the pattern to adopt).
- `waf/edit/+page.svelte`, `waf/limit/+page.svelte` — `waf-test` touches both, exactly where this PR adds the `managedRules` echo to the `waf.set` body. Resolution: keep the echo line; it must survive any refactor of the save body.
- `waf/+page.svelte` — this PR widens the table to 8 columns (`EmptyRow`/`ErrorRow` colspan 7→8). `waf-ip-lists`/`waf-copy-zone` adding columns is a **semantic** conflict: recount the colspan, don't take either side textually.
- `mock.ts` / `api.d.ts` — three branches touch them; unions are additive, merge both sides.
- `waf-copy-zone`'s cross-location copy modal must decide copy-vs-drop for `managedRules` and handle a target location without the flag (same hazard class as the editor-echo fix in this PR): suggested resolution — copy the block with `enabled:false` when the target lacks `features.waf.managedRules`, copy verbatim otherwise.

## Screenshots

Generated via the Playwright mock harness (`bun run test`, mock fixtures), published on the `screenshots` branch.

| managed rules card (enabled + tuned) | disabled but tuned (frozen) |
| --- | --- |
| ![managed card](https://raw.githubusercontent.com/deploys-app/console/screenshots/331-managed-card.png) | ![disabled but tuned](https://raw.githubusercontent.com/deploys-app/console/screenshots/331-managed-disabled.png) |

| un-flagged location with stored enabled block (disable exit) | firewall index CRS column |
| --- | --- |
| ![unavailable with exit](https://raw.githubusercontent.com/deploys-app/console/screenshots/331-managed-unavailable.png) | ![index CRS column](https://raw.githubusercontent.com/deploys-app/console/screenshots/331-index-crs.png) |

