### PR TITLE
Add alert rules UI (metric alerts phase 1)

### DIFF
--- a/src/lib/alert.ts
+++ b/src/lib/alert.ts
@@ -1,0 +1,57 @@
+/**
+ * Metric vocabulary + condition/target formatting shared by the alert list,
+ * create/edit form, and detail page. Mirrors api/alert.go's AlertMetrics /
+ * alertConditionString / alertTargetString (see AlertMetricCPU/Memory/
+ * Requests/Egress and AlertPercentThresholdMax).
+ */
+import * as format from '$lib/format'
+
+export interface AlertMetricMeta {
+	value: string
+	label: string
+}
+
+export const ALERT_METRICS: AlertMetricMeta[] = [
+	{ value: 'cpu', label: 'CPU (% of limit)' },
+	{ value: 'memory', label: 'Memory (% of limit)' },
+	{ value: 'requests', label: 'Requests (per minute)' },
+	{ value: 'egress', label: 'Egress (bytes per minute)' }
+]
+
+export const ALERT_OPS = [
+	{ value: '>=', label: '>= (at or above)' },
+	{ value: '<=', label: '<= (at or below)' }
+]
+
+export function alertMetricLabel (metric: string): string {
+	return ALERT_METRICS.find((m) => m.value === metric)?.label ?? metric
+}
+
+/**
+ * Format a threshold/value for its metric's unit — percent for cpu/memory,
+ * binary bytes/min for egress, req/min otherwise.
+ */
+export function alertThresholdString (metric: string, value: number): string {
+	if (metric === 'cpu' || metric === 'memory') return `${value}%`
+	if (metric === 'egress') return `${format.storage(value)}/min`
+	return `${value}/min`
+}
+
+/**
+ * Human-readable one-liner for a condition, e.g. "cpu >= 90% for 10m".
+ */
+export function alertConditionString (c: Api.AlertCondition): string {
+	return `${c.metric} ${c.op} ${alertThresholdString(c.metric, c.threshold)} for ${c.forMinutes}m`
+}
+
+export function alertTargetString (t: Api.AlertTarget): string {
+	return `${t.location} / ${t.deployment}`
+}
+
+/**
+ * lastValue is null before the first evaluation (or while nodata).
+ */
+export function alertValueString (metric: string, v: number | null | undefined): string {
+	if (v === null || v === undefined) return '—'
+	return alertThresholdString(metric, v)
+}

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -37,5 +37,6 @@ export const projectMenu: ProjectMenuItem[] = [
 	{ id: 'github', title: 'GitHub', icon: 'fa-code-branch', link: '/github', preview: true },
 	{ id: 'scheduler', title: 'Scheduler', icon: 'fa-clock', link: '/scheduler', preview: true },
 	{ id: 'notification', title: 'Notifications', icon: 'fa-bell', link: '/notification', preview: true },
+	{ id: 'alert', title: 'Alerts', icon: 'fa-bell-exclamation', link: '/alert', preview: true },
 	{ id: 'audit-log', title: 'Audit Logs', icon: 'fa-clipboard-list', link: '/audit-log' }
 ]

--- a/src/lib/server/mock.ts
+++ b/src/lib/server/mock.ts
@@ -1142,6 +1142,109 @@ const notificationDeliveries = [
 	{ id: '1', startedAt: CREATED_AT, result: 'failed', httpStatus: 0, latencyMs: 30002, error: 'context deadline exceeded' }
 ]
 
+// Alert — metric alert rules (project-scoped, location-less at the resource
+// level; Target carries the location). Mutated by alert.create/update/delete
+// within a session, mirroring githubLinks, so the create -> detail redirect
+// and edit flows work offline.
+interface AlertRuleFixture {
+	project: string
+	name: string
+	target: { location: string, deployment: string }
+	condition: { metric: string, op: string, threshold: number, forMinutes: number }
+	renotifyMinutes: number
+	disabled: boolean
+	status: 'ok' | 'firing' | 'nodata'
+	lastValue: number | null
+	firingSince: string | null
+	lastEvaluatedAt: string | null
+	createdAt: string
+	createdBy: string
+	updatedAt: string
+	updatedBy: string
+}
+
+const alertRules: AlertRuleFixture[] = [
+	{
+		project: 'acme',
+		name: 'web-cpu-high',
+		target: { location: LOCATION_ID, deployment: 'web' },
+		condition: { metric: 'cpu', op: '>=', threshold: 90, forMinutes: 10 },
+		renotifyMinutes: 0,
+		disabled: false,
+		status: 'ok',
+		lastValue: 42.5,
+		firingSince: null,
+		lastEvaluatedAt: CREATED_AT,
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL,
+		updatedAt: CREATED_AT,
+		updatedBy: USER_EMAIL
+	},
+	{
+		project: 'acme',
+		name: 'api-memory-high',
+		target: { location: LOCATION_ID, deployment: 'api' },
+		condition: { metric: 'memory', op: '>=', threshold: 85, forMinutes: 5 },
+		renotifyMinutes: 60,
+		disabled: false,
+		status: 'firing',
+		lastValue: 93.2,
+		firingSince: CREATED_AT,
+		lastEvaluatedAt: CREATED_AT,
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL,
+		updatedAt: CREATED_AT,
+		updatedBy: USER_EMAIL
+	},
+	{
+		// Targets a deployment that doesn't exist in the fixtures — demonstrates
+		// the "nodata" state (deployment paused/deleted, or no limit set).
+		project: 'acme',
+		name: 'worker-requests-drop',
+		target: { location: LOCATION_ID, deployment: 'worker' },
+		condition: { metric: 'requests', op: '<=', threshold: 1, forMinutes: 15 },
+		renotifyMinutes: 0,
+		disabled: false,
+		status: 'nodata',
+		lastValue: null,
+		firingSince: null,
+		lastEvaluatedAt: CREATED_AT,
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL,
+		updatedAt: CREATED_AT,
+		updatedBy: USER_EMAIL
+	},
+	{
+		project: 'acme',
+		name: 'website-egress-spike',
+		target: { location: LOCATION_ID, deployment: 'website' },
+		condition: { metric: 'egress', op: '>=', threshold: 524288000, forMinutes: 10 },
+		renotifyMinutes: 0,
+		disabled: true,
+		status: 'ok',
+		lastValue: 12345678,
+		firingSince: null,
+		lastEvaluatedAt: CREATED_AT,
+		createdAt: CREATED_AT,
+		createdBy: USER_EMAIL,
+		updatedAt: CREATED_AT,
+		updatedBy: USER_EMAIL
+	}
+]
+
+interface AlertEventFixture {
+	at: string
+	transition: 'trigger' | 'resolve' | 'renotify'
+	value: number | null
+}
+
+const alertEvents: AlertEventFixture[] = [
+	{ at: CREATED_AT, transition: 'renotify', value: 94.1 },
+	{ at: CREATED_AT, transition: 'trigger', value: 93.2 },
+	{ at: CREATED_AT, transition: 'resolve', value: 61.0 },
+	{ at: CREATED_AT, transition: 'trigger', value: 88.4 }
+]
+
 const roles = [
 	{
 		role: 'viewer',
@@ -2431,6 +2534,55 @@ const handlers: Record<string, (args: any) => object> = {
 	'notification.test': () => ok({ id: '', startedAt: CREATED_AT, result: 'success', httpStatus: 200, latencyMs: 73, error: '' }),
 	'notification.deliveries': () => list(notificationDeliveries),
 	'notification.pull': () => ok({ project: 'acme', name: 'local-agent', events: [], cursor: 0, hasMore: false }),
+
+	'alert.list': () => list(alertRules),
+	'alert.get': (args) => {
+		const item = alertRules.find((a) => a.name === args?.name)
+		if (!item) return err('api: alert not found')
+		return ok(item)
+	},
+	'alert.create': (args) => {
+		if (alertRules.some((a) => a.name === args?.name)) return err('api: alert already exists')
+		alertRules.push({
+			project: args?.project ?? 'acme',
+			name: args?.name ?? '',
+			target: args?.target ?? { location: LOCATION_ID, deployment: '' },
+			condition: args?.condition ?? { metric: 'cpu', op: '>=', threshold: 90, forMinutes: 10 },
+			renotifyMinutes: args?.renotifyMinutes ?? 0,
+			disabled: args?.disabled ?? false,
+			status: 'ok',
+			lastValue: null,
+			firingSince: null,
+			lastEvaluatedAt: null,
+			createdAt: CREATED_AT,
+			createdBy: USER_EMAIL,
+			updatedAt: CREATED_AT,
+			updatedBy: USER_EMAIL
+		})
+		return ok({})
+	},
+	'alert.update': (args) => {
+		const item = alertRules.find((a) => a.name === args?.name)
+		if (!item) return err('api: alert not found')
+		item.target = args?.target ?? item.target
+		item.condition = args?.condition ?? item.condition
+		item.renotifyMinutes = args?.renotifyMinutes ?? item.renotifyMinutes
+		item.disabled = args?.disabled ?? item.disabled
+		item.updatedAt = CREATED_AT
+		item.updatedBy = USER_EMAIL
+		return ok({})
+	},
+	'alert.delete': (args) => {
+		const i = alertRules.findIndex((a) => a.name === args?.name)
+		if (i < 0) return err('api: alert not found')
+		alertRules.splice(i, 1)
+		return ok({})
+	},
+	'alert.events': (args) => {
+		const item = alertRules.find((a) => a.name === args?.name)
+		if (!item) return err('api: alert not found')
+		return list(alertEvents)
+	},
 
 	'email.list': () => list([{ domain: 'mail.acme.example.com', createdAt: CREATED_AT }]),
 

--- a/src/routes/(auth)/(project)/alert/+layout.ts
+++ b/src/routes/(auth)/(project)/alert/+layout.ts
@@ -1,0 +1,8 @@
+import type { LayoutLoad } from './$types'
+
+export const load: LayoutLoad = () => {
+	return {
+		menu: 'alert',
+		overrideRedirect: '/alert'
+	}
+}

--- a/src/routes/(auth)/(project)/alert/+page.svelte
+++ b/src/routes/(auth)/(project)/alert/+page.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+	import { onMount } from 'svelte'
+	import { invalidateAll } from '$app/navigation'
+	import type { PageData } from './$types'
+	import ListTable from '$lib/components/ListTable.svelte'
+	import { alertConditionString, alertTargetString, alertValueString } from '$lib/alert'
+	import { denyTooltip, getPermissionContext } from '$lib/permission'
+
+	const { can } = getPermissionContext()
+
+	const { data }: { data: PageData } = $props()
+
+	const project = $derived(data.project)
+	const alerts = $derived(data.alerts)
+	const error = $derived(data.error)
+
+	// Rules can flip firing/resolve at any minute (the alert-tick cron runs every
+	// minute), so keep the list fresh the same way the deployment metrics page
+	// does: a self-rescheduling timeout that reinvokes the page load, not a plain
+	// interval — this way a slow reload never overlaps the next tick.
+	const RELOAD_INTERVAL_MS = 60_000
+	let reloadTimeout: ReturnType<typeof setTimeout> | null = null
+
+	function scheduleReload () {
+		reloadTimeout && clearTimeout(reloadTimeout)
+		reloadTimeout = setTimeout(async () => {
+			await invalidateAll()
+			scheduleReload()
+		}, RELOAD_INTERVAL_MS)
+	}
+
+	onMount(() => {
+		scheduleReload()
+		return () => { reloadTimeout && clearTimeout(reloadTimeout) }
+	})
+</script>
+
+<ListTable
+	title="Alerts"
+	items={alerts}
+	{error}
+	noun="alert rule"
+	createPermission="alert.create"
+	createHref="/alert/create?project={project}"
+	createLabel="Create rule"
+	columns={['Name', 'Target', 'Condition', 'Status', 'Last value']}
+	actions
+	key={(it) => it.name}>
+	{#snippet row(it)}
+		<td>
+			<a class="link cell-name" href="/alert/detail?project={project}&name={it.name}">
+				{it.name}
+			</a>
+		</td>
+		<td><span class="font-mono text-sm text-content/70">{alertTargetString(it.target)}</span></td>
+		<td><span class="font-mono text-sm">{alertConditionString(it.condition)}</span></td>
+		<td>
+			{#if it.disabled}
+				<span class="inline-flex items-center gap-2 text-content/60"><i class="fa-solid fa-ban"></i> Disabled</span>
+			{:else}
+				<span class="status-badge" data-status={it.status}>{it.status}</span>
+			{/if}
+		</td>
+		<td class="tabular-nums">{alertValueString(it.condition.metric, it.lastValue)}</td>
+		<td>
+			<span class="inline-flex" title={can('alert.update') ? null : denyTooltip('alert.update')}>
+				<a
+					href={can('alert.update') ? `/alert/create?project=${project}&name=${it.name}` : null}
+					aria-label="Edit"
+					aria-disabled={can('alert.update') ? null : 'true'}>
+					<div class="icon-button">
+						<i class="fa-solid fa-pen"></i>
+					</div>
+				</a>
+			</span>
+		</td>
+	{/snippet}
+</ListTable>
+
+<style>
+	.status-badge {
+		display: inline-flex;
+		padding: 0.0625rem 0.5rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: capitalize;
+		color: hsl(var(--hsl-content) / 0.75);
+		background-color: hsl(var(--hsl-content) / 0.08);
+	}
+
+	.status-badge[data-status='ok'] {
+		color: hsl(var(--hsl-positive));
+		background-color: hsl(var(--hsl-positive) / 0.12);
+	}
+
+	.status-badge[data-status='firing'] {
+		color: hsl(var(--hsl-negative));
+		background-color: hsl(var(--hsl-negative) / 0.12);
+	}
+
+	.status-badge[data-status='nodata'] {
+		color: hsl(var(--hsl-content) / 0.55);
+		background-color: hsl(var(--hsl-content) / 0.08);
+	}
+</style>

--- a/src/routes/(auth)/(project)/alert/+page.ts
+++ b/src/routes/(auth)/(project)/alert/+page.ts
@@ -1,0 +1,3 @@
+import { listLoad } from '$lib/loaders'
+
+export const load = listLoad<Api.AlertItem, 'alerts'>('alert.list', 'alerts')

--- a/src/routes/(auth)/(project)/alert/create/+page.svelte
+++ b/src/routes/(auth)/(project)/alert/create/+page.svelte
@@ -1,0 +1,276 @@
+<script lang="ts">
+	import { onMount, untrack } from 'svelte'
+	import { goto } from '$app/navigation'
+	import type { PageData } from './$types'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import Select from '$lib/components/Select.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import { ALERT_METRICS, ALERT_OPS, alertMetricLabel } from '$lib/alert'
+
+	const { data }: { data: PageData } = $props()
+
+	const project = $derived(data.project)
+	const locations = $derived(data.locations)
+	const alert = $derived(data.alert)
+	const isEdit = $derived(!!data.alert)
+	const hasChannels = $derived(data.hasChannels)
+
+	const metricOptions = ALERT_METRICS.map((m) => ({ value: m.value, label: m.label }))
+	const opOptions = ALERT_OPS
+
+	const form = $state(untrack(() => ({
+		name: alert?.name ?? '',
+		location: alert?.target.location ?? '',
+		deployment: alert?.target.deployment ?? '',
+		metric: alert?.condition.metric ?? 'cpu',
+		op: alert?.condition.op ?? '>=',
+		threshold: alert?.condition.threshold ?? 90,
+		forMinutes: alert?.condition.forMinutes ?? 10,
+		renotify: (alert?.renotifyMinutes ?? 0) > 0,
+		renotifyMinutes: alert?.renotifyMinutes && alert.renotifyMinutes > 0 ? alert.renotifyMinutes : 60,
+		disabled: alert?.disabled ?? false
+	})))
+
+	const metricUnit = $derived(
+		form.metric === 'cpu' || form.metric === 'memory'
+			? '%'
+			: form.metric === 'egress' ? 'bytes/min' : 'req/min'
+	)
+
+	let deployments = $state<{ name: string, paused: boolean }[]>([])
+
+	// The paired deployment picker: location narrows the deployment list, mirroring
+	// the route create form. Paused deployments stay selectable (a rule can be
+	// wired up ahead of a resume) but are flagged.
+	//
+	// On edit, the configured deployment may no longer exist (deleted/renamed) —
+	// keep it selectable and flagged rather than silently clearing the field, so
+	// saving the form without touching this field doesn't accidentally repoint the
+	// rule. Matches the "nodata" story in the SPEC: a missing target is a valid
+	// (if unhealthy) state, not an error.
+	const deploymentOptions = $derived([
+		...(form.deployment && !deployments.some((d) => d.name === form.deployment)
+			? [{ value: form.deployment, label: form.deployment, dot: 'negative' as const, badge: 'Not found', badgeTone: 'negative' as const }]
+			: []),
+		...deployments.map((d) => ({
+			value: d.name,
+			label: d.name,
+			dot: (d.paused ? 'warning' : 'positive') as 'warning' | 'positive',
+			badge: d.paused ? 'Paused' : undefined,
+			badgeTone: 'warning' as const
+		}))
+	])
+
+	async function fetchDeployments () {
+		deployments = []
+
+		const resp = await api.invoke<Api.List<Api.DeploymentListItem>>('deployment.list', { project }, fetch)
+		if (!resp.ok) {
+			modal.error({ error: resp.error })
+			return
+		}
+		const list = resp.result?.items ?? []
+		deployments = list
+			.filter((x) => x.location === form.location)
+			.filter((x) => x.ttl === 0)
+			.map((x) => ({ name: x.name, paused: x.action === 'pause' }))
+	}
+
+	function onLocationChange () {
+		form.deployment = ''
+		fetchDeployments()
+	}
+
+	onMount(() => {
+		if (form.location) fetchDeployments()
+	})
+
+	let saving = $state(false)
+
+	async function save (e: SubmitEvent) {
+		e.preventDefault()
+		if (saving) return
+
+		saving = true
+		try {
+			const fn = isEdit ? 'alert.update' : 'alert.create'
+			const args = {
+				project,
+				name: form.name,
+				target: {
+					location: form.location,
+					deployment: form.deployment
+				},
+				condition: {
+					metric: form.metric,
+					op: form.op,
+					threshold: Number(form.threshold),
+					forMinutes: Number(form.forMinutes)
+				},
+				renotifyMinutes: form.renotify ? Number(form.renotifyMinutes) : 0,
+				disabled: form.disabled
+			}
+
+			const resp = await api.invoke(fn, args, fetch)
+			if (!resp.ok) {
+				modal.error({ error: resp.error })
+				return
+			}
+			await goto(`/alert/detail?project=${project}&name=${encodeURIComponent(form.name)}`)
+		} finally {
+			saving = false
+		}
+	}
+
+	function cancel () {
+		goto(`/alert?project=${project}`)
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/alert?project=${project}`} class="link"><h6>Alerts</h6></a>
+	</div>
+	{#if isEdit && alert}
+		<div class="breadcrumb-item">
+			<a href={`/alert/detail?project=${project}&name=${encodeURIComponent(alert.name)}`} class="link"><h6>{alert.name}</h6></a>
+		</div>
+		<div class="breadcrumb-item"><h6>Edit</h6></div>
+	{:else}
+		<div class="breadcrumb-item"><h6>Create</h6></div>
+	{/if}
+</div>
+
+<br>
+
+<div class="page-head">
+	<div>
+		<h4><strong>{isEdit ? 'Edit alert rule' : 'Create alert rule'}</strong></h4>
+		<p class="page-sub">Notify when a deployment metric crosses a threshold for a sustained period.</p>
+	</div>
+</div>
+
+<div class="panel is-level-300 grid gap-4">
+	<form class="grid gap-4 w-full" onsubmit={save}>
+		<div class="field">
+			<label for="input-name">Name</label>
+			<div class="input">
+				<input id="input-name" placeholder="web-cpu-high" bind:value={form.name} required readonly={isEdit}>
+			</div>
+		</div>
+
+		<br>
+		<hr>
+		<br>
+
+		<h6><strong>Target</strong></h6>
+
+		<div class="grid gap-4 sm:grid-cols-2">
+			<div class="field">
+				<label for="input-location">Location</label>
+				<Select
+					id="input-location"
+					bind:value={form.location}
+					onchange={onLocationChange}
+					required
+					placeholder="Select Location"
+					options={locations.map((it) => ({ value: it.id, label: it.id }))} />
+			</div>
+			{#if form.location}
+				<div class="field">
+					<label for="input-deployment">Deployment</label>
+					<Select
+						id="input-deployment"
+						bind:value={form.deployment}
+						required
+						placeholder="Select Deployment"
+						options={deploymentOptions} />
+				</div>
+			{/if}
+		</div>
+
+		<br>
+		<hr>
+		<br>
+
+		<h6><strong>Condition</strong></h6>
+
+		<div class="field">
+			<label for="input-metric">Metric</label>
+			<Select id="input-metric" bind:value={form.metric} options={metricOptions} />
+		</div>
+
+		<div class="grid gap-4 sm:grid-cols-3">
+			<div class="field">
+				<label for="input-op">Comparison</label>
+				<Select id="input-op" bind:value={form.op} options={opOptions} />
+			</div>
+			<div class="field">
+				<label for="input-threshold">Threshold ({metricUnit})</label>
+				<div class="input">
+					<input id="input-threshold" type="number" min="0" step="any" bind:value={form.threshold} required>
+				</div>
+			</div>
+			<div class="field">
+				<label for="input-for-minutes">For (minutes)</label>
+				<div class="input">
+					<input id="input-for-minutes" type="number" min="1" max="60" bind:value={form.forMinutes} required>
+				</div>
+			</div>
+		</div>
+		<p class="text-content/50 text-sm">
+			Fires when <strong>{alertMetricLabel(form.metric)}</strong> stays {form.op} the threshold for the full window — a single missed minute of data doesn't reset the clock.
+		</p>
+
+		<br>
+		<hr>
+		<br>
+
+		<h6><strong>Notification</strong></h6>
+
+		<label class="checkbox">
+			<input type="checkbox" bind:checked={form.renotify}>
+			Notify again while still firing
+		</label>
+
+		{#if form.renotify}
+			<div class="field sm:w-64">
+				<label for="input-renotify-minutes">Every (minutes)</label>
+				<div class="input">
+					<input id="input-renotify-minutes" type="number" min="10" max="1440" bind:value={form.renotifyMinutes} required>
+				</div>
+			</div>
+		{/if}
+
+		<p class="text-content/60 text-sm">
+			<i class="fa-solid fa-circle-info"></i>
+			Delivery uses your project's <a class="link" href={`/notification?project=${project}`}>notification channels</a>.
+			{#if !hasChannels}
+				<br>
+				<span class="text-warning">
+					<i class="fa-solid fa-triangle-exclamation"></i>
+					No notification channels exist yet — this rule will evaluate but reach nobody until you add one.
+				</span>
+			{/if}
+		</p>
+
+		<br>
+		<hr>
+		<br>
+
+		<label class="checkbox">
+			<input type="checkbox" bind:checked={form.disabled}>
+			Disabled (do not evaluate until re-enabled)
+		</label>
+
+		<hr>
+
+		<div class="flex gap-3">
+			<GuardedButton permission={isEdit ? 'alert.update' : 'alert.create'} type="submit" loading={saving}>
+				{isEdit ? 'Save' : 'Create'}
+			</GuardedButton>
+			<button type="button" class="button is-variant-secondary" onclick={cancel}>Cancel</button>
+		</div>
+	</form>
+</div>

--- a/src/routes/(auth)/(project)/alert/create/+page.ts
+++ b/src/routes/(auth)/(project)/alert/create/+page.ts
@@ -1,0 +1,31 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async ({ url, parent, fetch }) => {
+	const { project } = await parent()
+	const name = url.searchParams.get('name')
+
+	let alert: Api.AlertItem | null = null
+	if (name) {
+		const res = await api.invoke<Api.AlertItem>('alert.get', { project, name }, fetch)
+		if (!res.ok) {
+			if (res.error?.notFound) redirect(302, `/alert?project=${project}`)
+			error(500, res.error?.message)
+		}
+		if (!res.result) redirect(302, `/alert?project=${project}`)
+		alert = res.result
+	}
+
+	// Delivery uses the project's notification channels; a failure here shouldn't
+	// break the form, so default to "channels exist" (no warning) rather than
+	// false-alarming on a transient error.
+	const channels = await api.invoke<Api.List<Api.NotificationItem>>('notification.list', { project }, fetch)
+	const hasChannels = channels.ok ? (channels.result?.items.length ?? 0) > 0 : true
+
+	return {
+		menu: 'alert',
+		alert,
+		hasChannels
+	}
+}

--- a/src/routes/(auth)/(project)/alert/detail/+page.svelte
+++ b/src/routes/(auth)/(project)/alert/detail/+page.svelte
@@ -1,0 +1,200 @@
+<script lang="ts">
+	import { goto } from '$app/navigation'
+	import type { PageData } from './$types'
+	import * as format from '$lib/format'
+	import * as modal from '$lib/modal'
+	import api from '$lib/api'
+	import DangerZone from '$lib/components/DangerZone.svelte'
+	import GuardedButton from '$lib/components/GuardedButton.svelte'
+	import { getPermissionContext } from '$lib/permission'
+	import { registerPageActions, type PageAction } from '$lib/pageactions/store.svelte'
+	import { alertConditionString, alertValueString } from '$lib/alert'
+
+	const { data }: { data: PageData } = $props()
+
+	const project = $derived(data.project)
+	const alert = $derived(data.alert)
+	const events = $derived(data.events)
+
+	const { can } = getPermissionContext()
+	$effect(() => {
+		const actions: PageAction[] = []
+		if (can('alert.update')) {
+			actions.push({ id: 'alert-detail:edit', label: 'Edit', icon: 'fa-pen', keywords: 'edit modify update alert rule', href: `/alert/create?project=${project}&name=${encodeURIComponent(alert.name)}` })
+		}
+		if (!actions.length) return
+		return registerPageActions(actions)
+	})
+
+	function deleteItem () {
+		modal.confirm({
+			title: `Delete "${alert.name}"?`,
+			yes: 'Delete',
+			callback: async () => {
+				const resp = await api.invoke('alert.delete', { project, name: alert.name }, fetch)
+				if (!resp.ok) {
+					modal.error({ error: resp.error })
+					return
+				}
+				await goto(`/alert?project=${project}`)
+			}
+		})
+	}
+</script>
+
+<div class="breadcrumb">
+	<div class="breadcrumb-item">
+		<a href={`/alert?project=${project}`} class="link"><h6>Alerts</h6></a>
+	</div>
+	<div class="breadcrumb-item min-w-0">
+		<h6 class="min-w-0 wrap-anywhere">{alert.name}</h6>
+	</div>
+</div>
+
+<br>
+
+<div class="page-head">
+	<div class="min-w-0">
+		<h4 class="min-w-0 wrap-anywhere"><strong>{alert.name}</strong></h4>
+		<p class="page-sub">
+			{#if alert.disabled}
+				<span class="text-content/60"><i class="fa-solid fa-ban"></i> Disabled</span>
+			{:else}
+				<span class="status-badge" data-status={alert.status}>{alert.status}</span>
+			{/if}
+		</p>
+	</div>
+	<div class="flex gap-3 flex-wrap">
+		<GuardedButton permission="alert.update" class="button is-variant-secondary is-icon-left"
+			href={`/alert/create?project=${project}&name=${encodeURIComponent(alert.name)}`}>
+			<i class="fa-solid fa-pen"></i>
+			Edit
+		</GuardedButton>
+	</div>
+</div>
+
+<div class="panel is-level-300 grid gap-6">
+	<div class="grid gap-4 w-full">
+		<div class="field">
+			<span class="label">Target</span>
+			<p>
+				<a class="link font-mono text-sm" href={`/deployment/metrics?project=${project}&location=${alert.target.location}&name=${alert.target.deployment}`}>
+					{alert.target.location} / {alert.target.deployment}
+				</a>
+			</p>
+		</div>
+
+		<div class="grid gap-4 sm:grid-cols-2">
+			<div class="field">
+				<label for="d-condition">Condition</label>
+				<div class="input"><input id="d-condition" class="font-mono" value={alertConditionString(alert.condition)} readonly disabled></div>
+			</div>
+			<div class="field">
+				<label for="d-renotify">Re-notify while firing</label>
+				<div class="input">
+					<input id="d-renotify" value={alert.renotifyMinutes > 0 ? `Every ${alert.renotifyMinutes} minutes` : 'Only on trigger/resolve'} readonly disabled>
+				</div>
+			</div>
+		</div>
+
+		<hr>
+
+		<div>
+			<h6><strong>Evaluator state</strong></h6>
+			<p class="text-content/50 text-sm mt-1">Set by the alert-tick cron on every evaluation.</p>
+		</div>
+
+		<div class="grid gap-4 sm:grid-cols-3">
+			<div class="field">
+				<label for="d-last-value">Last value</label>
+				<div class="input"><input id="d-last-value" class="tabular-nums" value={alertValueString(alert.condition.metric, alert.lastValue)} readonly disabled></div>
+			</div>
+			<div class="field">
+				<label for="d-firing-since">Firing since</label>
+				<div class="input">
+					<input id="d-firing-since" value={alert.firingSince ? format.datetime(alert.firingSince) : '—'} readonly disabled title={alert.firingSince ? format.fromNow(alert.firingSince) : ''}>
+				</div>
+			</div>
+			<div class="field">
+				<label for="d-last-evaluated">Last evaluated</label>
+				<div class="input">
+					<input id="d-last-evaluated" value={alert.lastEvaluatedAt ? format.fromNow(alert.lastEvaluatedAt) : 'Never'} readonly disabled title={alert.lastEvaluatedAt ? format.datetime(alert.lastEvaluatedAt) : ''}>
+				</div>
+			</div>
+		</div>
+
+		<hr>
+
+		<div>
+			<h6><strong>Transition history</strong></h6>
+			<p class="text-content/50 text-sm mt-1">The most recent state changes for this rule.</p>
+		</div>
+
+		<div class="table-container">
+			<table class="table is-variant-compact">
+				<thead>
+					<tr>
+						<th>Time</th>
+						<th>Transition</th>
+						<th>Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<!-- AlertEvent carries no id (see api/alert.go) and two transitions can
+					     legitimately land in the same second, so key by index rather than
+					     `at` — the list is always a wholesale reload, never incrementally
+					     patched, so index-keying is safe here. -->
+					{#each events as ev, i (i)}
+						<tr>
+							<td><span title={format.datetime(ev.at)}>{format.fromNow(ev.at)}</span></td>
+							<td>
+								{#if ev.transition === 'trigger'}
+									<span class="inline-flex items-center gap-2 text-negative/80"><i class="fa-solid fa-triangle-exclamation"></i> Trigger</span>
+								{:else if ev.transition === 'resolve'}
+									<span class="inline-flex items-center gap-2 text-positive/80"><i class="fa-solid fa-circle-check"></i> Resolve</span>
+								{:else}
+									<span class="inline-flex items-center gap-2 text-content/60"><i class="fa-solid fa-rotate"></i> Renotify</span>
+								{/if}
+							</td>
+							<td class="tabular-nums">{alertValueString(alert.condition.metric, ev.value)}</td>
+						</tr>
+					{:else}
+						<tr><td colspan="3" class="text-center text-content/50">No transitions yet.</td></tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+
+		<DangerZone description="Permanently delete this alert rule.">
+			<GuardedButton permission="alert.delete" class="button is-variant-negative" type="button" onclick={deleteItem}>Delete</GuardedButton>
+		</DangerZone>
+	</div>
+</div>
+
+<style>
+	.status-badge {
+		display: inline-flex;
+		padding: 0.0625rem 0.5rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: capitalize;
+		color: hsl(var(--hsl-content) / 0.75);
+		background-color: hsl(var(--hsl-content) / 0.08);
+	}
+
+	.status-badge[data-status='ok'] {
+		color: hsl(var(--hsl-positive));
+		background-color: hsl(var(--hsl-positive) / 0.12);
+	}
+
+	.status-badge[data-status='firing'] {
+		color: hsl(var(--hsl-negative));
+		background-color: hsl(var(--hsl-negative) / 0.12);
+	}
+
+	.status-badge[data-status='nodata'] {
+		color: hsl(var(--hsl-content) / 0.55);
+		background-color: hsl(var(--hsl-content) / 0.08);
+	}
+</style>

--- a/src/routes/(auth)/(project)/alert/detail/+page.ts
+++ b/src/routes/(auth)/(project)/alert/detail/+page.ts
@@ -1,0 +1,26 @@
+import { redirect, error } from '@sveltejs/kit'
+import api from '$lib/api'
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async ({ url, parent, fetch }) => {
+	const { project } = await parent()
+	const name = url.searchParams.get('name')
+	if (!name) redirect(302, `/alert?project=${project}`)
+
+	const res = await api.invoke<Api.AlertItem>('alert.get', { project, name }, fetch)
+	if (!res.ok) {
+		if (res.error?.notFound) redirect(302, `/alert?project=${project}`)
+		error(500, res.error?.message)
+	}
+	if (!res.result) redirect(302, `/alert?project=${project}`)
+
+	// Recent state transitions. A failure here shouldn't break the detail page,
+	// so the items default to empty.
+	const events = await api.invoke<Api.AlertEventsResult>('alert.events', { project, name, limit: 50 }, fetch)
+
+	return {
+		menu: 'alert',
+		alert: res.result,
+		events: events.result?.items ?? []
+	}
+}

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -1133,6 +1133,62 @@ declare namespace Api {
         items: NotificationDelivery[]
     }
 
+    // Alert — metric alert rules on deployment usage (project-scoped,
+    // location-less at the resource level; Target carries the location, like
+    // Notification carries its delivery config). Evaluated by an apiserver cron
+    // tick against the existing per-minute deployment_usages table; delivery
+    // reuses the notification-channels feature entirely.
+    export type AlertTarget = {
+        location: string
+        deployment: string
+    }
+
+    // Threshold's unit depends on Metric: percent 0-100 for cpu/memory, req/min
+    // for requests, bytes/min for egress. Op defaults to ">=" server-side when
+    // left empty.
+    export type AlertCondition = {
+        metric: 'cpu' | 'memory' | 'requests' | 'egress'
+        op: '>=' | '<='
+        threshold: number
+        forMinutes: number
+    }
+
+    export type AlertItem = {
+        project: string
+        name: string
+        target: AlertTarget
+        condition: AlertCondition
+        // 0 = notify only on trigger/resolve transitions.
+        renotifyMinutes: number
+        disabled: boolean
+        // read-only evaluator state, set by the alert-tick cron.
+        status: 'ok' | 'firing' | 'nodata'
+        lastValue: number | null
+        firingSince: string | null
+        lastEvaluatedAt: string | null
+        createdAt: string
+        createdBy: string
+        updatedAt: string
+        updatedBy: string
+    }
+
+    export type AlertListResult = {
+        project: string
+        items: AlertItem[]
+    }
+
+    export type AlertEvent = {
+        at: string
+        transition: 'trigger' | 'resolve' | 'renotify'
+        value: number | null
+    }
+
+    export type AlertEventsResult = {
+        project: string
+        name: string
+        items: AlertEvent[]
+    }
+
     // cache.metrics reuses WafMetricsTimeRange.
     export type CacheMetricsSeries = {
         overrideId: string

--- a/tests/alert.spec.js
+++ b/tests/alert.spec.js
@@ -1,0 +1,265 @@
+import { test, expect, setMocks, getRequestLog, pickSelect } from './helpers.js'
+import { sampleAlertRule, sampleAlertEvent, sampleDeployment } from './fixtures/mocks.js'
+
+test.describe('alerts', () => {
+	test('lists alert rules with status badges', async ({ page }) => {
+		await setMocks({
+			'alert.list': {
+				ok: true,
+				result: {
+					items: [
+						sampleAlertRule,
+						{
+							...sampleAlertRule,
+							name: 'api-memory-high',
+							condition: { metric: 'memory', op: '>=', threshold: 85, forMinutes: 5 },
+							status: 'firing',
+							lastValue: 93.2
+						},
+						{
+							...sampleAlertRule,
+							name: 'worker-requests-drop',
+							condition: { metric: 'requests', op: '<=', threshold: 1, forMinutes: 15 },
+							status: 'nodata',
+							lastValue: null
+						}
+					]
+				}
+			}
+		})
+
+		await page.goto('/alert?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Alerts' })).toBeVisible()
+		await expect(main.getByRole('link', { name: 'web-cpu-high' })).toBeVisible()
+		await expect(main.getByRole('link', { name: 'api-memory-high' })).toBeVisible()
+		await expect(main.getByRole('link', { name: 'worker-requests-drop' })).toBeVisible()
+
+		await expect(main.getByRole('cell', { name: 'ok', exact: true })).toBeVisible()
+		await expect(main.getByRole('cell', { name: 'firing', exact: true })).toBeVisible()
+		await expect(main.getByRole('cell', { name: 'nodata', exact: true })).toBeVisible()
+
+		// Condition + target render as a human-readable one-liner.
+		await expect(main.getByText('cpu >= 90% for 10m', { exact: true })).toBeVisible()
+		await expect(main.getByText('memory >= 85% for 5m', { exact: true })).toBeVisible()
+		await expect(main.getByText('gke / web', { exact: true }).first()).toBeVisible()
+	})
+
+	test('shows a disabled badge instead of the status for a disabled rule', async ({ page }) => {
+		await setMocks({
+			'alert.list': { ok: true, result: { items: [{ ...sampleAlertRule, disabled: true }] } }
+		})
+
+		await page.goto('/alert?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('Disabled')).toBeVisible()
+		await expect(main.getByRole('cell', { name: 'ok', exact: true })).toHaveCount(0)
+	})
+
+	test('empty state when no alert rules', async ({ page }) => {
+		await page.goto('/alert?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('Nothing here yet')).toBeVisible()
+	})
+
+	test('surfaces an API error in the list', async ({ page }) => {
+		await setMocks({
+			'alert.list': { ok: false, error: { message: 'api: internal error' } }
+		})
+		await page.goto('/alert?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText(/Something went wrong while loading this data/)).toBeVisible()
+		await expect(main.getByRole('button', { name: 'Try again' })).toBeVisible()
+	})
+
+	test('gates the create button when the create permission is missing', async ({ page }) => {
+		await setMocks({
+			'me.permissions': { ok: true, result: { permissions: ['alert.list'], admin: false } }
+		})
+		await page.goto('/alert?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('button', { name: 'Create rule' })).toBeDisabled()
+		await expect(main.getByRole('link', { name: 'Create rule' })).toHaveCount(0)
+	})
+})
+
+test.describe('alert — create', () => {
+	test('submits alert.create with the target, condition, and notification settings', async ({ page }) => {
+		await setMocks({
+			'deployment.list': { ok: true, result: { items: [sampleDeployment] } },
+			'alert.create': { ok: true, result: {} },
+			// The successful-create redirect lands on the detail page, which loads
+			// the rule by name — the created name must resolve.
+			'alert.get': {
+				ok: true,
+				result: {
+					...sampleAlertRule,
+					condition: { metric: 'requests', op: '>=', threshold: 500, forMinutes: 15 },
+					renotifyMinutes: 120
+				}
+			},
+			'alert.events': { ok: true, result: { items: [] } }
+		})
+
+		await page.goto('/alert/create?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await main.locator('#input-name').fill('web-cpu-high')
+		await pickSelect(page, 'input-location', 'gke')
+		await pickSelect(page, 'input-deployment', 'web')
+		await pickSelect(page, 'input-metric', 'Requests (per minute)')
+		await main.locator('#input-threshold').fill('500')
+		await main.locator('#input-for-minutes').fill('15')
+		await main.getByRole('checkbox', { name: 'Notify again while still firing' }).check()
+		await main.locator('#input-renotify-minutes').fill('120')
+
+		await main.getByRole('button', { name: 'Create', exact: true }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/alert.create')
+		}).toBeTruthy()
+
+		const req = (await getRequestLog()).find((r) => r.path === '/alert.create')
+		if (!req) throw new Error('expected an alert.create request')
+		const body = JSON.parse(req.body)
+		expect(body.name).toBe('web-cpu-high')
+		expect(body.target).toEqual({ location: 'gke', deployment: 'web' })
+		expect(body.condition).toEqual({ metric: 'requests', op: '>=', threshold: 500, forMinutes: 15 })
+		expect(body.renotifyMinutes).toBe(120)
+
+		await expect(page).toHaveURL(/\/alert\/detail\?project=test-project&name=web-cpu-high/)
+	})
+
+	test('shows the API error in a modal when create fails', async ({ page }) => {
+		await setMocks({
+			'deployment.list': { ok: true, result: { items: [sampleDeployment] } },
+			'alert.create': { ok: false, error: { message: 'api: alert already exists' } }
+		})
+
+		await page.goto('/alert/create?project=test-project')
+
+		const main = page.locator('.content-wrapper')
+		await main.locator('#input-name').fill('web-cpu-high')
+		await pickSelect(page, 'input-location', 'gke')
+		await pickSelect(page, 'input-deployment', 'web')
+		await main.locator('#input-threshold').fill('90')
+		await main.locator('#input-for-minutes').fill('10')
+		await main.getByRole('button', { name: 'Create', exact: true }).click()
+
+		await expect(page.locator('#app-modal')).toBeVisible()
+		await expect(page.locator('#app-modal')).toContainText('api: alert already exists')
+	})
+
+	test('disables Create when the create permission is missing', async ({ page }) => {
+		await setMocks({
+			'me.permissions': { ok: true, result: { permissions: ['alert.list'], admin: false } }
+		})
+		await page.goto('/alert/create?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('button', { name: 'Create', exact: true })).toBeDisabled()
+	})
+
+	test('warns when the project has no notification channels', async ({ page }) => {
+		await setMocks({
+			'notification.list': { ok: true, result: { items: [] } }
+		})
+		await page.goto('/alert/create?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('No notification channels exist yet')).toBeVisible()
+	})
+
+	test('does not warn when notification channels exist', async ({ page }) => {
+		await setMocks({
+			'notification.list': { ok: true, result: { items: [{ project: 'test-project', name: 'ops-webhook' }] } }
+		})
+		await page.goto('/alert/create?project=test-project')
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByText('No notification channels exist yet')).toHaveCount(0)
+	})
+})
+
+test.describe('alert — edit', () => {
+	test('seeds the form from the existing rule and submits alert.update', async ({ page }) => {
+		await setMocks({
+			'alert.get': { ok: true, result: sampleAlertRule },
+			'deployment.list': { ok: true, result: { items: [sampleDeployment] } },
+			'alert.update': { ok: true, result: {} }
+		})
+
+		await page.goto('/alert/create?project=test-project&name=web-cpu-high')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'Edit alert rule' })).toBeVisible()
+		await expect(main.locator('#input-name')).toHaveValue('web-cpu-high')
+		await expect(main.locator('#input-name')).toHaveAttribute('readonly', '')
+		await expect(main.locator('#input-threshold')).toHaveValue('90')
+		await expect(main.locator('#input-for-minutes')).toHaveValue('10')
+
+		await main.locator('#input-threshold').fill('95')
+		await main.getByRole('button', { name: 'Save', exact: true }).click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/alert.update')
+		}).toBeTruthy()
+
+		const req = (await getRequestLog()).find((r) => r.path === '/alert.update')
+		if (!req) throw new Error('expected an alert.update request')
+		const body = JSON.parse(req.body)
+		expect(body.name).toBe('web-cpu-high')
+		expect(body.condition.threshold).toBe(95)
+		await expect(page).toHaveURL(/\/alert\/detail\?project=test-project&name=web-cpu-high/)
+	})
+})
+
+test.describe('alert — detail', () => {
+	test('renders condition, status, and transition history', async ({ page }) => {
+		await setMocks({
+			'alert.get': { ok: true, result: sampleAlertRule },
+			'alert.events': {
+				ok: true,
+				result: {
+					items: [
+						sampleAlertEvent,
+						{ at: sampleAlertEvent.at, transition: 'resolve', value: 61 }
+					]
+				}
+			}
+		})
+
+		await page.goto('/alert/detail?project=test-project&name=web-cpu-high')
+
+		const main = page.locator('.content-wrapper')
+		await expect(main.getByRole('heading', { name: 'web-cpu-high', level: 4 })).toBeVisible()
+		await expect(main.locator('#d-condition')).toHaveValue('cpu >= 90% for 10m')
+		await expect(main.getByRole('link', { name: 'gke / web' })).toHaveAttribute(
+			'href', '/deployment/metrics?project=test-project&location=gke&name=web'
+		)
+		await expect(main.getByText('Trigger')).toBeVisible()
+		await expect(main.getByText('Resolve')).toBeVisible()
+	})
+
+	test('deletes the rule and returns to the list', async ({ page }) => {
+		await setMocks({
+			'alert.get': { ok: true, result: sampleAlertRule },
+			'alert.delete': { ok: true, result: {} }
+		})
+
+		await page.goto('/alert/detail?project=test-project&name=web-cpu-high')
+
+		await page.getByRole('button', { name: 'Delete' }).click()
+		await page.locator('#app-modal-confirm').click()
+
+		await expect.poll(async () => {
+			const log = await getRequestLog()
+			return log.some((r) => r.path === '/alert.delete')
+		}).toBeTruthy()
+
+		const req = (await getRequestLog()).find((r) => r.path === '/alert.delete')
+		if (!req) throw new Error('expected an alert.delete request')
+		expect(JSON.parse(req.body)).toMatchObject({ name: 'web-cpu-high' })
+		await expect(page).toHaveURL(/\/alert\?project=test-project/)
+	})
+})

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -161,6 +161,10 @@ export function defaultMocks () {
 		'/dropbox.list': {
 			ok: true,
 			result: { items: [] }
+		},
+		'/alert.list': {
+			ok: true,
+			result: { items: [] }
 		}
 	}
 }
@@ -393,6 +397,29 @@ export const sampleSchedulerJob = {
 	createdBy: '[email protected]',
 	updatedAt: now,
 	updatedBy: '[email protected]'
+}
+
+export const sampleAlertRule = {
+	project: 'test-project',
+	name: 'web-cpu-high',
+	target: { location: 'gke', deployment: 'web' },
+	condition: { metric: 'cpu', op: '>=', threshold: 90, forMinutes: 10 },
+	renotifyMinutes: 0,
+	disabled: false,
+	status: 'ok',
+	lastValue: 42.5,
+	firingSince: null,
+	lastEvaluatedAt: now,
+	createdAt: now,
+	createdBy: '[email protected]',
+	updatedAt: now,
+	updatedBy: '[email protected]'
+}
+
+export const sampleAlertEvent = {
+	at: now,
+	transition: 'trigger',
+	value: 93.2
 }
 
 export const sampleBillingAccount = {


### PR DESCRIPTION
## Summary

Console UI for the new `alert` resource (SPEC-metric-alerts.md Phase 1; API: deploys-app/api#133, server: deploys-app/apiserver#249).

- `/alert` list — condition rendered human-readable, status badges (ok/firing/nodata, disabled takes precedence), 60s auto-refresh
- `/alert/create` — create + edit (`?name=`): location/deployment picker, metric/op/threshold/for-minutes, optional renotify, inline warning when the project has no notification channels
- `/alert/detail` — evaluator state, transition history (alert.events), link to the deployment metrics chart, gated edit/delete
- Nav entry (preview), `Api` types, mock fixtures/handlers covering ok/firing/nodata/disabled, 13 Playwright specs

Screenshots to follow in a comment.

## Testing

`bun run check`, lint, and full Playwright suite green (394 tests).