### PR TITLE
waf: remove the sidebar Preview badge

### DIFF
--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -21,7 +21,7 @@ export const projectMenu: ProjectMenuItem[] = [
 	{ id: 'errors', title: 'Errors', icon: 'fa-bug', link: '/errors', preview: true },
 	{ id: 'domain', title: 'Domains', icon: 'fa-globe', link: '/domain' },
 	{ id: 'route', title: 'Routes', icon: 'fa-router', link: '/route' },
-	{ id: 'waf', title: 'Firewall', icon: 'fa-shield-halved', link: '/waf', preview: true },
+	{ id: 'waf', title: 'Firewall', icon: 'fa-shield-halved', link: '/waf' },
 	{ id: 'cache', title: 'Cache', icon: 'fa-bolt', link: '/cache', preview: true },
 	{ id: 'transform', title: 'Transform', icon: 'fa-wand-magic-sparkles', link: '/transform', preview: true },
 	{ id: 'workload-identity', title: 'Workload Identities', icon: 'fa-network-wired', link: '/workload-identity' },


### PR DESCRIPTION
## What

Drops `preview: true` from the Firewall entry in `src/lib/nav.ts`, removing the "Preview" badge from the sidebar.

## Why

The WAF is feature-complete and enabled in every location (`gke.cluster-rcf2` and `cluster-lab` both carry the `waf` feature flag). The feature set now covers CEL rules, rate limits, metrics, the `waf.test` dry-run tester (#328), zone copy (#327), IP lists (#329), firewall events (#330), and Coraza managed rules (#331) — no remaining preview caveats.

Companion docs PR removes the preview callout from the WAF docs page.

## Test

`bun lint` 0 errors, `bun check` 0 errors, `bun run test` 331/331 passed.

No screenshots: one-token nav change; the badge simply disappears from the sidebar entry.