### PR TITLE
billing: upload slip + WHT cert together via Pay (no dead-end attach)

### DIFF
--- a/src/routes/(auth)/billing/invoice/+page.svelte
+++ b/src/routes/(auth)/billing/invoice/+page.svelte
@@ -65,15 +65,17 @@
 		}
 	}
 
-	// Attach a withholding-tax certificate after the fact (company invoices). Shown
-	// while the invoice is still open (may withhold) or once it was paid with
-	// withholding — for customers who send the 50 ทวิ certificate later.
+	// Attach a withholding-tax certificate after payment (company invoices paid
+	// with WHT). For an open invoice, attach the cert together with the payment
+	// slip in the Pay modal — billing.uploadWHTCertificate requires an existing
+	// slip, so showing this button before one is uploaded only produces
+	// "upload your payment slip before attaching a withholding tax certificate".
 	const MAX_CERT_SIZE = 10 * 1024 * 1024
 	let attachingCert = $state(false)
 	let elCert = $state<HTMLInputElement | null>(null)
 	const canAttachCert = $derived(
 		invoice.taxEntityType === 'company' &&
-		(invoice.status === 'open' || invoice.withholdingTaxAmount > 0)
+		invoice.withholdingTaxAmount > 0
 	)
 
 	async function onCertChange (e: Event) {

--- a/tests/billing.spec.js
+++ b/tests/billing.spec.js
@@ -213,6 +213,18 @@ test.describe('invoice detail', () => {
 		await expect(page.getByRole('button', { name: /Attach WHT certificate/ })).toBeVisible()
 	})
 
+	test('hides page-level Attach WHT on an open company invoice (use Pay for slip+cert together)', async ({ page }) => {
+		await setMocks({
+			'billing.getInvoice': { ok: true, result: sampleInvoice }, // company, open
+			'billing.get': { ok: true, result: sampleBillingAccount }
+		})
+		await page.goto('/billing/invoice?id=inv-1')
+		// Cert-only attach needs an existing slip; on an open invoice the cert rides
+		// along with the slip in the Pay modal instead of a separate button.
+		await expect(page.getByRole('button', { name: /^Attach WHT certificate$/ })).toHaveCount(0)
+		await expect(page.getByRole('button', { name: 'Pay' })).toBeVisible()
+	})
+
 	test('hides the Attach WHT certificate button for an individual invoice', async ({ page }) => {
 		await setMocks({
 			'billing.getInvoice': { ok: true, result: { ...sampleInvoice, taxEntityType: 'individual' } },


### PR DESCRIPTION
## Summary

- Stop showing **Attach WHT certificate** on open company invoices. That path calls `billing.uploadWHTCertificate`, which requires an existing transfer slip, so customers who still needed to pay hit `api: upload your payment slip before attaching a withholding tax certificate`.
- Keep the button for **late attach** only: company invoices already paid with withholding (`withholdingTaxAmount > 0`).
- On open invoices, slip + optional 50 ทวิ ride together on `billing.uploadTransferSlip` in the Pay modal (existing behavior).

## Test plan

- [x] Playwright: WHT modal + attach gating tests (`tests/billing.spec.js` WHT cases)
- [ ] Open company invoice → no page-level Attach; Pay → withhold 3% → attach cert optional → upload slip works with both files
- [ ] Company invoice paid with WHT → Attach WHT certificate still visible and uploads

---
Requested via Grok Work
Prompter: ACS