### PR TITLE
billing: show Company Name label when entity type is company

### DIFF
--- a/src/routes/(auth)/billing/create/+page.svelte
+++ b/src/routes/(auth)/billing/create/+page.svelte
@@ -104,7 +104,7 @@
 		</div>
 
 		<div class="field">
-			<label for="input-tax_name">Name</label>
+			<label for="input-tax_name">{form.type === 'company' ? 'Company Name' : 'Name'}</label>
 			<div class="input">
 				<input id="input-tax_name" bind:value={form.taxName} required>
 			</div>

--- a/tests/billing.spec.js
+++ b/tests/billing.spec.js
@@ -66,6 +66,31 @@ test.describe('billing accounts', () => {
 		const main = page.locator('.content-wrapper')
 		await expect(main.getByText(/don't have access to any billing accounts/)).toBeVisible()
 	})
+
+	test('create form labels tax name as Company Name when entity type is company', async ({ page }) => {
+		await page.goto('/billing/create')
+
+		const main = page.locator('.content-wrapper')
+		const taxNameLabel = main.locator('label[for="input-tax_name"]')
+		await expect(taxNameLabel).toHaveText('Name')
+
+		await main.locator('#input-type').selectOption('company')
+		await expect(taxNameLabel).toHaveText('Company Name')
+
+		await main.locator('#input-type').selectOption('individual')
+		await expect(taxNameLabel).toHaveText('Name')
+	})
+
+	test('update form labels tax name as Company Name for a company account', async ({ page }) => {
+		await setMocks({
+			'billing.get': { ok: true, result: sampleBillingAccount } // type: company
+		})
+
+		await page.goto('/billing/create?id=ba-1')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.locator('label[for="input-tax_name"]')).toHaveText('Company Name')
+	})
 })
 
 test.describe('invoice detail', () => {


### PR DESCRIPTION
## Summary

On the billing account create/update form, the tax name field label now switches based on entity type:

- **Individual** → `Name`
- **Company** → `Company Name`

Previously the label was always `Name`, which is less clear when registering a company.

## Screenshots

| Individual | Company |
| --- | --- |
| ![individual](https://raw.githubusercontent.com/deploys-app/console/screenshots/334-individual.png) | ![company](https://raw.githubusercontent.com/deploys-app/console/screenshots/334-company.png) |

## Test plan

- [x] Playwright: create form toggles label between Name / Company Name with entity type
- [x] Playwright: update form shows Company Name for a company account
- [x] Manual screenshots via mock + Playwright
- [x] `bun lint` / `bun check` clean

---
Requested via Grok Work
Prompter: ACS